### PR TITLE
feat: expose environment setting

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -23,12 +23,13 @@ import io.sentry.protocol.SentryId;
 public class SentryBridgeJava {
 	public static native void onConfigureScope(long callbackAddr, Scope scope);
 
-	public static void init(Activity activity, final String dsnUrl, final String releaseName) {
+	public static void init(Activity activity, final String dsnUrl, final String releaseName, final String environment) {
 		SentryAndroid.init(activity, new Sentry.OptionsConfiguration<SentryAndroidOptions>() {
 			@Override
 			public void configure(SentryAndroidOptions options) {
 				options.setDsn(dsnUrl);
 				options.setRelease(releaseName);
+				options.setEnvironment(environment);
 			}
 		});
 	}

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
@@ -26,7 +26,7 @@ const ANSICHAR* SentrySubsystemAndroid::SentryBridgeJavaClassName = "io/sentry/u
 void SentrySubsystemAndroid::InitWithSettings(const USentrySettings* settings)
 {
 	SentryMethodCallAndroid::CallStaticVoidMethod(SentryBridgeJavaClassName, "init", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;)V",
-		FJavaWrapper::GameActivityThis, *FJavaClassObject::GetJString(settings->DsnUrl), *FJavaClassObject::GetJString(settings->Release));
+		FJavaWrapper::GameActivityThis, *FJavaClassObject::GetJString(settings->DsnUrl), *FJavaClassObject::GetJString(settings->Release), *FJavaClassObject::GetJString(settings->Environment));
 }
 
 void SentrySubsystemAndroid::Close()

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
@@ -27,6 +27,7 @@ void SentrySubsystemApple::InitWithSettings(const USentrySettings* settings)
 	[SENTRY_APPLE_CLASS(SentrySDK) startWithConfigureOptions:^(SentryOptions *options) {
 		options.dsn = settings->DsnUrl.GetNSString();
 		options.releaseName = settings->Release.GetNSString();
+		options.environment = settings->Environment.GetNSString();
 	}];
 }
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashReporter.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashReporter.cpp
@@ -23,6 +23,14 @@ void SentryCrashReporter::SetRelease(const FString& release)
 	UpdateCrashReporterConfig();
 }
 
+void SentryCrashReporter::SetEnvironment(const FString& environment)
+{
+	if (!environment.IsEmpty())
+		crashReporterConfig->SetStringField(TEXT("environment"), environment);
+
+	UpdateCrashReporterConfig();
+}
+
 void SentryCrashReporter::SetUser(USentryUser* user)
 {
 	TSharedPtr<FJsonObject> userConfig = MakeShareable(new FJsonObject);

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashReporter.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashReporter.h
@@ -15,6 +15,7 @@ public:
 	SentryCrashReporter();
 
 	void SetRelease(const FString& release);
+	void SetEnvironment(const FString& environment);
 	void SetUser(USentryUser* user);
 	void RemoveUser();
 	void SetContext(const FString& key, const TMap<FString, FString>& values);

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -62,6 +62,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_release(options, TCHAR_TO_ANSI(*settings->Release));
+	sentry_options_set_environment(options, TCHAR_TO_ANSI(*settings->Environment));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 
@@ -77,6 +78,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 #endif
 
 	crashReporter->SetRelease(settings->Release);
+	crashReporter->SetEnvironment(settings->Environment);
 }
 
 void SentrySubsystemDesktop::Close()

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -14,6 +14,7 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 {
 	DsnUrl = TEXT("");
 	Release = TEXT("");
+	Environment = TEXT("");
 	CrashReporterUrl = TEXT("");
 
 	LoadDebugSymbolsProperties();

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -80,6 +80,10 @@ public:
 		Meta = (DisplayName = "Release", ToolTip = "Release name which will be used for enriching events."))
 	FString Release;
 
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Core",
+		Meta = (DisplayName = "Environment", ToolTip = "Environment which will be used for enriching events."))
+	FString Environment;
+
 	UPROPERTY(Config, EditAnywhere, Category = "Misc",
 		Meta = (DisplayName = "Initialize SDK automatically", ToolTip = "Flag indicating whether to automatically initialize the SDK when the app starts."))
 	bool InitAutomatically;


### PR DESCRIPTION
The environment settings of the SDKs were not exposed, but they can be very useful to filter out events and crashes from test environments for example.