### PR TITLE
Unify release name for all supported platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Unify release name for all supported platforms ([#294](https://github.com/getsentry/sentry-unreal/pull/294))
+
 ### Dependencies
 
 - Bump Java SDK (Android) from v6.19.1 to v6.20.0 ([#291](https://github.com/getsentry/sentry-unreal/pull/291))

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -27,17 +27,6 @@ import io.sentry.protocol.SentryId;
 public class SentryBridgeJava {
 	public static native void onConfigureScope(long callbackAddr, Scope scope);
 
-	public static String getFormattedReleaseName(Activity activity) {
-		PackageManager packageManager = activity.getPackageManager();
-		PackageInfo packageInfo;
-		try {
-			packageInfo = packageManager.getPackageInfo(activity.getPackageName(), 0);
-		} catch (PackageManager.NameNotFoundException e) {
-			throw new RuntimeException(e);
-		}
-		return String.format("%s@%s", activity.getPackageName(), packageInfo.versionName);
-	}
-
 	public static void init(
 			Activity activity,
 			final String dsnUrl,

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
@@ -32,8 +32,7 @@ void SentrySubsystemAndroid::InitWithSettings(const USentrySettings* settings)
 
 	const FString ReleaseName = settings->OverrideReleaseName
 		? settings->Release
-		: FSentryJavaObjectWrapper::CallStaticMethod<FString>(SentryJavaClasses::SentryBridgeJava,
-			"getFormattedReleaseName", "(Landroid/app/Activity;)Ljava/lang/String;", FJavaWrapper::GameActivityThis);
+		: settings->GetFormattedReleaseName();
 
 	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, 
 		"init", "(Landroid/app/Activity;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ZJ)V",

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
@@ -22,8 +22,6 @@
 
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
 #include "HAL/FileManager.h"
-#include "Misc/App.h"
-#include "Misc/ConfigCacheIni.h"
 
 void SentrySubsystemApple::InitWithSettings(const USentrySettings* settings)
 {
@@ -36,7 +34,7 @@ void SentrySubsystemApple::InitWithSettings(const USentrySettings* settings)
 		options.sessionTrackingIntervalMillis = settings->SessionTimeout;
 		options.releaseName = settings->OverrideReleaseName
 			? settings->Release.GetNSString()
-			: GetFormattedReleaseName().GetNSString();
+			: settings->GetFormattedReleaseName().GetNSString();
 	}];
 
 	[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
@@ -167,26 +165,4 @@ void SentrySubsystemApple::StartSession()
 void SentrySubsystemApple::EndSession()
 {
 	[SENTRY_APPLE_CLASS(SentrySDK) endSession];
-}
-
-FString SentrySubsystemApple::GetFormattedReleaseName()
-{
-	FString FormattedReleaseName;
-
-#if PLATFORM_MAC
-	FString Version;
-	GConfig->GetString(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), Version, GGameIni);
-	if(!Version.IsEmpty())
-	{
-		FormattedReleaseName = FString::Printf(TEXT("%s@%s"), FApp::GetProjectName(), *Version);
-	}
-#elif PLATFORM_IOS
-	NSDictionary* infoDictionary = [[NSBundle mainBundle] infoDictionary];
-	FormattedReleaseName = FString([NSString stringWithFormat:@"%@@%@",
-		infoDictionary[@"CFBundleIdentifier"],
-		infoDictionary[@"CFBundleShortVersionString"]
-	]);
-#endif
-
-	return FormattedReleaseName;
 }

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.h
@@ -25,7 +25,4 @@ public:
 	virtual void SetLevel(ESentryLevel level) override;
 	virtual void StartSession() override;
 	virtual void EndSession() override;
-
-private:
-	FString GetFormattedReleaseName();
 };

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -16,8 +16,6 @@
 #include "Infrastructure/SentryConvertorsDesktop.h"
 #include "CrashReporter/SentryCrashReporter.h"
 
-#include "Misc/App.h"
-#include "Misc/ConfigCacheIni.h"
 #include "Misc/Paths.h"
 #include "HAL/FileManager.h"
 #include "Launch/Resources/Version.h"
@@ -77,7 +75,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 
 	sentry_options_set_release(options, TCHAR_TO_ANSI(settings->OverrideReleaseName
 		? *settings->Release
-		: *GetFormattedReleaseName()));
+		: *settings->GetFormattedReleaseName()));
 
 	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
 	sentry_options_set_environment(options, TCHAR_TO_ANSI(*settings->Environment));
@@ -205,20 +203,6 @@ void SentrySubsystemDesktop::StartSession()
 void SentrySubsystemDesktop::EndSession()
 {
 	sentry_end_session();
-}
-
-FString SentrySubsystemDesktop::GetFormattedReleaseName()
-{
-	FString FormattedReleaseName;
-
-	FString Version;
-	GConfig->GetString(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), Version, GGameIni);
-	if(!Version.IsEmpty())
-	{
-		FormattedReleaseName = FString::Printf(TEXT("%s@%s"), FApp::GetProjectName(), *Version);
-	}
-
-	return FormattedReleaseName;
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
@@ -33,8 +33,6 @@ public:
 	virtual void EndSession() override;
 
 private:
-	FString GetFormattedReleaseName();
-
 	TSharedPtr<SentryCrashReporter> crashReporter;
 };
 

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -4,6 +4,7 @@
 
 #include "Misc/Paths.h"
 #include "Misc/ConfigCacheIni.h"
+#include "Misc/App.h"
 
 USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
@@ -30,6 +31,20 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 #endif
 
 	LoadDebugSymbolsProperties();
+}
+
+FString USentrySettings::GetFormattedReleaseName() const
+{
+	FString FormattedReleaseName = FApp::GetProjectName();
+
+	FString Version;
+	GConfig->GetString(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), Version, GGameIni);
+	if(!Version.IsEmpty())
+	{
+		FormattedReleaseName = FString::Printf(TEXT("%s@%s"), *FormattedReleaseName, *Version);
+	}
+
+	return FormattedReleaseName;
 }
 
 void USentrySettings::LoadDebugSymbolsProperties()

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -123,7 +123,6 @@ class SENTRY_API USentrySettings : public UObject
 {
 	GENERATED_UCLASS_BODY()
 
-public:
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Core",
 		Meta = (DisplayName = "DSN", ToolTip = "The DSN (Data Source Name) tells the SDK where to send the events to. Get your DSN in the Sentry dashboard."))
 	FString DsnUrl;
@@ -203,6 +202,9 @@ public:
 	UPROPERTY(Config, EditAnywhere, Category = "Crash Reporter",
 		Meta = (DisplayName = "Crash Reporter Endpoint", ToolTip = "Endpoint that Unreal Engine Crah Reporter should use in order to upload crash data to Sentry."))
 	FString CrashReporterUrl;
+
+public:
+	FString GetFormattedReleaseName() const;
 
 private:
 	void LoadDebugSymbolsProperties();


### PR DESCRIPTION
This fixes an issue with different release names on desktop/iOS/Android in case one wasn't provided explicitly in plugin settings.