### PR TITLE
Fix event capturing on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -194,7 +194,7 @@ jobs:
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
 
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+        run: docker exec unreal /bin/bash "export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,7 @@ jobs:
         run: docker exec unreal bash -c '
           pip3 install --upgrade pip ;
           pip3 install -Iv ue4cli==0.0.54 ;
-          ue4 setroot /home/ue4/UnrealEngine ;
-          apt-get install ca-certificates '
+          ue4 setroot /home/ue4/UnrealEngine '
 
       - name: Download package
         uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,6 +165,8 @@ jobs:
           # Chown some paths to the GH user to make UE5 work properly. We can't just chown the whole UnrealEngine or
           # docker would implicitly have to copy it to the container and we would run out of space on the GH runner.
           docker exec --user root unreal bash -c "
+            mkdir -p /etc/pki/tls/certs ;
+            cp /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt ;
             chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
             chown -R $uid /home/ue4/UnrealEngine/Engine/Programs/UnrealPak/Saved "
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,7 +192,9 @@ jobs:
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
         
       - name: TEST1
-        run: docker exec -w /workspace/checkout unreal cat /etc/ssl/certs/ca-certificates.crt
+        run: |
+            docker exec -w /workspace/checkout unreal cat /etc/ssl/certs/ca-certificates.crt
+            docker exec -w /workspace/checkout unreal curl-config --configure
 
       - name: Run tests
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,6 @@ jobs:
       - name: Extract package to ${{ matrix.app }}/Plugins
         run: unzip sentry-unreal-*-engine${{ matrix.unreal }}.zip -d checkout/${{ matrix.app }}/Plugins/sentry
 
-      - name: TEST
-        run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
-
       - name: Run tests
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,11 +190,11 @@ jobs:
       - name: TEST
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
-      - name: CA TEST
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
-
       - name: Run tests
         run: docker exec unreal /bin/bash "export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
+
+      - name: CA TEST
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
           docker exec --user root unreal bash -c "
             chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
             chown -R $uid /home/ue4/UnrealEngine/Engine/Programs/UnrealPak/Saved"
+            apt-get install ca-certificates
 
       - name: Setup UE CLI
         run: docker exec unreal bash -c '
@@ -188,9 +189,6 @@ jobs:
 
       - name: TEST
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
-
-      - name: CA TEST 1
-        run: docker exec unreal /bin/bash "sudo apt-get install ca-certificates"
 
       - name: CA TEST 2
         run: docker exec unreal /bin/bash "export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,16 +157,17 @@ jobs:
             --workdir /workspace \
             --user $uid:$gid \
             --env PATH="/home/$user/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
-            --env CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
             ghcr.io/epicgames/unreal-engine:dev-slim-${{ matrix.unreal }}
           docker logout ghcr.io
           # Add the user so it has a home directory (needed for the pip cache later on)
           docker exec --user root unreal useradd -u $uid -g $gid --create-home $user
+          # Ensure CA certs are in the right directory (needed for running tests)
+          docker exec --user root unreal bash -c "
+            mkdir -p /etc/pki/tls/certs ;
+            cp /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt "
           # Chown some paths to the GH user to make UE5 work properly. We can't just chown the whole UnrealEngine or
           # docker would implicitly have to copy it to the container and we would run out of space on the GH runner.
           docker exec --user root unreal bash -c "
-            mkdir -p /etc/pki/tls/certs ;
-            cp /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt ;
             chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
             chown -R $uid /home/ue4/UnrealEngine/Engine/Programs/UnrealPak/Saved "
 
@@ -189,7 +190,8 @@ jobs:
       - name: Extract package to ${{ matrix.app }}/Plugins
         run: unzip sentry-unreal-*-engine${{ matrix.unreal }}.zip -d checkout/${{ matrix.app }}/Plugins/sentry
 
-      - name: TEST
+      - name: Set permissions for ${{ matrix.app }}
+        # sentry-native requires write access to sample project directory in order to initialize itself properly
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,6 @@ jobs:
           # time docker rmi $(docker image ls -aq)
           # time du --max-depth=3 --threshold=100M -h /usr /opt /var 2>/dev/null | sort -hr
           df -h
