### PR TITLE
chore: Create link to 5.1 sample project

### DIFF
--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -32,5 +32,9 @@ setupPluginLink() {
 }
 
 setupPluginLink "sample"
+if [[ -d "sample 5.1" ]]; then
+    setupPluginLink "sample 5.1"
+fi
+
 "$(dirname "$0")/download-sdks.sh"
 "$(dirname "$0")/download-cli.sh"


### PR DESCRIPTION
In case the `sample 5.1` exists `init.sh` now sets up the link for it as well.

#skip-changelog