### PR TITLE
Fix running automation tests in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,17 +197,37 @@ jobs:
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests
+        id: run-tests
         run: |
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal mkdir TestReport
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build Development Editor
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 editor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
-            -ExecCmds="Automation RunTests Sentry;quit" \
-            -ReportOutputPath=/workspace/checkout/${{ matrix.app }}/TestReport \
-            -nullrhi \
-            -nopause \
-            -nosplash \
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 editor \
+            -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \            
+            -reportoutputpath=/workspace/checkout/${{ matrix.app }}/Saved/Automation \
+            -execcmds="Automation RunTests Sentry;quit" \
+            -game \
+            -buildmachine \
+            -stdout \
+            -fullstdoutlogoutput \
+            -forcelogflush \
             -unattended \
-            -testexit="Automation Test Queue Empty"
+            -nopause \
+            -nosplash
+
+      - name: Collect ${{ matrix.app }} test info
+        if: contains(fromJson('["success", "failure"]'), steps.run-tests.outcome)
+        uses: actions/upload-artifact@v3.1.1
+        with:
+          name: UE ${{ matrix.unreal }} ${{ matrix.app }} test report
+          path: |
+            checkout/${{ matrix.app }}/Saved/Automation
+
+      - name: Build & package ${{ matrix.app }}
+        # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27
+        if: ${{ matrix.unreal == '4.27'}}
+        id: package-app
+        run: |
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 package
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal cp -r '/home/gh/Library/Logs/Unreal Engine/LocalBuildLogs' Saved/Logs
   
       - name: Collect ${{ matrix.app }} build info
         if: contains(fromJson('["success", "failure"]'), steps.package-app.outcome)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,8 @@ jobs:
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -nullRHI -nopause -unattended -testexit="Automation Test Queue Empty"
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
+          -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -nullRHI -nopause -unattended -testexit="Automation Test Queue Empty"
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -205,7 +205,9 @@ jobs:
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal cp -r '/home/gh/Library/Logs/Unreal Engine/LocalBuildLogs' Saved/Logs
 
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -game -buildmachine -stdout -fullstdoutlogoutput -forcelogflush -nullrhi -nopause -nosplash -unattended -testexit="Automation Test Queue Empty"
+        run: |
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build Development Editor
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -game -buildmachine -stdout -fullstdoutlogoutput -forcelogflush -nullrhi -nopause -nosplash -unattended -testexit="Automation Test Queue Empty"
   
       - name: Collect ${{ matrix.app }} build info
         if: contains(fromJson('["success", "failure"]'), steps.package-app.outcome)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,7 @@ jobs:
       - name: Run tests
         run: |
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build Development Editor
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -game -buildmachine -stdout -fullstdoutlogoutput -forcelogflush -nullrhi -nopause -nosplash -unattended -testexit="Automation Test Queue Empty"
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=/workspace/checkout/${{ matrix.app }}/TestReport -game -buildmachine -stdout -fullstdoutlogoutput -forcelogflush -nullrhi -nopause -nosplash -unattended -testexit="Automation Test Queue Empty"
   
       - name: Collect ${{ matrix.app }} build info
         if: contains(fromJson('["success", "failure"]'), steps.package-app.outcome)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,8 +200,8 @@ jobs:
         run: |
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal mkdir TestReport
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build Development Editor
-          docker exec unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
-            -ExecCmds="Automation RunTests Sentry" \
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 editor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
+            -ExecCmds="Automation RunTests Sentry;quit" \
             -ReportOutputPath=/workspace/checkout/${{ matrix.app }}/TestReport \
             -nullrhi \
             -nopause \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     uses: ./.github/workflows/sdk.yml
     with:
       target: IOS
-      runsOn: macos-12
+      runsOn: macos-latest
 
   macos-sdk:
     uses: ./.github/workflows/sdk.yml
     with:
       target: Mac
-      runsOn: macos-12
+      runsOn: macos-latest
 
   linux-sdk:
     uses: ./.github/workflows/sdk.yml
@@ -197,7 +197,7 @@ jobs:
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -nullRHI -nopause -unattended -testexit="Automation Test Queue Empty"
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -nullRHI -nopause -unattended -testexit="Automation Test Queue Empty"
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,6 @@ jobs:
 
       - name: Run tests
         run: |
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build Development Editor
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor \
             /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -ExecCmds="Automation RunTests Sentry" \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,13 +201,14 @@ jobs:
         run: |
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 editor \
-            -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
-            -reportoutputpath=/workspace/checkout/${{ matrix.app }}/Saved/Automation \
-            -execcmds="Automation RunTests Sentry;quit" \
-            -unattended \
-            -nopause \
-            -nosplash \
-            -nullrhi
+            -Project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
+            -ReportExportPath=/workspace/checkout/${{ matrix.app }}/Saved/Automation \
+            -ExecCmds="Automation RunTests Sentry;quit" \
+            -TestExit="Automation Test Queue Empty" \
+            -Unattended \
+            -NoPause \
+            -NoSplash \
+            -NullRHI
 
       - name: Collect ${{ matrix.app }} test info
         if: contains(fromJson('["success", "failure"]'), steps.run-tests.outcome)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,7 @@ jobs:
             -NullRHI
 
       - name: Collect ${{ matrix.app }} test info
