### PR TITLE
Fix scoped event/message capturing on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Packaged plugin `EngineVersion` should include `.0` patch version ([#101](https://github.com/getsentry/sentry-unreal/pull/101))
 - Plugin packaging issues on Windows ([#110](https://github.com/getsentry/sentry-unreal/pull/110))
 - Sentry libs linking for desktop ([#114](https://github.com/getsentry/sentry-unreal/pull/114))
+- Fix scoped event/message capturing on Android ([#116](https://github.com/getsentry/sentry-unreal/pull/116))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -47,34 +47,23 @@ public class SentryBridgeJava {
 	}
 
 	public static SentryId captureMessageWithScope(final String message, final SentryLevel level, final long callback) throws InterruptedException {
-		// TODO Find another solution for returning ID since CountDownLatch blocks game thread
-		final CountDownLatch doneSignal = new CountDownLatch(1);
-		Sentry.withScope(new ScopeCallback() {
+		SentryId messageId = Sentry.captureMessage(message, new ScopeCallback() {
 			@Override
 			public void run(@NonNull Scope scope) {
-				scope.setLevel(level);
 				onConfigureScope(callback, scope);
-				Sentry.captureMessage(message);
-				doneSignal.countDown();
 			}
 		});
-		doneSignal.await();
-		return Sentry.getLastEventId();
+		return messageId;
 	}
 
 	public static SentryId captureEventWithScope(final SentryEvent event, final long callback) throws InterruptedException {
-		// TODO Find another solution for returning ID since CountDownLatch blocks game thread
-		final CountDownLatch doneSignal = new CountDownLatch(1);
-		Sentry.withScope(new ScopeCallback() {
+		SentryId eventId = Sentry.captureEvent(event, new ScopeCallback() {
 			@Override
 			public void run(@NonNull Scope scope) {
 				onConfigureScope(callback, scope);
-				Sentry.captureEvent(event);
-				doneSignal.countDown();
 			}
 		});
-		doneSignal.await();
-		return Sentry.getLastEventId();
+		return eventId;
 	}
 
 	public static void configureScope(final long callback) {

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -50,6 +50,7 @@ public class SentryBridgeJava {
 		SentryId messageId = Sentry.captureMessage(message, new ScopeCallback() {
 			@Override
 			public void run(@NonNull Scope scope) {
+				scope.setLevel(level);
 				onConfigureScope(callback, scope);
 			}
 		});

--- a/plugin-dev/Source/Sentry/Private/Android/Jni/SentryJniAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Jni/SentryJniAndroid.cpp
@@ -5,7 +5,7 @@
 
 #include "Android/AndroidJNI.h"
 
-JNI_METHOD void Java_com_sentry_unreal_SentryBridgeJava_onConfigureScope(JNIEnv* env, jclass clazz, jlong objAddr, jobject scope)
+JNI_METHOD void Java_io_sentry_unreal_SentryBridgeJava_onConfigureScope(JNIEnv* env, jclass clazz, jlong objAddr, jobject scope)
 {
 	USentryScopeCallbackAndroid* callback = reinterpret_cast<USentryScopeCallbackAndroid*>(objAddr);
 


### PR DESCRIPTION
Closes #78 

Also, replaced event/messages capture methods with their overloads that accept callback parameter (https://github.com/getsentry/sentry-java/pull/2084)