### PR TITLE
Fix debug symbol uploading scripts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix snapshot update script ([#253](https://github.com/getsentry/sentry-unreal/pull/253))
+- Fix debug symbol uploading scripts ([#261](https://github.com/getsentry/sentry-unreal/pull/261))
 
 ### Dependencies
 

--- a/plugin-dev/Scripts/upload-debug-symbols-win.ps1
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.ps1
@@ -94,8 +94,8 @@ $PropertiesFile = "$ProjectPath/sentry.properties"
 
 If (-not (Test-Path -Path $PropertiesFile -PathType Leaf))
 {
-    Write-Error "Sentry: Properties file is missing: '$PropertiesFile'"
-    Exit 1
+    Write-Warning "Sentry: Properties file is missing: '$PropertiesFile'"
+    Exit
 }
 
 Write-Host "Sentry: Upload started using PropertiesFile '$PropertiesFile'"

--- a/plugin-dev/Scripts/upload-debug-symbols-win.ps1
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.ps1
@@ -90,7 +90,7 @@ If ("$IncludeSourceFiles".ToLower() -eq "true")
     $CliArgs += "--include-sources"
 }
 
-$PropertiesFile = "$ProjectPath/sentry.properties"
+$PropertiesFile = "$ProjectPath\sentry.properties"
 
 If (-not (Test-Path -Path $PropertiesFile -PathType Leaf))
 {

--- a/plugin-dev/Scripts/upload-debug-symbols.sh
+++ b/plugin-dev/Scripts/upload-debug-symbols.sh
@@ -51,7 +51,7 @@ fi
 export SENTRY_PROPERTIES="$projectPath/sentry.properties"
 if [ ! -f "$SENTRY_PROPERTIES" ]; then
     echo "Sentry: Properties file is missing: '$SENTRY_PROPERTIES'"
-    exit 1
+    exit
 fi
 
 echo "Sentry: Upload started using PropertiesFile '$SENTRY_PROPERTIES'"


### PR DESCRIPTION
This removes returning non-zero exit code during uploading the debug symbols if `sentry.properties` file is missing in project's root directory. 

If  `sentry.properties` file is present but misconfigured a corresponding error message will be printed to console and game build proceeds.

Not that in case with Android the Sentry's gradle plugin is used instead of a script and game build still will be terminated if the properties file is absent.

Closes #258 