-        if: ${{ steps.run-tests.outcome == 'failure' }}
+        if: ${{ always() && steps.run-tests.outcome == 'failure' }}
         uses: actions/upload-artifact@v3.1.1
         with:
           name: UE ${{ matrix.unreal }} ${{ matrix.app }} test report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,19 @@ jobs:
       - name: Run tests
         run: |
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build Development Editor
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=/workspace/checkout/${{ matrix.app }}/TestReport -game -buildmachine -stdout -fullstdoutlogoutput -forcelogflush -nullrhi -nopause -nosplash -unattended -testexit="Automation Test Queue Empty"
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor \
+            /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
+            -ExecCmds="Automation RunTests Sentry" \
+            -ReportOutputPath=/workspace/checkout/${{ matrix.app }}/TestReport \
+            -game \
+            -buildmachine \
+            -stdout \
+            -fullstdoutlogoutput \
+            -forcelogflush \
+            -nullrhi \
+            -nopause \
+            -nosplash \
+            -unattended
   
       - name: Collect ${{ matrix.app }} build info
         if: contains(fromJson('["success", "failure"]'), steps.package-app.outcome)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,8 @@ jobs:
 
       - name: Run tests
         run: |
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 uat BuildCookRun -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -platform=Linux -nop4 -cook -build
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal mkdir TestReport
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build Development Editor
           docker exec unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -ExecCmds="Automation RunTests Sentry" \
             -ReportOutputPath=/workspace/checkout/${{ matrix.app }}/TestReport \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,8 +197,7 @@ jobs:
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
-          -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -nullRHI -nopause -unattended -testexit="Automation Test Queue Empty"
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -nullRHI -nopause -unattended -testexit="Automation Test Queue Empty"
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,17 +196,9 @@ jobs:
         # sentry-native requires write access to sample project directory in order to initialize itself properly
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
-      - name: Build & package ${{ matrix.app }}
-        # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27
-        if: ${{ matrix.unreal == '4.27'}}
-        id: package-app
-        run: |
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 package
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal cp -r '/home/gh/Library/Logs/Unreal Engine/LocalBuildLogs' Saved/Logs
-
       - name: Run tests
         run: |
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build -notools
+          docker exec unreal ue4 uat BuildCookRun -platform=Linux -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -nop4 -cook -build
           docker exec unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -ExecCmds="Automation RunTests Sentry" \
             -ReportOutputPath=/workspace/checkout/${{ matrix.app }}/TestReport \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,9 +196,6 @@ jobs:
         # sentry-native requires write access to sample project directory in order to initialize itself properly
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
-      - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -game -buildmachine -stdout -fullstdoutlogoutput -forcelogflush -nullrhi -nopause -nosplash -unattended -testexit="Automation Test Queue Empty"
-
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27
         if: ${{ matrix.unreal == '4.27'}}
@@ -207,6 +204,9 @@ jobs:
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 package
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal cp -r '/home/gh/Library/Logs/Unreal Engine/LocalBuildLogs' Saved/Logs
 
+      - name: Run tests
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -game -buildmachine -stdout -fullstdoutlogoutput -forcelogflush -nullrhi -nopause -nosplash -unattended -testexit="Automation Test Queue Empty"
+  
       - name: Collect ${{ matrix.app }} build info
         if: contains(fromJson('["success", "failure"]'), steps.package-app.outcome)
         uses: actions/upload-artifact@v3.1.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,8 +206,8 @@ jobs:
 
       - name: Run tests
         run: |
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor \
-            /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build -notools
+          docker exec unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -ExecCmds="Automation RunTests Sentry" \
             -ReportOutputPath=/workspace/checkout/${{ matrix.app }}/TestReport \
             -game \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,7 +198,7 @@ jobs:
 
       - name: Run tests
         run: |
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 uat BuildCookRun -platform=Linux -nop4 -cook -build
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 uat BuildCookRun -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -platform=Linux -nop4 -cook -build
           docker exec unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -ExecCmds="Automation RunTests Sentry" \
             -ReportOutputPath=/workspace/checkout/${{ matrix.app }}/TestReport \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -nullRHI -nopause -unattended -testexit="Automation Test Queue Empty"
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -game -buildmachine -stdout -fullstdoutlogoutput -forcelogflush -nullrhi -nopause -nosplash -unattended -testexit="Automation Test Queue Empty"
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,7 +211,8 @@ jobs:
             -forcelogflush \
             -unattended \
             -nopause \
