### PR TITLE
Fix Android packaging issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix scoped event/message capturing on Android ([#116](https://github.com/getsentry/sentry-unreal/pull/116))
 - Fix event capturing on Linux ([#123](https://github.com/getsentry/sentry-unreal/pull/123))
 - Fix incomplete type forward declaration ([#125](https://github.com/getsentry/sentry-unreal/pull/125))
+- Fix Android packaging issue ([#133](https://github.com/getsentry/sentry-unreal/pull/133))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -3,19 +3,19 @@
     <init>
         <log text="Sentry SDK Android UPL initialization"/>
 
-        <setBoolFromProperty result="bUploadSymbols" ini="Engine" section="/Script/Sentry.SentrySettings" property="UploadSymbolsAutomatically" default="true" />
-
-        <setStringFromProperty result="PropertiesFilePath" ini="Engine" section="/Script/Sentry.SentrySettings" property="PropertiesFilePath"/>
-        <setStringReplace result="PropertiesFilePath" source="$S(PropertiesFilePath)" find="(FilePath=&quot;" with=""/>
-        <setStringReplace result="PropertiesFilePath" source="$S(PropertiesFilePath)" find="&quot;)" with=""/>
+        <setBoolFromProperty result="bUploadSymbols" ini="Engine" section="/Script/Sentry.SentrySettings" property="UploadSymbolsAutomatically" default="false" />
     </init>
 
     <prebuildCopies>
         <copyDir src="$S(PluginDir)/Private/Android/Java" dst="$S(BuildDir)/src/io/sentry/unreal" />
-        <copyFile src="$S(ProjectDir)/$S(PropertiesFilePath)" dst="$S(BuildDir)/gradle/sentry.properties" />
         <copyFile src="$S(PluginDir)/../ThirdParty/Android/sentry.jar" dst="$S(BuildDir)/gradle/app/libs/sentry.jar" />
         <copyFile src="$S(PluginDir)/../ThirdParty/Android/sentry-android-core-release.aar" dst="$S(BuildDir)/gradle/app/libs/sentry-android-core-release.aar" />
         <copyFile src="$S(PluginDir)/../ThirdParty/Android/sentry-android-ndk-release.aar" dst="$S(BuildDir)/gradle/app/libs/sentry-android-ndk-release.aar" />
+        <if condition="bUploadSymbols">
+            <true>
+                <copyFile src="$S(ProjectDir)/sentry.properties" dst="$S(BuildDir)/gradle/sentry.properties" />
+            </true>
+        </if>
     </prebuildCopies>
 
     <androidManifestUpdates>


### PR DESCRIPTION
Set `bUploadSymbols` flag to `false` by default and removed deprecated code for determining `sentry.properties` file path based on plugin settings.

Closes #132 