### PR TITLE
Remove empty release version string from demo config

### DIFF
--- a/sample/Config/DefaultEngine.ini
+++ b/sample/Config/DefaultEngine.ini
@@ -265,7 +265,6 @@ DsnUrl="https://93c7a68867db43539980de54f09b139a@o447951.ingest.sentry.io/625305
 InitAutomatically=False
 AutomaticBreadcrumbs=(bOnMapLoadingStarted=True,bOnMapLoaded=True,bOnGameStateClassChanged=True,bOnGameSessionIDChanged=True,bOnUserActivityStringChanged=True)
 UploadSymbolsAutomatically=False
-Release=
 PropertiesFilePath=Config/sentry.properties
 CrashReporterUrl="https://o447951.ingest.sentry.io/api/6253052/unreal/93c7a68867db43539980de54f09b139a/"
 


### PR DESCRIPTION
Sentry plugin can determine the project version automatically if one wasn't set by the user explicitly and use that during the initialization.

#skip-changelog