### PR TITLE
Fix non-unity build

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Desktop/Convenience/SentryInclude.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Convenience/SentryInclude.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "HAL/Platform.h"
+
 #if PLATFORM_WINDOWS
 #include "Windows/AllowWindowsPlatformTypes.h"
 #include "sentry.h"

--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -10,9 +10,11 @@
 #include "Misc/Paths.h"
 #include "Misc/ConfigCacheIni.h"
 #include "PropertyHandle.h"
+#include "Launch/Resources/Version.h"
 
 #include "Widgets/Text/SRichTextBlock.h"
 #include "Widgets/Layout/SBorder.h"
+#include "Widgets/Input/SButton.h"
 
 #if ENGINE_MAJOR_VERSION >= 5
 #include "Styling/AppStyle.h"

--- a/sample/Source/SentryPlayground.Target.cs
+++ b/sample/Source/SentryPlayground.Target.cs
@@ -12,5 +12,8 @@ public class SentryPlaygroundTarget : TargetRules
 		ExtraModuleNames.AddRange( new string[] { "SentryPlayground" } );
 
 		bOverrideBuildEnvironment = true;
+
+		bUsePCHFiles = false;
+		bUseUnityBuild = false;
 	}
 }

--- a/sample/Source/SentryPlaygroundEditor.Target.cs
+++ b/sample/Source/SentryPlaygroundEditor.Target.cs
@@ -12,5 +12,8 @@ public class SentryPlaygroundEditorTarget : TargetRules
 		ExtraModuleNames.AddRange( new string[] { "SentryPlayground" } );
 
 		bOverrideBuildEnvironment = true;
+
+		bUsePCHFiles = false;
+		bUseUnityBuild = false;
 	}
 }


### PR DESCRIPTION
Fixes issue addressed in PR #166

Also, a non-unity build was enabled for the sample app in order to catch compilation errors related to missing includes in CI.

#skip-changelog