### PR TITLE
Suppressing warnings (Needed for when using Warnings as Errors) 

### DIFF
--- a/plugin-dev/Source/Sentry/Private/SentryLibrary.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryLibrary.cpp
@@ -89,7 +89,10 @@ USentryAttachment* USentryLibrary::CreateSentryAttachmentWithPath(const FString&
 
 void USentryLibrary::Crash()
 {
+	// Supressing warnings for when using warnings as errors on the target. 
+	#pragma warning(suppress: 6011)	
 	char *ptr = 0;
+	#pragma warning(suppress: 6011)
 	*ptr += 1;
 }
 


### PR DESCRIPTION
Closes #85 