-          sudo apt-get install ca-certificates
 
       - name: Start Docker container
         run: |
@@ -190,10 +189,13 @@ jobs:
       - name: TEST
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
-      - name: Run tests
+      - name: CA TEST 1
+        run: docker exec unreal /bin/bash "sudo apt-get install ca-certificates"
+
+      - name: CA TEST 2
         run: docker exec unreal /bin/bash "export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
 
-      - name: CA TEST
+      - name: Run tests
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
 
       - name: Build & package ${{ matrix.app }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
             --workdir /workspace \
             --user $uid:$gid \
             --env PATH="/home/$user/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
+            --env CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt \
             ghcr.io/epicgames/unreal-engine:dev-slim-${{ matrix.unreal }}
           docker logout ghcr.io
           # Add the user so it has a home directory (needed for the pip cache later on)
@@ -189,9 +190,6 @@ jobs:
 
       - name: TEST
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
-
-      - name: CA TEST 2
-        run: docker exec unreal /bin/bash -c "export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
 
       - name: Run tests
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         run: unzip sentry-unreal-*-engine${{ matrix.unreal }}.zip -d checkout/${{ matrix.app }}/Plugins/sentry
 
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal sudo ue4 test --filter Product
+        run: docker exec -u root -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           # time docker rmi $(docker image ls -aq)
           # time du --max-depth=3 --threshold=100M -h /usr /opt /var 2>/dev/null | sort -hr
           df -h
+          cat /etc/ssl/certs/ca-certificates.crt
 
       - name: Start Docker container
         run: |
@@ -190,6 +191,9 @@ jobs:
 
       - name: TEST
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
+        
+      - name: TEST1
+        run: docker exec -w /workspace/checkout unreal cat /etc/ssl/certs/ca-certificates.crt
 
       - name: Run tests
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,7 @@ jobs:
           pip3 install --upgrade pip ;
           pip3 install -Iv ue4cli==0.0.54 ;
           ue4 setroot /home/ue4/UnrealEngine ;
-          sudo apt-get install ca-certificates '
+          apt-get install ca-certificates '
 
       - name: Download package
         uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,14 +165,14 @@ jobs:
           # docker would implicitly have to copy it to the container and we would run out of space on the GH runner.
           docker exec --user root unreal bash -c "
             chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
-            chown -R $uid /home/ue4/UnrealEngine/Engine/Programs/UnrealPak/Saved ;
-            apt-get install ca-certificates"
+            chown -R $uid /home/ue4/UnrealEngine/Engine/Programs/UnrealPak/Saved "
 
       - name: Setup UE CLI
         run: docker exec unreal bash -c '
           pip3 install --upgrade pip ;
           pip3 install -Iv ue4cli==0.0.54 ;
-          ue4 setroot /home/ue4/UnrealEngine '
+          ue4 setroot /home/ue4/UnrealEngine ;
+          sudo apt-get install ca-certificates '
 
       - name: Download package
         uses: vaind/download-artifact@989a39a417730897d098ab11c34e49ac4e13ed70
@@ -191,7 +191,7 @@ jobs:
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: CA TEST 2
-        run: docker exec unreal /bin/bash "export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
+        run: docker exec unreal /bin/bash -c "export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt"
 
       - name: Run tests
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,8 +190,11 @@ jobs:
       - name: TEST
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
-      - name: Run tests
+      - name: CA TEST
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
+
+      - name: Run tests
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal export CURL_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         run: unzip sentry-unreal-*-engine${{ matrix.unreal }}.zip -d checkout/${{ matrix.app }}/Plugins/sentry
 
       - name: Run tests
-        run: docker exec -u root -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         run: unzip sentry-unreal-*-engine${{ matrix.unreal }}.zip -d checkout/${{ matrix.app }}/Plugins/sentry
 
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal sudo ue4 test --filter Product
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         run: unzip sentry-unreal-*-engine${{ matrix.unreal }}.zip -d checkout/${{ matrix.app }}/Plugins/sentry
 
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product Sentry
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,8 +186,11 @@ jobs:
       - name: Extract package to ${{ matrix.app }}/Plugins
         run: unzip sentry-unreal-*-engine${{ matrix.unreal }}.zip -d checkout/${{ matrix.app }}/Plugins/sentry
 
+      - name: TEST
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal chmod -R +x Saved
+
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product Sentry
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,7 +187,7 @@ jobs:
         run: unzip sentry-unreal-*-engine${{ matrix.unreal }}.zip -d checkout/${{ matrix.app }}/Plugins/sentry
 
       - name: TEST
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal chmod -R +x Saved
+        run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,9 @@ jobs:
       - name: Extract package to ${{ matrix.app }}/Plugins
         run: unzip sentry-unreal-*-engine${{ matrix.unreal }}.zip -d checkout/${{ matrix.app }}/Plugins/sentry
 
+      - name: List tests
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --list
+
       - name: Run tests
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -165,8 +165,8 @@ jobs:
           # docker would implicitly have to copy it to the container and we would run out of space on the GH runner.
           docker exec --user root unreal bash -c "
             chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
-            chown -R $uid /home/ue4/UnrealEngine/Engine/Programs/UnrealPak/Saved"
-            apt-get install ca-certificates
+            chown -R $uid /home/ue4/UnrealEngine/Engine/Programs/UnrealPak/Saved ;
+            apt-get install ca-certificates"
 
       - name: Setup UE CLI
         run: docker exec unreal bash -c '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,6 @@ jobs:
           # time docker rmi $(docker image ls -aq)
           # time du --max-depth=3 --threshold=100M -h /usr /opt /var 2>/dev/null | sort -hr
           df -h
-          cat /etc/ssl/certs/ca-certificates.crt
 
       - name: Start Docker container
         run: |
@@ -190,11 +189,6 @@ jobs:
 
       - name: TEST
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
-        
-      - name: TEST1
-        run: |
-            docker exec -w /workspace/checkout unreal cat /etc/ssl/certs/ca-certificates.crt
-            docker exec -w /workspace/checkout unreal curl-config --configure
 
       - name: Run tests
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
           # time docker rmi $(docker image ls -aq)
           # time du --max-depth=3 --threshold=100M -h /usr /opt /var 2>/dev/null | sort -hr
           df -h
+          sudo apt-get install ca-certificates
 
       - name: Start Docker container
         run: |
@@ -186,8 +187,8 @@ jobs:
       - name: Extract package to ${{ matrix.app }}/Plugins
         run: unzip sentry-unreal-*-engine${{ matrix.unreal }}.zip -d checkout/${{ matrix.app }}/Plugins/sentry
 
-      - name: List tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --list
+      - name: TEST
+        run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests
         run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Sentry libs linking for desktop ([#114](https://github.com/getsentry/sentry-unreal/pull/114))
 - Fix sentry-cocoa SDK name ([#118](https://github.com/getsentry/sentry-unreal/pull/118))
 - Fix scoped event/message capturing on Android ([#116](https://github.com/getsentry/sentry-unreal/pull/116))
+- Fix event capturing on Linux ([#123](https://github.com/getsentry/sentry-unreal/pull/123))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -53,7 +53,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	sentry_options_set_database_path(options, ".sentry-native");
+	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -53,7 +53,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
+	//sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -51,6 +51,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
+	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*FSentryModule::Get().GetBinariesPath()));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -47,11 +47,13 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 		return;
 	}
 
+	const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), ".sentry-native"));
+
 	sentry_options_t* options = sentry_options_new();
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*FSentryModule::Get().GetBinariesPath()));
+	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -55,7 +55,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
+	//sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -47,13 +47,15 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 		return;
 	}
 
