### PR TITLE
Fix subsystem deinitialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Fix Linux debug symbols upload when cross-compiling on Windows ([#196](https://github.com/getsentry/sentry-unreal/pull/196))
 - Fix crashpad staging issue ([#211](https://github.com/getsentry/sentry-unreal/pull/211))
+- Fix subsystem deinitialization ([#218](https://github.com/getsentry/sentry-unreal/pull/218))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -45,9 +45,9 @@ void USentrySubsystem::Initialize(FSubsystemCollectionBase& Collection)
 
 void USentrySubsystem::Deinitialize()
 {
-	Super::Deinitialize();
-
 	DisableAutomaticBreadcrumbs();
+
+	Super::Deinitialize();
 }
 
 void USentrySubsystem::Initialize()


### PR DESCRIPTION
Moved base class implementation invocation to the end of the `USentrySubsystem::Deinitialize()` method in order to avoid potential issues during dismissing the plugin.