### PR TITLE
Refactor initialization logic for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add API allowing to set custom handler for `beforeSend` hook ([#318](https://github.com/getsentry/sentry-unreal/pull/318))
+- Refactor initialization logic for Android ([#319](https://github.com/getsentry/sentry-unreal/pull/319))
 
 ### Fixes
 


### PR DESCRIPTION
This allows replacing a constantly growing list of parameters passed to Java layer with a single JSON string preventing potential errors whenever a new option has to be added.