### PR TITLE
Add editor menu for automatic CRC configuration

### DIFF
--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -13,6 +13,7 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 {
 	DsnUrl = TEXT("");
 	Release = TEXT("");
+	CrashReporterUrl = TEXT("");
 
 	LoadDebugSymbolsProperties();
 }

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -78,6 +78,10 @@ public:
 		Meta = (DisplayName = "Authentication token", ToolTip = "Authentication token for performing actions against Sentry API.", EditCondition = "UploadSymbolsAutomatically"))
 	FString AuthToken;
 
+	UPROPERTY(Config, EditAnywhere, Category = "Crash Reporter",
+		Meta = (DisplayName = "Crash Reporter Endpoint", ToolTip = "Endpoint that Unreal Engine Crah Reporter should use in order to upload crash data to Sentry."))
+	FString CrashReporterUrl;
+
 private:
 	void LoadDebugSymbolsProperties();
 };

--- a/plugin-dev/Source/SentryEditor/Private/SentryEditorModule.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentryEditorModule.cpp
@@ -9,6 +9,8 @@
 
 #define LOCTEXT_NAMESPACE "FSentryEditorModule"
 
+const FName FSentryEditorModule::ModuleName = "SentryEditor";
+
 void FSentryEditorModule::StartupModule()
 {
 	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
@@ -22,6 +24,11 @@ void FSentryEditorModule::ShutdownModule()
 {
 	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
 	// we call this function before unloading the module.
+}
+
+FSentryEditorModule& FSentryEditorModule::Get()
+{
+	return FModuleManager::LoadModuleChecked<FSentryEditorModule>(ModuleName);
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/plugin-dev/Source/SentryEditor/Public/SentryEditorModule.h
+++ b/plugin-dev/Source/SentryEditor/Public/SentryEditorModule.h
@@ -11,4 +11,14 @@ public:
 	/** IModuleInterface implementation */
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
+
+	/**
+	 * Singleton-like access to this module's interface. This is just for convenience!
+	 * Beware of calling this during the shutdown phase, though. Your module might be already unloaded.
+	 *
+	 * @return Returns singleton instance, loading the module on demand if needed.
+	 */
+	static FSentryEditorModule& Get();
+
+	static const FName ModuleName;
 };

--- a/plugin-dev/Source/SentryEditor/Public/SentrySettingsCustomization.h
+++ b/plugin-dev/Source/SentryEditor/Public/SentrySettingsCustomization.h
@@ -5,6 +5,7 @@
 #include "IDetailCustomization.h"
 
 class IPropertyHandle;
+class FSlateHyperlinkRun;
 
 class FSentrySettingsCustomization : public IDetailCustomization
 {
@@ -23,9 +24,15 @@ private:
 	void UpdateOrganizationName();
 	void UpdateAuthToken();
 
-	void UpdatePropertiesFile(const FString& PropertyName, const FString& PropertyValue); 
+	void UpdatePropertiesFile(const FString& PropertyName, const FString& PropertyValue);
+	void UpdateCrcConfig(const FString& Url);
+
+	// Gets path to CRC's DefaultEngine.ini in engine directory
+	FString GetCrcConfigPath();
 
 	TSharedPtr<IPropertyHandle> ProjectNameHandle;
 	TSharedPtr<IPropertyHandle> OrganizationNameHandle;
 	TSharedPtr<IPropertyHandle> AuthTokenHandle;
+
+	static const FString DefaultCrcEndpoint;
 };

--- a/sample/Config/DefaultEngine.ini
+++ b/sample/Config/DefaultEngine.ini
@@ -267,6 +267,7 @@ AutomaticBreadcrumbs=(bOnMapLoadingStarted=True,bOnMapLoaded=True,bOnGameStateCl
 UploadSymbolsAutomatically=False
 Release=
 PropertiesFilePath=Config/sentry.properties
+CrashReporterUrl="https://o447951.ingest.sentry.io/api/6253052/unreal/93c7a68867db43539980de54f09b139a/"
 
 [/Script/MacTargetPlatform.MacTargetSettings]
 SpatializationPlugin=Built-in Spatialization

--- a/sample/Config/DefaultGame.ini
+++ b/sample/Config/DefaultGame.ini
@@ -5,7 +5,7 @@ ProjectID=2F77D1EF624C7FE53C3E46A0AE066C2D
 [/Script/UnrealEd.ProjectPackagingSettings]
 BuildConfiguration=PPBC_Shipping
 ForDistribution=True
-IncludeCrashReporter=False
+IncludeCrashReporter=True
 IncludeDebugFiles=True
 FullRebuild=True
 


### PR DESCRIPTION
Now there is a button in the plugin settings menu that partially automates CRC configuration process so that users won't need to [change `DefaultEngine.ini` in the engine dir manually](https://docs.sentry.io/platforms/unreal/setup-crashreporter/#configure-the-crash-reporter-endpoint). Since this change affects global engine settings another button that allows reverting it was added as well.

The approach with adding PostBuildStep suggested earlier in the linked issue would be less user-friendly and flexible compared to the custom editor UI.

Closes #58 