-            -nosplash
+            -nosplash \
+            -nullrhi
 
       - name: Collect ${{ matrix.app }} test info
         if: contains(fromJson('["success", "failure"]'), steps.run-tests.outcome)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -198,19 +198,15 @@ jobs:
 
       - name: Run tests
         run: |
-          docker exec unreal ue4 uat BuildCookRun -platform=Linux -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject -nop4 -cook -build
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 uat BuildCookRun -platform=Linux -nop4 -cook -build
           docker exec unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -ExecCmds="Automation RunTests Sentry" \
             -ReportOutputPath=/workspace/checkout/${{ matrix.app }}/TestReport \
-            -game \
-            -buildmachine \
-            -stdout \
-            -fullstdoutlogoutput \
-            -forcelogflush \
             -nullrhi \
             -nopause \
             -nosplash \
-            -unattended
+            -unattended \
+            -testexit="Automation Test Queue Empty"
   
       - name: Collect ${{ matrix.app }} build info
         if: contains(fromJson('["success", "failure"]'), steps.package-app.outcome)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,7 +201,7 @@ jobs:
         run: |
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 editor \
-            -Project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
+            /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -ReportExportPath=/workspace/checkout/${{ matrix.app }}/Saved/Automation \
             -ExecCmds="Automation RunTests Sentry;quit" \
             -TestExit="Automation Test Queue Empty" \
@@ -211,7 +211,7 @@ jobs:
             -NullRHI
 
       - name: Collect ${{ matrix.app }} test info
-        if: contains(fromJson('["success", "failure"]'), steps.run-tests.outcome)
+        if: ${{ steps.run-tests.outcome == 'failure' }}
         uses: actions/upload-artifact@v3.1.1
         with:
           name: UE ${{ matrix.unreal }} ${{ matrix.app }} test report

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ jobs:
     uses: ./.github/workflows/sdk.yml
     with:
       target: IOS
-      runsOn: macos-latest
+      runsOn: macos-12
 
   macos-sdk:
     uses: ./.github/workflows/sdk.yml
     with:
       target: Mac
-      runsOn: macos-latest
+      runsOn: macos-12
 
   linux-sdk:
     uses: ./.github/workflows/sdk.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -201,14 +201,9 @@ jobs:
         run: |
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 build
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 editor \
-            -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \            
+            -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -reportoutputpath=/workspace/checkout/${{ matrix.app }}/Saved/Automation \
             -execcmds="Automation RunTests Sentry;quit" \
-            -game \
-            -buildmachine \
-            -stdout \
-            -fullstdoutlogoutput \
-            -forcelogflush \
             -unattended \
             -nopause \
             -nosplash \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,7 +197,7 @@ jobs:
         run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests
-        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal ue4 test --filter Product
+        run: docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/UnrealEditor SentryPlayground.uproject -ExecCmds="Automation RunTests Sentry" -ReportOutputPath=TestReport.txt -nullRHI -nopause -unattended -testexit="Automation Test Queue Empty"
 
       - name: Build & package ${{ matrix.app }}
         # Unreal 5.0 takes ~1 hour to build+package the app so only do it on v4.27

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
@@ -26,7 +26,7 @@ void SentryEventSpec::Define()
 			SentryEvent->SetLevel(ESentryLevel::Fatal);
 			SentryEvent->SetMessage(TestMessage);
 
-			TestEqual("Event level", SentryEvent->GetLevel(), ESentryLevel::Fatal);
+			TestNotEqual("Event level", SentryEvent->GetLevel(), ESentryLevel::Fatal);
 			TestEqual("Event message", SentryEvent->GetMessage(), TestMessage);
 		});
 	});

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
@@ -26,7 +26,7 @@ void SentryEventSpec::Define()
 			SentryEvent->SetLevel(ESentryLevel::Fatal);
 			SentryEvent->SetMessage(TestMessage);
 
-			TestNotEqual("Event level", SentryEvent->GetLevel(), ESentryLevel::Fatal);
+			TestEqual("Event level", SentryEvent->GetLevel(), ESentryLevel::Fatal);
 			TestEqual("Event message", SentryEvent->GetMessage(), TestMessage);
 		});
 	});


### PR DESCRIPTION
This improves plugin CI by throwing an error if some automation tests fail (previously we didn't know that something went wrong). Also, if not all tests were completed successfully a corresponding report will be attached to the list of generated artifacts.

#skip-changelog