### PR TITLE
Fix snapshot update script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix snapshot update script ([#253](https://github.com/getsentry/sentry-unreal/pull/253))
+
 ## 0.4.0
 
 ### Features

--- a/scripts/packaging/pack.ps1
+++ b/scripts/packaging/pack.ps1
@@ -1,7 +1,13 @@
 Remove-Item "package-release" -Force -Recurse -ErrorAction SilentlyContinue
 New-Item "package-release" -ItemType Directory
 
-$exclude = @('Sentry.uplugin', '.gitkeep')
+$exclude = @(
+    'Sentry.uplugin',
+    '.gitkeep',
+    '.DS_Store',
+    'Binaries',
+    'Intermediate'
+)
 
 Copy-Item "plugin-dev/*" "package-release/" -Exclude $exclude -Recurse
 Copy-Item "CHANGELOG.md" -Destination "package-release/CHANGELOG.md"


### PR DESCRIPTION
This prevents temporaries from getting into the plugin snapshot file.

Related to #239 