### PR TITLE
Fix sentry-cocoa SDK name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Packaged plugin `EngineVersion` should include `.0` patch version ([#101](https://github.com/getsentry/sentry-unreal/pull/101))
 - Plugin packaging issues on Windows ([#110](https://github.com/getsentry/sentry-unreal/pull/110))
 - Sentry libs linking for desktop ([#114](https://github.com/getsentry/sentry-unreal/pull/114))
+- Fix sentry-cocoa SDK name ([#118](https://github.com/getsentry/sentry-unreal/pull/118))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/IOS/SentrySubsystemIOS.cpp
+++ b/plugin-dev/Source/Sentry/Private/IOS/SentrySubsystemIOS.cpp
@@ -21,14 +21,12 @@
 
 void SentrySubsystemIOS::InitWithSettings(const USentrySettings* settings)
 {
-	NSMutableDictionary* dictOptions = [[NSMutableDictionary alloc] init];
-	dictOptions[@"sdk"] = @{ @"name" : @"sentry.cocoa.unreal" };
+	[PrivateSentrySDKOnly setSdkName:@"sentry.cocoa.unreal"];
 
-	SentryOptions* options = [[SentryOptions alloc] initWithDict:dictOptions didFailWithError:nil];
-	options.dsn = settings->DsnUrl.GetNSString();
-  options.releaseName = settings->Release.GetNSString();
-
-	[SentrySDK startWithOptionsObject:options];
+	[SentrySDK startWithConfigureOptions:^(SentryOptions *options) {
+		options.dsn = settings->DsnUrl.GetNSString();
+		options.releaseName = settings->Release.GetNSString();
+	}];
 }
 
 void SentrySubsystemIOS::Close()


### PR DESCRIPTION
Closes #95 