### PR TITLE
Build: Fix handling of third party dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix snapshot update script ([#253](https://github.com/getsentry/sentry-unreal/pull/253))
 - Fix debug symbol uploading scripts ([#261](https://github.com/getsentry/sentry-unreal/pull/261))
+- Fix handling of third party dependencies ([#249](https://github.com/getsentry/sentry-unreal/pull/249))
 
 ### Dependencies
 
@@ -98,10 +99,10 @@
 - Bump CLI from v2.5.2 to v2.9.0 ([#117](https://github.com/getsentry/sentry-unreal/pull/117), [#126](https://github.com/getsentry/sentry-unreal/pull/126), [#135](https://github.com/getsentry/sentry-unreal/pull/135), [#141](https://github.com/getsentry/sentry-unreal/pull/141), [#154](https://github.com/getsentry/sentry-unreal/pull/154))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#290)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.5.2...2.9.0)
-- Bump Java SDK (Android) from v6.4.1 to v6.8.0 ([#115](https://github.com/getsentry/sentry-unreal/pull/115)), [#127](https://github.com/getsentry/sentry-unreal/pull/127), [#129](https://github.com/getsentry/sentry-unreal/pull/129), [#134](https://github.com/getsentry/sentry-unreal/pull/134), [#137](https://github.com/getsentry/sentry-unreal/pull/137), [#137](https://github.com/getsentry/sentry-unreal/pull/137), [#144](https://github.com/getsentry/sentry-unreal/pull/144), [#156](https://github.com/getsentry/sentry-unreal/pull/156), [#158](https://github.com/getsentry/sentry-unreal/pull/158), 
+- Bump Java SDK (Android) from v6.4.1 to v6.8.0 ([#115](https://github.com/getsentry/sentry-unreal/pull/115)), [#127](https://github.com/getsentry/sentry-unreal/pull/127), [#129](https://github.com/getsentry/sentry-unreal/pull/129), [#134](https://github.com/getsentry/sentry-unreal/pull/134), [#137](https://github.com/getsentry/sentry-unreal/pull/137), [#137](https://github.com/getsentry/sentry-unreal/pull/137), [#144](https://github.com/getsentry/sentry-unreal/pull/144), [#156](https://github.com/getsentry/sentry-unreal/pull/156), [#158](https://github.com/getsentry/sentry-unreal/pull/158),
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#680)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.4.1...6.8.0)
-- Bump Cocoa SDK (iOS) from v7.24.1 to v7.31.2 ([#98](https://github.com/getsentry/sentry-unreal/pull/98)), [#106](https://github.com/getsentry/sentry-unreal/pull/106), [#120](https://github.com/getsentry/sentry-unreal/pull/120), [#122](https://github.com/getsentry/sentry-unreal/pull/122), [#128](https://github.com/getsentry/sentry-unreal/pull/128), [#130](https://github.com/getsentry/sentry-unreal/pull/130), [#136](https://github.com/getsentry/sentry-unreal/pull/136), [#143](https://github.com/getsentry/sentry-unreal/pull/143), [#145](https://github.com/getsentry/sentry-unreal/pull/145), [#151](https://github.com/getsentry/sentry-unreal/pull/151), [#153](https://github.com/getsentry/sentry-unreal/pull/153), [#157](https://github.com/getsentry/sentry-unreal/pull/157), [#159](https://github.com/getsentry/sentry-unreal/pull/159), 
+- Bump Cocoa SDK (iOS) from v7.24.1 to v7.31.2 ([#98](https://github.com/getsentry/sentry-unreal/pull/98)), [#106](https://github.com/getsentry/sentry-unreal/pull/106), [#120](https://github.com/getsentry/sentry-unreal/pull/120), [#122](https://github.com/getsentry/sentry-unreal/pull/122), [#128](https://github.com/getsentry/sentry-unreal/pull/128), [#130](https://github.com/getsentry/sentry-unreal/pull/130), [#136](https://github.com/getsentry/sentry-unreal/pull/136), [#143](https://github.com/getsentry/sentry-unreal/pull/143), [#145](https://github.com/getsentry/sentry-unreal/pull/145), [#151](https://github.com/getsentry/sentry-unreal/pull/151), [#153](https://github.com/getsentry/sentry-unreal/pull/153), [#157](https://github.com/getsentry/sentry-unreal/pull/157), [#159](https://github.com/getsentry/sentry-unreal/pull/159),
 - [changelog](https://github.com/getsentry/sentry-cocoa/blob/master/CHANGELOG.md#7312)
 - [diff](https://github.com/getsentry/sentry-cocoa/compare/7.24.1...7.31.2)
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -48,7 +48,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	const FString HandlerExecutableName = TEXT("crashpad_handler");
 #endif
 
-	const FString HandlerPath = FPaths::Combine(FSentryModule::Get().GetBinariesPath(), HandlerExecutableName);
+	const FString HandlerPath = FPaths::ConvertRelativePathToFull(HandlerExecutableName);
 	const FString DatabasePath = FPaths::Combine(FPaths::ProjectDir(), TEXT(".sentry-native"));
 
 	const FString LogFilePath = FGenericPlatformOutputDevices::GetAbsoluteLogFilename();

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -48,8 +48,8 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	const FString HandlerExecutableName = TEXT("crashpad_handler");
 #endif
 
-	const FString HandlerPath = FPaths::ConvertRelativePathToFull(HandlerExecutableName);
-	const FString DatabasePath = FPaths::Combine(FPaths::ProjectDir(), TEXT(".sentry-native"));
+	const FString HandlerPath = FPaths::Combine(FSentryModule::Get().GetBinariesPath(), HandlerExecutableName);
+	const FString DatabasePath = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT(".sentry-native"));
 
 	const FString LogFilePath = FGenericPlatformOutputDevices::GetAbsoluteLogFilename();
 

--- a/plugin-dev/Source/Sentry/Private/SentryModule.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryModule.cpp
@@ -10,6 +10,7 @@
 #include "Modules/ModuleManager.h"
 #include "Developer/Settings/Public/ISettingsModule.h"
 #include "Misc/Paths.h"
+#include "HAL/PlatformProcess.h"
 
 #define LOCTEXT_NAMESPACE "FSentryModule"
 
@@ -29,6 +30,9 @@ void FSentryModule::StartupModule()
 			SentrySettings);
 	}
 
+	const FString PluginBinariesPath = GetBinariesPath();
+	FPlatformProcess::PushDllDirectory(*PluginBinariesPath);
+
 #if PLATFORM_WINDOWS
 	mDllHandleSentry = FPlatformProcess::GetDllHandle(TEXT("sentry.dll"));
 #elif PLATFORM_MAC
@@ -36,6 +40,8 @@ void FSentryModule::StartupModule()
 #elif PLATFORM_LINUX
 	mDllHandleSentry = FPlatformProcess::GetDllHandle(TEXT("libsentry.so"));
 #endif
+
+	FPlatformProcess::PopDllDirectory(*PluginBinariesPath);
 }
 
 void FSentryModule::ShutdownModule()
@@ -85,6 +91,12 @@ void* FSentryModule::GetSentryLibHandle() const
 USentrySettings* FSentryModule::GetSettings() const
 {
 	return SentrySettings;
+}
+
+FString FSentryModule::GetBinariesPath()
+{
+	const FString PluginDir = IPluginManager::Get().FindPlugin(TEXT("Sentry"))->GetBaseDir();
+	return FPaths::Combine(PluginDir, TEXT("Binaries"), FPlatformProcess::GetBinariesSubdirectory());
 }
 
 FString FSentryModule::GetPluginVersion()

--- a/plugin-dev/Source/Sentry/Private/SentryModule.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryModule.cpp
@@ -30,18 +30,11 @@ void FSentryModule::StartupModule()
 	}
 
 #if PLATFORM_WINDOWS
-	const FString SentryLibName = TEXT("sentry.dll");
+	mDllHandleSentry = FPlatformProcess::GetDllHandle(TEXT("sentry.dll"));
 #elif PLATFORM_MAC
-	const FString SentryLibName = TEXT("sentry.dylib");
+	mDllHandleSentry = FPlatformProcess::GetDllHandle(TEXT("sentry.dylib"));
 #elif PLATFORM_LINUX
-	const FString SentryLibName = TEXT("libsentry.so");
-#endif
-
-#if PLATFORM_WINDOWS || PLATFORM_MAC || PLATFORM_LINUX
-	const FString BinariesDirPath = GetBinariesPath();
-	FPlatformProcess::PushDllDirectory(*BinariesDirPath);
-	mDllHandleSentry = FPlatformProcess::GetDllHandle(*FPaths::Combine(BinariesDirPath, SentryLibName));
-	FPlatformProcess::PopDllDirectory(*BinariesDirPath);
+	mDllHandleSentry = FPlatformProcess::GetDllHandle(TEXT("libsentry.so"));
 #endif
 }
 
@@ -92,27 +85,6 @@ void* FSentryModule::GetSentryLibHandle() const
 USentrySettings* FSentryModule::GetSettings() const
 {
 	return SentrySettings;
-}
-
-FString FSentryModule::GetBinariesPath()
-{
-	FString PlatformName;
-
-#if PLATFORM_ANDROID
-	PlatformName = TEXT("Android");
-#elif PLATFORM_IOS
-	PlatformName = TEXT("IOS");
-#elif PLATFORM_WINDOWS
-	PlatformName = TEXT("Win64");
-#elif PLATFORM_MAC
-	PlatformName = TEXT("Mac");
-#elif PLATFORM_LINUX
-	PlatformName = TEXT("Linux");
-#endif
-
-	const FString PluginDir = IPluginManager::Get().FindPlugin(TEXT("Sentry"))->GetBaseDir();
-
-	return FPaths::Combine(PluginDir, TEXT("Binaries"), PlatformName);
 }
 
 FString FSentryModule::GetPluginVersion()

--- a/plugin-dev/Source/Sentry/Public/SentryModule.h
+++ b/plugin-dev/Source/Sentry/Public/SentryModule.h
@@ -35,9 +35,6 @@ public:
 	/** Gets internal settings object to support runtime configuration changes. */
 	USentrySettings* GetSettings() const;
 
-	/** Gets path to plugin's binaries folder. */
-	FString GetBinariesPath();
-
 	/** Gets plugin's version. */
 	static FString GetPluginVersion();
 

--- a/plugin-dev/Source/Sentry/Public/SentryModule.h
+++ b/plugin-dev/Source/Sentry/Public/SentryModule.h
@@ -7,7 +7,7 @@
 
 class USentrySettings;
 
-class FSentryModule : public IModuleInterface
+class SENTRY_API FSentryModule : public IModuleInterface
 {
 public:
 	/** IModuleInterface implementation */
@@ -34,6 +34,9 @@ public:
 
 	/** Gets internal settings object to support runtime configuration changes. */
 	USentrySettings* GetSettings() const;
+
+	/** Gets path to plugin's binaries folder. */
+	FString GetBinariesPath();
 
 	/** Gets plugin's version. */
 	static FString GetPluginVersion();

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -82,123 +82,32 @@ public class Sentry : ModuleRules
 		}
 
 		// Additional routine for Desktop platforms
+		string PlatformThirdPartyDir = Path.Combine(ModuleDirectory, "..", "ThirdParty", Target.Platform.ToString());
 		if (Target.Platform == UnrealTargetPlatform.Win64 || Target.Platform == UnrealTargetPlatform.Mac || Target.Platform == UnrealTargetPlatform.Linux)
 		{
-			PublicIncludePaths.Add(Path.Combine(ModuleDirectory, "../ThirdParty", Target.Platform.ToString(), "include"));
+			PublicIncludePaths.Add(Path.Combine(PlatformThirdPartyDir, "include"));
+			RuntimeDependencies.Add("$(TargetOutputDir)/...", Path.Combine(PlatformThirdPartyDir, "bin/..."));
 		}
 
-		// Additional routine for Windows
 		if (Target.Platform == UnrealTargetPlatform.Win64)
 		{
+			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyDir, "lib", "sentry.lib"));
+			PublicDelayLoadDLLs.Add("sentry.dll");
+
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/Desktop"));
-
-			LoadThirdPartyLibrary("sentry", Target);
-			LoadCrashpadHandler("crashpad_handler.exe", Target);
-
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
 		}
-
-		// Additional routine for Linux
-		if (Target.Platform == UnrealTargetPlatform.Linux)
+		else if (Target.Platform == UnrealTargetPlatform.Linux)
 		{
+			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyDir, "bin", "libsentry.so"));
+
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/Desktop"));
-
-			LoadThirdPartyLibrary("libsentry", Target);
-			LoadCrashpadHandler("crashpad_handler", Target);
-
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
 		}
-		
-		// Additional routine for Mac
-		if (Target.Platform == UnrealTargetPlatform.Mac)
+		else if (Target.Platform == UnrealTargetPlatform.Mac)
 		{
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/Apple"));
-
-			LoadThirdPartyLibrary("sentry", Target);
-
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=0");
-		}
-	}
-
-	public void LoadThirdPartyLibrary(string libname, ReadOnlyTargetRules Target)
-	{
-		string StaticLibExtension = string.Empty;
-		string DynamicLibExtension = string.Empty;
-		string DebugSymbolsExtension = string.Empty;
-
-		if (Target.Platform == UnrealTargetPlatform.Win64)
-		{
-			StaticLibExtension = ".lib";
-			DynamicLibExtension = ".dll";
-			DebugSymbolsExtension = ".pdb";
-		}
-		if (Target.Platform == UnrealTargetPlatform.Mac)
-		{
-			StaticLibExtension = ".a";
-			DynamicLibExtension = ".dylib";
-			DebugSymbolsExtension = ".dylib.dSYM";
-		}
-		if (Target.Platform == UnrealTargetPlatform.Linux)
-		{
-			StaticLibExtension = ".a";
-			DynamicLibExtension = ".so";
-			DebugSymbolsExtension = ".dbg.so";
-		}
-
-		// Link libraries
-		string ThirdPartyPath = Path.Combine(ModuleDirectory, "../ThirdParty", Target.Platform.ToString());
-
-		string BinariesPath = Path.GetFullPath(Path.Combine(ModuleDirectory, "../../Binaries", Target.Platform.ToString()));
-
-		string SourceStaticLibPath = Path.Combine(ThirdPartyPath, "lib", libname + StaticLibExtension);
-		string SourceDynamicLibPath = Path.Combine(ThirdPartyPath, "bin", libname + DynamicLibExtension);
-		string SourceSymbolsPath = Path.Combine(ThirdPartyPath, "bin", libname + DebugSymbolsExtension);
-		string BinariesDynamicLibPath = Path.Combine(BinariesPath, libname + DynamicLibExtension);
-		string BinariesSymbolsPath = Path.Combine(BinariesPath, libname + DebugSymbolsExtension);
-
-		CopyPluginBinary(SourceDynamicLibPath, BinariesDynamicLibPath, BinariesPath);
-		RuntimeDependencies.Add(BinariesDynamicLibPath, SourceDynamicLibPath);
-
-		if (Target.Platform == UnrealTargetPlatform.Win64)
-		{
-			PublicAdditionalLibraries.Add(SourceStaticLibPath);
-			PublicDelayLoadDLLs.Add(libname + DynamicLibExtension);
-
-			CopyPluginBinary(SourceSymbolsPath, BinariesSymbolsPath, BinariesPath);
-			RuntimeDependencies.Add(BinariesSymbolsPath, SourceSymbolsPath);
-		}
-		if (Target.Platform == UnrealTargetPlatform.Linux)
-		{
-			PublicAdditionalLibraries.Add(BinariesDynamicLibPath);
-		}
-	}
-
-	public void LoadCrashpadHandler(string HandlerName, ReadOnlyTargetRules Target)
-	{
-		string ThirdPartyPath = Path.Combine(ModuleDirectory, "../ThirdParty", Target.Platform.ToString());
-
-		string BinariesPath = Path.GetFullPath(Path.Combine(ModuleDirectory, "../../Binaries", Target.Platform.ToString()));
-
-		string SourceHandlerPath = Path.Combine(ThirdPartyPath, "bin", HandlerName);
-		string BinariesHandlerPath = Path.Combine(BinariesPath, HandlerName);
-
-		CopyPluginBinary(SourceHandlerPath, BinariesHandlerPath, BinariesPath);
-		RuntimeDependencies.Add(BinariesHandlerPath, SourceHandlerPath);
-	}
-
-	public void CopyPluginBinary(string SourceFile, string DestFile, string DestFolder)
-	{
-		if (!Directory.Exists(DestFolder))
-		{
-			Directory.CreateDirectory(DestFolder);
-		}
-
-		if (!File.Exists(DestFile))
-		{
-			File.Copy(SourceFile, DestFile, true);
-
-			// Make binary writeable to avoid issues with UGS Binary Zips during sync (Perforce is usually read-only by default)
-			File.SetAttributes(DestFile, File.GetAttributes(DestFile) & ~FileAttributes.ReadOnly);
 		}
 	}
 }

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -46,7 +46,7 @@ public class Sentry : ModuleRules
 				"SlateCore",
 				"Projects",
 				"Json"
-				// ... add private dependencies that you statically link with here ...	
+				// ... add private dependencies that you statically link with here ...
 			}
 		);
 
@@ -86,7 +86,6 @@ public class Sentry : ModuleRules
 		if (Target.Platform == UnrealTargetPlatform.Win64 || Target.Platform == UnrealTargetPlatform.Mac || Target.Platform == UnrealTargetPlatform.Linux)
 		{
 			PublicIncludePaths.Add(Path.Combine(PlatformThirdPartyDir, "include"));
-			RuntimeDependencies.Add("$(TargetOutputDir)/...", Path.Combine(PlatformThirdPartyDir, "bin/..."));
 		}
 
 		if (Target.Platform == UnrealTargetPlatform.Win64)
@@ -96,6 +95,10 @@ public class Sentry : ModuleRules
 
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/Desktop"));
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
+
+			RuntimeDependencies.Add("$(TargetOutputDir)/crashpad_handler.exe", Path.Combine(PlatformThirdPartyDir, "bin/crashpad_handler.exe"));
+			RuntimeDependencies.Add("$(TargetOutputDir)/sentry.dll", Path.Combine(PlatformThirdPartyDir, "bin/sentry.dll"));
+			RuntimeDependencies.Add("$(TargetOutputDir)/sentry.pdb", Path.Combine(PlatformThirdPartyDir, "bin/sentry.pdb"), StagedFileType.DebugNonUFS);
 		}
 		else if (Target.Platform == UnrealTargetPlatform.Linux)
 		{
@@ -103,11 +106,17 @@ public class Sentry : ModuleRules
 
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/Desktop"));
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
+
+			RuntimeDependencies.Add("$(TargetOutputDir)/crashpad_handler", Path.Combine(PlatformThirdPartyDir, "bin/crashpad_handler"));
+			RuntimeDependencies.Add("$(TargetOutputDir)/libsentry.so", Path.Combine(PlatformThirdPartyDir, "bin/libsentry.so"));
+			RuntimeDependencies.Add("$(TargetOutputDir)/libsentry.dbg.so", Path.Combine(PlatformThirdPartyDir, "bin/libsentry.dbg.so"), StagedFileType.DebugNonUFS);
 		}
 		else if (Target.Platform == UnrealTargetPlatform.Mac)
 		{
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/Apple"));
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=0");
+
+			RuntimeDependencies.Add("$(TargetOutputDir)/sentry.dylib", Path.Combine(PlatformThirdPartyDir, "bin/sentry.dylib"));
 		}
 	}
 }

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -97,9 +97,9 @@ public class Sentry : ModuleRules
 
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/Desktop"));
 
-			RuntimeDependencies.Add("$(TargetOutputDir)/crashpad_handler.exe", Path.Combine(PlatformThirdPartyDir, "bin/crashpad_handler.exe"));
-			RuntimeDependencies.Add("$(TargetOutputDir)/sentry.dll", Path.Combine(PlatformThirdPartyDir, "bin/sentry.dll"));
-			RuntimeDependencies.Add("$(TargetOutputDir)/sentry.pdb", Path.Combine(PlatformThirdPartyDir, "bin/sentry.pdb"), StagedFileType.DebugNonUFS);
+			RuntimeDependencies.Add("$(PluginDir)/Binaries/Win64/crashpad_handler.exe", Path.Combine(PlatformThirdPartyDir, "bin/crashpad_handler.exe"));
+			RuntimeDependencies.Add("$(PluginDir)/Binaries/Win64/sentry.dll", Path.Combine(PlatformThirdPartyDir, "bin/sentry.dll"));
+			RuntimeDependencies.Add("$(PluginDir)/Binaries/Win64/sentry.pdb", Path.Combine(PlatformThirdPartyDir, "bin/sentry.pdb"), StagedFileType.DebugNonUFS);
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
 		}
