### PR TITLE
Add plugin setting for toggling native sources upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add extra event context params and and tags promotion ([#183](https://github.com/getsentry/sentry-unreal/pull/183))
 - Add automatic crash capturing for Mac ([#190](https://github.com/getsentry/sentry-unreal/pull/190))
 - Add environment property to plugin settings ([#204](https://github.com/getsentry/sentry-unreal/pull/204))
-- Add plugin setting for toggling native sources upload ([#217](https://github.com/getsentry/sentry-unreal/pull/217))
+- Add native sources upload toggle to plugin settings ([#217](https://github.com/getsentry/sentry-unreal/pull/217))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add extra event context params and and tags promotion ([#183](https://github.com/getsentry/sentry-unreal/pull/183))
 - Add automatic crash capturing for Mac ([#190](https://github.com/getsentry/sentry-unreal/pull/190))
 - Add environment property to plugin settings ([#204](https://github.com/getsentry/sentry-unreal/pull/204))
+- Add plugin setting for toggling native sources upload ([#217](https://github.com/getsentry/sentry-unreal/pull/217))
 
 ### Fixes
 

--- a/plugin-dev/Scripts/upload-debug-symbols-win.ps1
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.ps1
@@ -82,6 +82,14 @@ If ("$UploadSymbols".ToLower() -ne "true")
     Exit
 }
 
+$IncludeSourceFiles = $ConfigIni.$SentrySettingsSection.IncludeSources
+
+$CliArgs = @()
+If ("$IncludeSourceFiles".ToLower() -eq "true")
+{
+    $CliArgs.Add("--include-sources")
+}
+
 $PropertiesFile = "$ProjectPath/sentry.properties"
 
 If (-not (Test-Path -Path $PropertiesFile -PathType Leaf))
@@ -93,6 +101,6 @@ If (-not (Test-Path -Path $PropertiesFile -PathType Leaf))
 Write-Host "Sentry: Upload started using PropertiesFile '$PropertiesFile'"
 
 $env:SENTRY_PROPERTIES = $PropertiesFile
-& $CliExec upload-dif --include-sources --log-level info $ProjectBinariesPath $PluginBinariesPath
+& $CliExec upload-dif $CliArgs --log-level info $ProjectBinariesPath $PluginBinariesPath
 
 Write-Host "Sentry: Upload finished"

--- a/plugin-dev/Scripts/upload-debug-symbols-win.ps1
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.ps1
@@ -87,7 +87,7 @@ $IncludeSourceFiles = $ConfigIni.$SentrySettingsSection.IncludeSources
 $CliArgs = @()
 If ("$IncludeSourceFiles".ToLower() -eq "true")
 {
-    $CliArgs.Add("--include-sources")
+    $CliArgs += "--include-sources"
 }
 
 $PropertiesFile = "$ProjectPath/sentry.properties"

--- a/plugin-dev/Scripts/upload-debug-symbols.sh
+++ b/plugin-dev/Scripts/upload-debug-symbols.sh
@@ -41,17 +41,23 @@ if [ $UPLOAD_SYMBOLS != "True" ]; then
     exit
 fi
 
+INCLUDE_SOURCES=$(awk -F "=" '/IncludeSources/ {print $2}' ${CONFIG_PATH}/DefaultEngine.ini)
+
+CLI_ARGS=()
+if [ -z $INCLUDE_SOURCES -a $UPLOAD_SYMBOLS == "True" ]; then
+    CLI_ARGS+=(--include-sources)
+fi
+
 export SENTRY_PROPERTIES="$projectPath/sentry.properties"
 if [ ! -f "$SENTRY_PROPERTIES" ]; then
     echo "Sentry: Properties file is missing: '$SENTRY_PROPERTIES'"
     exit 1
 fi
 
-
 echo "Sentry: Upload started using PropertiesFile '$SENTRY_PROPERTIES'"
 
 chmod +x $SENTRY_CLI_EXEC
 
-$SENTRY_CLI_EXEC upload-dif --include-sources $PROJECT_BINARIES_PATH $PLUGIN_BINARIES_PATH
+$SENTRY_CLI_EXEC upload-dif $CLI_ARGS[@] $PROJECT_BINARIES_PATH $PLUGIN_BINARIES_PATH
 
 echo "Sentry: Upload finished"

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -12,6 +12,7 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 	, EnableVerboseLogging(true)
 	, EnableAutoCrashCapturing(true)
 	, UploadSymbolsAutomatically(false)
+	, IncludeSources(false)
 	, CrashReporterUrl()
 {
 	GConfig->GetString(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), Release, GGameIni);

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -120,6 +120,10 @@ public:
 		Meta = (DisplayName = "Authentication token", ToolTip = "Authentication token for performing actions against Sentry API.", EditCondition = "UploadSymbolsAutomatically"))
 	FString AuthToken;
 
+	UPROPERTY(EditAnywhere, Category = "Debug Symbols",
+		Meta = (DisplayName = "Include sources", ToolTip = "Flag indicating whether to automatically scan the debug files for references to source code files and upload them if any.", EditCondition = "UploadSymbolsAutomatically"))
+	bool IncludeSources;
+
 	UPROPERTY(Config, EditAnywhere, Category = "Crash Reporter",
 		Meta = (DisplayName = "Crash Reporter Endpoint", ToolTip = "Endpoint that Unreal Engine Crah Reporter should use in order to upload crash data to Sentry."))
 	FString CrashReporterUrl;

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -120,7 +120,7 @@ public:
 		Meta = (DisplayName = "Authentication token", ToolTip = "Authentication token for performing actions against Sentry API.", EditCondition = "UploadSymbolsAutomatically"))
 	FString AuthToken;
 
-	UPROPERTY(EditAnywhere, Category = "Debug Symbols",
+	UPROPERTY(Config, EditAnywhere, Category = "Debug Symbols",
 		Meta = (DisplayName = "Include sources", ToolTip = "Flag indicating whether to automatically scan the debug files for references to source code files and upload them if any.", EditCondition = "UploadSymbolsAutomatically"))
 	bool IncludeSources;
 

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -121,7 +121,7 @@ public:
 	FString AuthToken;
 
 	UPROPERTY(Config, EditAnywhere, Category = "Debug Symbols",
-		Meta = (DisplayName = "Include sources", ToolTip = "Flag indicating whether to automatically scan the debug files for references to source code files and upload them if any.", EditCondition = "UploadSymbolsAutomatically"))
+		Meta = (DisplayName = "Upload sources", ToolTip = "Flag indicating whether to automatically scan the debug files for references to source code files and upload them if any.", EditCondition = "UploadSymbolsAutomatically"))
 	bool IncludeSources;
 
 	UPROPERTY(Config, EditAnywhere, Category = "Crash Reporter",

--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -4,6 +4,7 @@
         <log text="Sentry SDK Android UPL initialization"/>
 
         <setBoolFromProperty result="bUploadSymbols" ini="Engine" section="/Script/Sentry.SentrySettings" property="UploadSymbolsAutomatically" default="false" />
+        <setBoolFromProperty result="bIncludeSources" ini="Engine" section="/Script/Sentry.SentrySettings" property="IncludeSources" default="false" />
     </init>
 
     <prebuildCopies>

--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -49,9 +49,17 @@
 
                     sentry {
                         uploadNativeSymbols = true
-                        includeNativeSources = true
                     }
                 </insert>
+                <if condition="bIncludeSources">
+                    <true>
+                        <insert>
+                            sentry {
+                                includeNativeSources = true
+                            }
+                        </insert>
+                    </true>
+                </if> 
             </true>
         </if>
     </buildGradleAdditions>


### PR DESCRIPTION
Added a new plugin setting allowing to toggle automatic source files upload along with other debug symbols. By default this option is disabled and in order to upload sources user has to give his consent to do it first.