### PR TITLE
Add plugin settings allowing to disable event capturing for certain build configurations/targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add plugin settings allowing to disable event capturing for certain build configurations/targets ([#273](https://github.com/getsentry/sentry-unreal/pull/273))
+
 ### Dependencies
 
 - Bump Native SDK from v0.6.1 to v0.6.2 ([#269](https://github.com/getsentry/sentry-unreal/pull/269))

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -57,15 +57,9 @@ void USentrySubsystem::Initialize()
 {
 	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
 
-	if(IsCurrentBuildConfigurationDisabled())
+	if(!IsCurrentBuildConfigurationEnabled() || !IsCurrentBuildTargetEnabled())
 	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization skipped since event capturing is disabled for the current build configuration in plugin settings."));
-		return;
-	}
-
-	if(IsCurrentBuildTargetDisabled())
-	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization skipped since event capturing is disabled for the current build target in plugin settings."));
+		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization skipped since event capturing is disabled for the current build configuration/target in plugin settings."));
 		return;
 	}
 
@@ -354,62 +348,62 @@ void USentrySubsystem::DisableAutomaticBreadcrumbs()
 	}
 }
 
-bool USentrySubsystem::IsCurrentBuildConfigurationDisabled()
+bool USentrySubsystem::IsCurrentBuildConfigurationEnabled()
 {
 	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
 
-	bool IsBuildConfigurationDisabled;
+	bool IsBuildConfigurationEnabled;
 
 	switch (FApp::GetBuildConfiguration())
 	{
 	case EBuildConfiguration::Debug:
-		IsBuildConfigurationDisabled = Settings->DisableBuildConfigurations.bDisableDebug;
+		IsBuildConfigurationEnabled = Settings->EnableBuildConfigurations.bEnableDebug;
 		break;
 	case EBuildConfiguration::DebugGame:
-		IsBuildConfigurationDisabled = Settings->DisableBuildConfigurations.bDisableDebugGame;
+		IsBuildConfigurationEnabled = Settings->EnableBuildConfigurations.bEnableDebugGame;
 		break;
 	case EBuildConfiguration::Development:
-		IsBuildConfigurationDisabled = Settings->DisableBuildConfigurations.bDisableDevelopment;
+		IsBuildConfigurationEnabled = Settings->EnableBuildConfigurations.bEnableDevelopment;
 		break;
 	case EBuildConfiguration::Shipping:
-		IsBuildConfigurationDisabled = Settings->DisableBuildConfigurations.bDisableShipping;
+		IsBuildConfigurationEnabled = Settings->EnableBuildConfigurations.bEnableShipping;
 		break;
 	case EBuildConfiguration::Test:
-		IsBuildConfigurationDisabled = Settings->DisableBuildConfigurations.bDisableTest;
+		IsBuildConfigurationEnabled = Settings->EnableBuildConfigurations.bEnableTest;
 		break;
 	default:
-		IsBuildConfigurationDisabled = false;
+		IsBuildConfigurationEnabled = false;
 	}
 
-	return IsBuildConfigurationDisabled;
+	return IsBuildConfigurationEnabled;
 }
 
-bool USentrySubsystem::IsCurrentBuildTargetDisabled()
+bool USentrySubsystem::IsCurrentBuildTargetEnabled()
 {
 	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
 
-	bool IsBuildTargetTypeDisabled;
+	bool IsBuildTargetTypeEnabled;
 
 	switch (FApp::GetBuildTargetType())
 	{
 	case EBuildTargetType::Game:
-		IsBuildTargetTypeDisabled = Settings->DisableBuildTargets.bDisableGame;
+		IsBuildTargetTypeEnabled = Settings->EnableBuildTargets.bEnableGame;
 		break;
 	case EBuildTargetType::Server:
-		IsBuildTargetTypeDisabled = Settings->DisableBuildTargets.bDisableServer;
+		IsBuildTargetTypeEnabled = Settings->EnableBuildTargets.bEnableServer;
 		break;
 	case EBuildTargetType::Client:
-		IsBuildTargetTypeDisabled = Settings->DisableBuildTargets.bDisableClient;
+		IsBuildTargetTypeEnabled = Settings->EnableBuildTargets.bEnableClient;
 		break;
 	case EBuildTargetType::Editor:
-		IsBuildTargetTypeDisabled = Settings->DisableBuildTargets.bDisableEditor;
+		IsBuildTargetTypeEnabled = Settings->EnableBuildTargets.bEnableEditor;
 		break;
 	case EBuildTargetType::Program:
-		IsBuildTargetTypeDisabled = Settings->DisableBuildTargets.bDisableProgram;
+		IsBuildTargetTypeEnabled = Settings->EnableBuildTargets.bEnableProgram;
 		break;
 	default:
-		IsBuildTargetTypeDisabled = false;
+		IsBuildTargetTypeEnabled = false;
 	}
 
-	return IsBuildTargetTypeDisabled;
+	return IsBuildTargetTypeEnabled;
 }

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -63,6 +63,58 @@ struct FTagsPromotion
 	bool bPromoteIsUnattended = true;
 };
 