@@ -109,9 +109,9 @@ public class Sentry : ModuleRules
 
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/Desktop"));
 
-			RuntimeDependencies.Add("$(TargetOutputDir)/crashpad_handler", Path.Combine(PlatformThirdPartyDir, "bin/crashpad_handler"));
-			RuntimeDependencies.Add("$(TargetOutputDir)/libsentry.so", Path.Combine(PlatformThirdPartyDir, "bin/libsentry.so"));
-			RuntimeDependencies.Add("$(TargetOutputDir)/libsentry.dbg.so", Path.Combine(PlatformThirdPartyDir, "bin/libsentry.dbg.so"), StagedFileType.DebugNonUFS);
+			RuntimeDependencies.Add("$(PluginDir)/Binaries/Linux/crashpad_handler", Path.Combine(PlatformThirdPartyDir, "bin/crashpad_handler"));
+			RuntimeDependencies.Add("$(PluginDir)/Binaries/Linux/libsentry.so", Path.Combine(PlatformThirdPartyDir, "bin/libsentry.so"));
+			RuntimeDependencies.Add("$(PluginDir)/Binaries/Linux/libsentry.dbg.so", Path.Combine(PlatformThirdPartyDir, "bin/libsentry.dbg.so"), StagedFileType.DebugNonUFS);
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
 		}
@@ -119,7 +119,7 @@ public class Sentry : ModuleRules
 		{
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private/Apple"));
 
-			RuntimeDependencies.Add("$(TargetOutputDir)/sentry.dylib", Path.Combine(PlatformThirdPartyDir, "bin/sentry.dylib"));
+			RuntimeDependencies.Add("$(PluginDir)/Binaries/Mac/sentry.dylib", Path.Combine(PlatformThirdPartyDir, "bin/sentry.dylib"));
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=0");
 			PublicDefinitions.Add("COCOAPODS=0");


### PR DESCRIPTION
This generally simplifies the complex manual handling of dependency files and resolves some teething problems we hit against in a distributed build system.