### PR TITLE
Add custom transport for Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add custom transport for Linux ([#297](https://github.com/getsentry/sentry-unreal/pull/297))
+
 ### Dependencies
 
 - Bump Java SDK (Android) from v6.19.1 to v6.20.0 ([#291](https://github.com/getsentry/sentry-unreal/pull/291))

--- a/plugin-dev/Source/Sentry/Private/Desktop/Infrastructure/SentryConvertorsDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Infrastructure/SentryConvertorsDesktop.cpp
@@ -115,4 +115,16 @@ FString SentryConvertorsDesktop::SentryLevelToString(ESentryLevel level)
 	return Result;
 }
 
+TArray<uint8> SentryConvertorsDesktop::SentryEnvelopeToByteArray(sentry_envelope_t* envelope)
+{
+	size_t size;
+	ANSICHAR* serializedEnvelopeStr = sentry_envelope_serialize(envelope, &size);
+
+	TArray<uint8> envelopeData = TArray(reinterpret_cast<uint8*>(serializedEnvelopeStr), size);
+
+	sentry_string_free(serializedEnvelopeStr);
+
+	return envelopeData;
+}
+
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/Infrastructure/SentryConvertorsDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Infrastructure/SentryConvertorsDesktop.h
@@ -24,6 +24,7 @@ public:
 
 	/** Other conversions */
 	static FString SentryLevelToString(ESentryLevel level);
+	static TArray<uint8> SentryEnvelopeToByteArray(sentry_envelope_t* envelope);
 };
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -15,6 +15,7 @@
 
 #include "Infrastructure/SentryConvertorsDesktop.h"
 #include "CrashReporter/SentryCrashReporter.h"
+#include "Transport/SentryTransport.h"
 
 #include "Misc/App.h"
 #include "Misc/ConfigCacheIni.h"
@@ -84,6 +85,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 	sentry_options_set_auto_session_tracking(options, settings->EnableAutoSessionTracking);
+	sentry_options_set_transport(options, FSentryTransport::Create());
 
 	int initResult = sentry_init(options);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -85,7 +85,10 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings)
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 	sentry_options_set_auto_session_tracking(options, settings->EnableAutoSessionTracking);
+
+#if PLATFORM_LINUX
 	sentry_options_set_transport(options, FSentryTransport::Create());
+#endif
 
 	int initResult = sentry_init(options);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.cpp
@@ -1,0 +1,32 @@
+﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+
+#include "SentryDsnUrl.h"
+
+SentryDsnUrl::SentryDsnUrl(const FString& Dsn)
+{
+	FString UrlRemainder;
+
+	Dsn.Split(TEXT("://"), &Scheme, &UrlRemainder);
+	UrlRemainder.Split(TEXT("@"), &Key, &UrlRemainder);
+	UrlRemainder.Split(TEXT("/"), &Host, &ProjectId);
+}
+
+const FString& SentryDsnUrl::GetScheme() const
+{
+	return Scheme;
+}
+
+const FString& SentryDsnUrl::GetHost() const
+{
+	return Host;
+}
+
+const FString& SentryDsnUrl::GetProjectId() const
+{
+	return ProjectId;
+}
+
+const FString& SentryDsnUrl::GetKey() const
+{
+	return Key;
+}

--- a/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.cpp
@@ -2,6 +2,8 @@
 
 #include "SentryDsnUrl.h"
 
+#if USE_SENTRY_NATIVE
+
 SentryDsnUrl::SentryDsnUrl(const FString& Dsn)
 {
 	FString UrlRemainder;
@@ -30,3 +32,5 @@ const FString& SentryDsnUrl::GetKey() const
 {
 	return Key;
 }
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.h
@@ -4,7 +4,7 @@
 
 #include "CoreMinimal.h"
 
-#pragma once
+#if USE_SENTRY_NATIVE
 
 class SentryDsnUrl
 {
@@ -22,3 +22,5 @@ private:
 	FString Host;
 	FString ProjectId;
 };
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.h
@@ -1,0 +1,24 @@
+﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#pragma once
+
+class SentryDsnUrl
+{
+public:
+	SentryDsnUrl(const FString& Dsn);
+
+	const FString& GetScheme() const;
+	const FString& GetHost() const;
+	const FString& GetProjectId() const;
+	const FString& GetKey() const;
+
+private:
+	FString Scheme;
+	FString Key;
+	FString Host;
+	FString ProjectId;
+};

--- a/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryTransport.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryTransport.cpp
@@ -1,0 +1,160 @@
+﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+
+#include "SentryTransport.h"
+#include "SentryDefines.h"
+#include "SentryModule.h"
+#include "SentryDsnUrl.h"
+#include "SentrySettings.h"
+
+#include "Infrastructure/SentryConvertorsDesktop.h"
+
+#include "HttpModule.h"
+#include "Misc/ScopeLock.h"
+
+#if USE_SENTRY_NATIVE
+
+const float FSentryTransport::RequestTickInterval = 0.01f;
+
+sentry_transport_t* FSentryTransport::Create()
+{
+	auto NewTransport = MakeShared<FSentryTransport, ESPMode::ThreadSafe>();
+
+	// Initialize transport object with the corresponding self-reference in order to control its lifetime from within `sentry-native`
+	NewTransport->Self = NewTransport;
+
+	sentry_transport_t* transport = sentry_transport_new([](sentry_envelope_t* envelope, void* state)
+	{
+		static_cast<FSentryTransport*>(state)->Send(envelope);
+	});
+
+	sentry_transport_set_state(transport, &NewTransport.Get());
+
+	sentry_transport_set_free_func(transport, [](void* state)
+	{
+		static_cast<FSentryTransport*>(state)->Free();
+	});
+	sentry_transport_set_startup_func(transport, [](const sentry_options_t* options, void* state)->int
+	{
+		return static_cast<FSentryTransport*>(state)->Startup(options);
+	});
+	sentry_transport_set_flush_func(transport, [](uint64_t timeout, void* state)->int
+	{
+		return static_cast<FSentryTransport*>(state)->Flush(timeout);
+	});
+	sentry_transport_set_shutdown_func(transport, [](uint64_t timeout, void* state)->int
+	{
+		return static_cast<FSentryTransport*>(state)->Shutdown(timeout);
+	});
+
+	return transport;
+}
+
+void FSentryTransport::Send(sentry_envelope_t* envelope)
+{
+	if(!IsRunning)
+	{
+		return;
+	}
+
+	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
+
+	const SentryDsnUrl DsnUrl(Settings->DsnUrl);
+
+	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> HttpRequest = FHttpModule::Get().CreateRequest();
+
+	HttpRequest->SetURL(FString::Printf(TEXT("https://%s/api/%s/envelope/"), *DsnUrl.GetHost(), *DsnUrl.GetProjectId()));
+	HttpRequest->SetVerb(TEXT("POST"));
+	HttpRequest->SetHeader(TEXT("Content-Type"), TEXT("application/x-sentry-envelope"));
+	HttpRequest->SetHeader(TEXT("X-Sentry-Auth"), FString::Printf(TEXT("Sentry sentry_version=7, sentry_client=sentry-unreal, sentry_key=%s"), *DsnUrl.GetKey()));
+	HttpRequest->SetContent(SentryConvertorsDesktop::SentryEnvelopeToByteArray(envelope));
+
+	HttpRequest->OnProcessRequestComplete().BindThreadSafeSP(this, &FSentryTransport::OnRequestCompleted);
+
+	{
+		FScopeLock Lock(&CriticalSection);
+		RequestsQueue.Add(HttpRequest);
+		if (!HttpRequest->ProcessRequest())
+		{
+			RequestsQueue.Pop();
+		}
+	}
+
+	sentry_envelope_free(envelope);
+}
+
+void FSentryTransport::Free()
+{
+	Self.Reset();
+}
+
+int FSentryTransport::Startup(const sentry_options_t* options)
+{
+	IsRunning = true;
+	return 0;
+}
+
+int FSentryTransport::Flush(uint64_t timeout)
+{
+	double EndTime = FPlatformTime::Seconds() + static_cast<double>(timeout) / 1000;
+
+	// Manually tick pending requests since relying on game thread for that might be insecure
+	while(true)
+	{
+		TArray< TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> > RequestsQueueCopy;
+
+		{
+			FScopeLock Lock(&CriticalSection);
+			RequestsQueueCopy = RequestsQueue;
+		}
+
+		if (!RequestsQueueCopy.Num())
+		{
+			return 0;
+		}
+
+		for (auto& Request : RequestsQueueCopy)
+		{
+			Request->Tick(RequestTickInterval);
+		}
+
+		if (RequestsQueue.Num())
+		{
+			if (FPlatformTime::Seconds() > EndTime)
+			{
+				return 1;
+			}
+
+			FPlatformProcess::Sleep(RequestTickInterval);
+		}
+	}
+
+	return 0;
+}
+
+int FSentryTransport::Shutdown(uint64_t timeout)
+{
+	IsRunning = false;
+	return Flush(timeout);
+}
+
+void FSentryTransport::OnRequestCompleted(TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> Request, TSharedPtr<IHttpResponse, ESPMode::ThreadSafe> Response, bool bSuccess)
+{
+	if(!bSuccess || !Response.IsValid() || !EHttpResponseCodes::IsOk(Response->GetResponseCode()))
+	{
+		UE_LOG(LogSentrySdk, Log, TEXT("Sending envelope failed."));
+	}
+
+	FScopeLock Lock(&CriticalSection);
+
+	int32 RequestIndex = RequestsQueue.IndexOfByPredicate([&](const TSharedPtr<IHttpRequest, ESPMode::ThreadSafe>& CachedRequest)
+	{
+		return CachedRequest.Get() == Request.Get();
+	});
+
+	if(RequestIndex != INDEX_NONE)
+	{
+		RequestsQueue.RemoveAt(RequestIndex);
+	}
+}
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryTransport.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryTransport.h
@@ -31,8 +31,6 @@ private:
 	FCriticalSection CriticalSection;
 
 	bool IsRunning = false;
-
-	const static float RequestTickInterval;
 };
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryTransport.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryTransport.h
@@ -1,0 +1,38 @@
+﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Http.h"
+#include "HAL/CriticalSection.h"
+
+#include "Convenience/SentryInclude.h"
+
+#if USE_SENTRY_NATIVE
+
+class FSentryTransport : public TSharedFromThis<FSentryTransport, ESPMode::ThreadSafe>
+{
+public:
+	static sentry_transport_t* Create();
+
+private:
+	void Send(sentry_envelope_t* envelope);
+	void Free();
+	int Startup(const sentry_options_t* options);
+	int Flush(uint64_t timeout);
+	int Shutdown(uint64_t timeout);
+
+	void OnRequestCompleted(TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> Request, TSharedPtr<IHttpResponse, ESPMode::ThreadSafe> Response, bool bSuccess);
+
+	TSharedPtr<FSentryTransport, ESPMode::ThreadSafe> Self;
+
+	TArray<TSharedPtr<IHttpRequest, ESPMode::ThreadSafe>> RequestsQueue;
+
+	FCriticalSection CriticalSection;
+
+	bool IsRunning = false;
+
+	const static float RequestTickInterval;
+};
+
+#endif

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -45,7 +45,8 @@ public class Sentry : ModuleRules
 				"Slate",
 				"SlateCore",
 				"Projects",
-				"Json"
+				"Json",
+				"HTTP"
 				// ... add private dependencies that you statically link with here ...	
 			}
 		);

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -6,7 +6,7 @@ export sentryArtifactsDestination=$2
 
 rm -rf "${sentryArtifactsDestination}/"*
 
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D CMAKE_BUILD_TYPE=RelWithDebInfo
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D CMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build "${sentryNativeRoot}/build" --target sentry --parallel
 
 mkdir "${sentryArtifactsDestination}/bin"

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -87,6 +87,11 @@ Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
 Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
 Source/Sentry/Private/Desktop/SentryUserDesktop.cpp
 Source/Sentry/Private/Desktop/SentryUserDesktop.h
+Source/Sentry/Private/Desktop/Transport/
+Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.cpp
+Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.h
+Source/Sentry/Private/Desktop/Transport/SentryTransport.cpp
+Source/Sentry/Private/Desktop/Transport/SentryTransport.h
 Source/Sentry/Private/Interface/
 Source/Sentry/Private/Interface/SentryAttachmentInterface.h
 Source/Sentry/Private/Interface/SentryBreadcrumbInterface.h


### PR DESCRIPTION
This PR introduces custom transport implementation for `sentry-native` which should help to resolve the issue with system/UE libraries compatibility on Linux.

Closes #259 