+USTRUCT(BlueprintType)
+struct FDisableBuildConfigurations
+{
+	GENERATED_BODY()
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Debug", ToolTip = "Flag indicating whether event capturing should be disabled for the Debug build configuration."))
+	bool bDisableDebug = false;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "DebugGame", ToolTip = "Flag indicating whether event capturing should be disabled for the DebugGame build configuration."))
+	bool bDisableDebugGame = false;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Development", ToolTip = "Flag indicating whether event capturing should be disabled for the Development build configuration."))
+	bool bDisableDevelopment = false;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Test", ToolTip = "Flag indicating whether event capturing should be disabled for the Test build configuration."))
+	bool bDisableTest = false;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Shipping", ToolTip = "Flag indicating whether event capturing should be disabled for the Shipping build configuration."))
+	bool bDisableShipping = false;
+};
+
+USTRUCT(BlueprintType)
+struct FDisableBuildTargets
+{
+	GENERATED_BODY()
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Client", ToolTip = "Flag indicating whether event capturing should be disabled for the Client target type."))
+	bool bDisableClient = false;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Game", ToolTip = "Flag indicating whether event capturing should be disabled for the Game target type."))
+	bool bDisableGame = false;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Editor", ToolTip = "Flag indicating whether event capturing should be disabled for the Editor target type."))
+	bool bDisableEditor = false;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Server", ToolTip = "Flag indicating whether event capturing should be disabled for the Server target type."))
+	bool bDisableServer = false;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Program", ToolTip = "Flag indicating whether event capturing should be disabled for the Program target type."))
+	bool bDisableProgram = false;
+};
+
 /**
  * Sentry settings used for plugin configuration.
  */
@@ -91,6 +143,14 @@ public:
 	UPROPERTY(Config, EditAnywhere, Category = "Misc",
 		Meta = (DisplayName = "Enable verbose logging", ToolTip = "Flag indicating whether to enable verbose logging on desktop."))
 	bool EnableVerboseLogging;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Disable for Build Configurations"))
+	FDisableBuildConfigurations DisableBuildConfigurations;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Disable for Build Target Types"))
+	FDisableBuildTargets DisableBuildTargets;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
 		Meta = (DisplayName = "Automatically add breadcrumbs"))

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -64,55 +64,55 @@ struct FTagsPromotion
 };
 
 USTRUCT(BlueprintType)
-struct FDisableBuildConfigurations
+struct FEnableBuildConfigurations
 {
 	GENERATED_BODY()
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Debug", ToolTip = "Flag indicating whether event capturing should be disabled for the Debug build configuration."))
-	bool bDisableDebug = false;
+		Meta = (DisplayName = "Debug", ToolTip = "Flag indicating whether event capturing should be enabled for the Debug build configuration."))
+	bool bEnableDebug = true;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "DebugGame", ToolTip = "Flag indicating whether event capturing should be disabled for the DebugGame build configuration."))
-	bool bDisableDebugGame = false;
+		Meta = (DisplayName = "DebugGame", ToolTip = "Flag indicating whether event capturing should be enabled for the DebugGame build configuration."))
+	bool bEnableDebugGame = true;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Development", ToolTip = "Flag indicating whether event capturing should be disabled for the Development build configuration."))
-	bool bDisableDevelopment = false;
+		Meta = (DisplayName = "Development", ToolTip = "Flag indicating whether event capturing should be enabled for the Development build configuration."))
+	bool bEnableDevelopment = true;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Test", ToolTip = "Flag indicating whether event capturing should be disabled for the Test build configuration."))
-	bool bDisableTest = false;
+		Meta = (DisplayName = "Test", ToolTip = "Flag indicating whether event capturing should be enabled for the Test build configuration."))
+	bool bEnableTest = true;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Shipping", ToolTip = "Flag indicating whether event capturing should be disabled for the Shipping build configuration."))
-	bool bDisableShipping = false;
+		Meta = (DisplayName = "Shipping", ToolTip = "Flag indicating whether event capturing should be enabled for the Shipping build configuration."))
+	bool bEnableShipping = true;
 };
 
 USTRUCT(BlueprintType)
