### PR TITLE
Enable unity build for sample project in UE 5.2

### DIFF
--- a/sample/Source/SentryPlayground.Target.cs
+++ b/sample/Source/SentryPlayground.Target.cs
@@ -13,7 +13,10 @@ public class SentryPlaygroundTarget : TargetRules
 
 		bOverrideBuildEnvironment = true;
 
-		bUsePCHFiles = false;
-		bUseUnityBuild = false;
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion < 2)
+		{
+			bUsePCHFiles = false;
+			bUseUnityBuild = false;
+		}
 	}
 }

--- a/sample/Source/SentryPlaygroundEditor.Target.cs
+++ b/sample/Source/SentryPlaygroundEditor.Target.cs
@@ -13,7 +13,10 @@ public class SentryPlaygroundEditorTarget : TargetRules
 
 		bOverrideBuildEnvironment = true;
 
-		bUsePCHFiles = false;
-		bUseUnityBuild = false;
+		if (Target.Version.MajorVersion == 5 && Target.Version.MinorVersion < 2)
+		{
+			bUsePCHFiles = false;
+			bUseUnityBuild = false;
+		}
 	}
 }


### PR DESCRIPTION
This fixes packaging issues that arise after upgrading sample project to UE 5.2 from some older engine versions.

#skip-changelog