-	const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), ".sentry-native"));
+	const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), TEXT(".sentry-native")));
+
+	UE_LOG(LogSentrySdk, Log, TEXT("IVAN %s"), *FString(DatabasePath));
 
 	sentry_options_t* options = sentry_options_new();
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	// sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
+	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -53,7 +53,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	//sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
+	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -47,7 +47,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 		return;
 	}
 
-	const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("sentry-native")));
+	const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectDir(), TEXT(".sentry-native")));
 
 	sentry_options_t* options = sentry_options_new();
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -49,13 +49,11 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 
 	const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("sentry-native")));
 
-	UE_LOG(LogSentrySdk, Log, TEXT("IVAN %s"), *FString(DatabasePath));
-
 	sentry_options_t* options = sentry_options_new();
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
+	// sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -47,13 +47,13 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 		return;
 	}
 
-	// const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("sentry-native")));
+	const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("sentry-native")));
 
 	sentry_options_t* options = sentry_options_new();
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	// sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
+	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -13,11 +13,18 @@
 #include "SentryUser.h"
 #include "SentryModule.h"
 
-#include "Convenience/SentryInclude.h"
 #include "Infrastructure/SentryConvertorsDesktop.h"
 #include "CrashReporter/SentryCrashReporter.h"
 
 #include "Misc/Paths.h"
