### PR TITLE
Fix Java version for Android SDK

### DIFF
--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           git submodule update --init --recursive ${{ steps.env.outputs.submodule }}
           mkdir -p '${{ steps.env.outputs.path }}'
+          export JAVA_HOME=$(JAVA_HOME_17_X64)
           ${{ steps.env.outputs.buildScript }} '${{ steps.env.outputs.submodule }}' '${{ steps.env.outputs.path }}'
 
       - uses: actions/upload-artifact@v3.1.1

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -28,6 +28,9 @@ jobs:
           else
             submodule="modules/sentry-native"
           fi
+          echo "::set-output name=submodule::$submodule"
+          echo "::set-output name=path::plugin-dev/Source/ThirdParty/${{ inputs.target }}"
+          echo "::set-output name=buildScript::scripts/build-$(echo '${{ inputs.target }}' | tr '[:upper:]' '[:lower:]').sh"
 
       - name: Get submodule status
         run: git submodule status --cached ${{ steps.env.outputs.submodule }} | tee submodule-status

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -49,12 +49,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install zlib1g-dev libcurl4-openssl-dev libssl-dev
 
+      - name: Setup Java 17 for Android
+        if: ${{ inputs.target == 'Android' }}
+        uses: actions/setup-java@v3
+        with:
+          distribution: temurin
+          java-version: 17
+
       - name: Build
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           git submodule update --init --recursive ${{ steps.env.outputs.submodule }}
           mkdir -p '${{ steps.env.outputs.path }}'
-          export JAVA_HOME=$(JAVA_HOME_17_X64)
           ${{ steps.env.outputs.buildScript }} '${{ steps.env.outputs.submodule }}' '${{ steps.env.outputs.path }}'
 
       - uses: actions/upload-artifact@v3.1.1

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -28,9 +28,6 @@ jobs:
           else
             submodule="modules/sentry-native"
           fi
-          echo "::set-output name=submodule::$submodule"
-          echo "::set-output name=path::plugin-dev/Source/ThirdParty/${{ inputs.target }}"
-          echo "::set-output name=buildScript::scripts/build-$(echo '${{ inputs.target }}' | tr '[:upper:]' '[:lower:]').sh"
 
       - name: Get submodule status
         run: git submodule status --cached ${{ steps.env.outputs.submodule }} | tee submodule-status
@@ -49,9 +46,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install zlib1g-dev libcurl4-openssl-dev libssl-dev
 
-      - name: Setup Java 17 for Android
+      uses: actions/setup-java@v3
         if: ${{ inputs.target == 'Android' }}
-        uses: actions/setup-java@v3
         with:
           distribution: temurin
           java-version: 17

--- a/.github/workflows/sdk.yml
+++ b/.github/workflows/sdk.yml
@@ -46,7 +46,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install zlib1g-dev libcurl4-openssl-dev libssl-dev
 
-      uses: actions/setup-java@v3
+      - uses: actions/setup-java@v3
         if: ${{ inputs.target == 'Android' }}
         with:
           distribution: temurin

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -4,6 +4,8 @@ set -euo pipefail
 export sentryJavaRoot=$1
 export sentryArtifactsDestination=$2
 
+export JAVA_HOME=$(JAVA_HOME_17_X64)
+
 rm -rf "${sentryArtifactsDestination}/"*
 
 pushd ${sentryJavaRoot}

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -4,8 +4,6 @@ set -euo pipefail
 export sentryJavaRoot=$1
 export sentryArtifactsDestination=$2
 
-export JAVA_HOME=$(JAVA_HOME_17_X64)
-
 rm -rf "${sentryArtifactsDestination}/"*
 
 pushd ${sentryJavaRoot}


### PR DESCRIPTION
It looks like sentry-java started to use a newer Java version recently, so the following tweak helped to fix build errors in CI.

#skip-changelog