-struct FDisableBuildTargets
+struct FEnableBuildTargets
 {
 	GENERATED_BODY()
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Client", ToolTip = "Flag indicating whether event capturing should be disabled for the Client target type."))
-	bool bDisableClient = false;
+		Meta = (DisplayName = "Client", ToolTip = "Flag indicating whether event capturing should be enabled for the Client target type."))
+	bool bEnableClient = true;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Game", ToolTip = "Flag indicating whether event capturing should be disabled for the Game target type."))
-	bool bDisableGame = false;
+		Meta = (DisplayName = "Game", ToolTip = "Flag indicating whether event capturing should be enabled for the Game target type."))
+	bool bEnableGame = true;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Editor", ToolTip = "Flag indicating whether event capturing should be disabled for the Editor target type."))
-	bool bDisableEditor = false;
+		Meta = (DisplayName = "Editor", ToolTip = "Flag indicating whether event capturing should be enabled for the Editor target type."))
+	bool bEnableEditor = true;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Server", ToolTip = "Flag indicating whether event capturing should be disabled for the Server target type."))
-	bool bDisableServer = false;
+		Meta = (DisplayName = "Server", ToolTip = "Flag indicating whether event capturing should be enabled for the Server target type."))
+	bool bEnableServer = true;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Program", ToolTip = "Flag indicating whether event capturing should be disabled for the Program target type."))
-	bool bDisableProgram = false;
+		Meta = (DisplayName = "Program", ToolTip = "Flag indicating whether event capturing should be enabled for the Program target type."))
+	bool bEnableProgram = true;
 };
 
 /**
@@ -145,12 +145,12 @@ public:
 	bool EnableVerboseLogging;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Disable for Build Configurations"))
-	FDisableBuildConfigurations DisableBuildConfigurations;
+		Meta = (DisplayName = "Enable for Build Configurations"))
+	FEnableBuildConfigurations EnableBuildConfigurations;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
-		Meta = (DisplayName = "Disable for Build Target Types"))
-	FDisableBuildTargets DisableBuildTargets;
+		Meta = (DisplayName = "Enable for Build Target Types"))
+	FEnableBuildTargets EnableBuildTargets;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
 		Meta = (DisplayName = "Automatically add breadcrumbs"))

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -221,6 +221,12 @@ private:
 	/** Unsubscribe from game events that are used for automatic breadcrumbs. */
 	void DisableAutomaticBreadcrumbs();
 
+	/** Check whether the event capturing should be disabled for the current build configuration */
+	bool IsCurrentBuildConfigurationDisabled();
+
+	/** Check whether the event capturing should be disabled for the current build configuration */
+	bool IsCurrentBuildTargetDisabled();
+
 private:
 	TSharedPtr<ISentrySubsystem> SubsystemNativeImpl;
 

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -222,10 +222,10 @@ private:
 	void DisableAutomaticBreadcrumbs();
 
 	/** Check whether the event capturing should be disabled for the current build configuration */
-	bool IsCurrentBuildConfigurationDisabled();
+	bool IsCurrentBuildConfigurationEnabled();
 
 	/** Check whether the event capturing should be disabled for the current build configuration */
-	bool IsCurrentBuildTargetDisabled();
+	bool IsCurrentBuildTargetEnabled();
 
 private:
 	TSharedPtr<ISentrySubsystem> SubsystemNativeImpl;


### PR DESCRIPTION
This change should provide extra flexibility for the Sentry initialization by allowing to disable it for certain build configurations/targets via the settings menu:

![image](https://github.com/getsentry/sentry-unreal/assets/3168564/80a4778a-617b-4650-846e-89bdb8ba0a0e)

Closes #262 