### PR TITLE
chore: rename `com.sentry.unreal` to `io.sentry.unreal`

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -1,6 +1,6 @@
 // Copyright (c) 2022 Sentry. All Rights Reserved.
 
-package com.sentry.unreal;
+package io.sentry.unreal;
 
 import android.app.Activity;
 

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
@@ -19,7 +19,7 @@
 #include "Infrastructure/SentryMethodCallAndroid.h"
 
 const ANSICHAR* SentrySubsystemAndroid::SentryJavaClassName = "io/sentry/Sentry";
-const ANSICHAR* SentrySubsystemAndroid::SentryBridgeJavaClassName = "com/sentry/unreal/SentryBridgeJava";
+const ANSICHAR* SentrySubsystemAndroid::SentryBridgeJavaClassName = "io/sentry/unreal/SentryBridgeJava";
 
 void SentrySubsystemAndroid::InitWithSettings(const USentrySettings* settings)
 {

--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -11,7 +11,7 @@
     </init>
 
     <prebuildCopies>
-        <copyDir src="$S(PluginDir)/Private/Android/Java" dst="$S(BuildDir)/src/com/sentry/unreal" />
+        <copyDir src="$S(PluginDir)/Private/Android/Java" dst="$S(BuildDir)/src/io/sentry/unreal" />
         <copyFile src="$S(ProjectDir)/$S(PropertiesFilePath)" dst="$S(BuildDir)/gradle/sentry.properties" />
         <copyFile src="$S(PluginDir)/../ThirdParty/Android/sentry.jar" dst="$S(BuildDir)/gradle/app/libs/sentry.jar" />
         <copyFile src="$S(PluginDir)/../ThirdParty/Android/sentry-android-core-release.aar" dst="$S(BuildDir)/gradle/app/libs/sentry-android-core-release.aar" />
@@ -34,10 +34,8 @@
 
     <proguardAdditions>
         <insert>
-            -dontwarn com.sentry.unreal.**
-            -keep class com.sentry.unreal.** { *; }
+            -dontwarn io.sentry.unreal.**
             -keep class io.sentry.** { *; }
-            -keep interface com.sentry.unreal.** { *; }
             -keep interface io.sentry.** { *; }
         </insert>
     </proguardAdditions>

--- a/sample/Config/DefaultEngine.ini
+++ b/sample/Config/DefaultEngine.ini
@@ -143,7 +143,7 @@ VisualizeCalibrationGrayscaleMaterialPath=None
 bExplicitCanvasChildZOrder=True
 
 [/Script/AndroidRuntimeSettings.AndroidRuntimeSettings]
-PackageName=com.sentry.unreal.sample
+PackageName=io.sentry.unreal.sample
 StoreVersion=1
 StoreVersionOffsetArmV7=0
 StoreVersionOffsetArm64=0
@@ -250,7 +250,7 @@ bEnableDomStorage=False
 
 [/Script/IOSRuntimeSettings.IOSRuntimeSettings]
 BundleDisplayName=SentryDemo
-BundleIdentifier=com.sentry.unreal
+BundleIdentifier=io.sentry.unreal.sample
 bAutomaticSigning=True
 IOSTeamID=
 BundleName=SentryDemo


### PR DESCRIPTION
closes #65 
#skip-changelog