+
+void PrintVerboseLog(sentry_level_t level, const char *message, va_list args, void *userdata)
+{
+	char buffer[512];
+	vsnprintf(buffer, 512, message, args);
+
+	UE_LOG(LogSentrySdk, Log, TEXT("%s"), *FString(buffer));
+}
 
 SentrySubsystemDesktop::SentrySubsystemDesktop()
 {
@@ -44,6 +51,8 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
+	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
+	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 	sentry_init(options);
 
 	crashReporter->SetRelease(settings->Release);

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -47,7 +47,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 		return;
 	}
 
-	const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), TEXT(".sentry-native")));
+	const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("sentry-native")));
 
 	UE_LOG(LogSentrySdk, Log, TEXT("IVAN %s"), *FString(DatabasePath));
 
@@ -55,7 +55,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	//sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
+	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -53,7 +53,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
+	// sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -53,7 +53,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	sentry_options_set_database_pathw(options, TCHAR_TO_WCHAR(*DatabasePath));
+	sentry_options_set_database_path(options, ".sentry-native");
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -47,7 +47,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 		return;
 	}
 
-	const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("sentry-native")));
+	// const FString DatabasePath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("sentry-native")));
 
 	sentry_options_t* options = sentry_options_new();
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -53,7 +53,10 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
-	sentry_init(options);
+
+	int initResult = sentry_init(options);
+
+	UE_LOG(LogSentrySdk, Log, TEXT("Sentry initialization completed with result %d (0 on success)."), initResult);
 
 	crashReporter->SetRelease(settings->Release);
 }

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -53,7 +53,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
 	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*HandlerPath));
-	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*DatabasePath));
+	sentry_options_set_database_pathw(options, TCHAR_TO_WCHAR(*DatabasePath));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -8,6 +8,7 @@
 USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
 	, InitAutomatically(false)
+	, EnableVerboseLogging(true)
 	, UploadSymbolsAutomatically(false)
 {
 	DsnUrl = TEXT("");

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -54,6 +54,10 @@ public:
 		Meta = (DisplayName = "Initialize SDK automatically", ToolTip = "Flag indicating whether to automatically initialize the SDK when the app starts."))
 	bool InitAutomatically;
 
+	UPROPERTY(Config, EditAnywhere, Category = "Misc",
+		Meta = (DisplayName = "Enable verbose logging", ToolTip = "Flag indicating whether to enable verbose logging on desktop."))
+	bool EnableVerboseLogging;
+
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
 		Meta = (DisplayName = "Automatically add breadcrumbs"))
 	FAutomaticBreadcrumbs AutomaticBreadcrumbs;


### PR DESCRIPTION
In order to fix events capturing on Linux in CI environment two changes were required:

- Give user write access to the sample project directory that allows sentry-native to initialize itself properly (needed to create `.sentry-native` folder at a given database path, project root in this case)
- Ensure that CA certs are at the right location (needed for sending captured events to Sentry with curl)

Closes #100 