### PR TITLE
Add extra event context params and and tags promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Automatic crash capturing for UE 5.1 (Windows only) ([#175](https://github.com/getsentry/sentry-unreal/pull/175))
+- Add extra event context params and and tags promotion ([#183](https://github.com/getsentry/sentry-unreal/pull/183))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -33,6 +33,36 @@ struct FAutomaticBreadcrumbs
 	bool bOnUserActivityStringChanged = false;
 };
 
+USTRUCT(BlueprintType)
+struct FTagsPromotion
+{
+	GENERATED_BODY()
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Build configuration", ToolTip = "Flag indicating whether the build configuration should be promoted to a captured event's tag."))
+	bool bPromoteBuildConfiguration = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Target type", ToolTip = "Flag indicating whether the target type should be promoted to a captured event's tag."))
+	bool bPromoteTargetType = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Engine mode", ToolTip = "Flag indicating whether the engine mode should be promoted to a captured event's tag."))
+	bool bPromoteEngineMode = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Is game", ToolTip = "Flag indicating whether the `IsGame` parameter should be promoted to a captured event's tag."))
+	bool bPromoteIsGame = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Is standalone", ToolTip = "Flag indicating whether the `IsStandalone` parameter should be promoted to a captured event's tag."))
+	bool bPromoteIsStandalone = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Is unattended", ToolTip = "Flag indicating whether the `IsUnattended` parameter should be promoted to a captured event's tag."))
+	bool bPromoteIsUnattended = true;
+};
+
 /**
  * Sentry settings used for plugin configuration.
  */
@@ -61,6 +91,10 @@ public:
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
 		Meta = (DisplayName = "Automatically add breadcrumbs"))
 	FAutomaticBreadcrumbs AutomaticBreadcrumbs;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Promote values to tags"))
+	FTagsPromotion TagsPromotion;
 
 	UPROPERTY(Config, EditAnywhere, Category = "Misc",
 		Meta = (DisplayName = "Enable automatic crash capturing (Windows editor, UE 5.1+)", ToolTip = "Flag indicating whether to capture crashes automatically on Windows as an alternative to Crash Reporter."))

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -212,6 +212,9 @@ private:
 	/** Adds default context data for all events captured by Sentry SDK. */
 	void AddDefaultContext();
 
+	/** Promote specified values to tags for all events captured by Sentry SDK. */
+	void PromoteTags();
+
 	/** Subscribe to specified game events in order to add corresponding breadcrumbs automatically. */
 	void ConfigureBreadcrumbs();
 


### PR DESCRIPTION
This PR introduces the new plugin settings section where users can specify which extra tags should be automatically attached to captured events.

<img width="1607" alt="image" src="https://user-images.githubusercontent.com/3168564/209816007-ac6d7c55-9f33-48b1-9e1b-ce3ed2bdcebf.png">

Closes #170 