### PR TITLE
Fixing issue where the Sentry.so file hasn't been copied yet to the binaries folder therefore resulting in a compile error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add HTTP proxy for desktop ([#322](https://github.com/getsentry/sentry-unreal/pull/322))
 
+### Fixes
+
+- Fix Linux Compile/Staging Error ([#327](https://github.com/getsentry/sentry-unreal/pull/327))
+
 ### Dependencies
 
 - Bump Java SDK (Android) from v6.25.0 to v6.25.1 ([#323](https://github.com/getsentry/sentry-unreal/pull/323))
@@ -25,6 +29,7 @@
 ### Fixes
 
 - Fix automatic game log attachment (Android) ([#309](https://github.com/getsentry/sentry-unreal/pull/309))
+  
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -119,7 +119,7 @@ public class Sentry : ModuleRules
 
 			PublicRuntimeLibraryPaths.Add(PlatformBinariesPath);
 
-			PublicAdditionalLibraries.Add(Path.Combine(PlatformBinariesPath, "libsentry.so"));
+			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "bin", "libsentry.so"));
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
 		}


### PR DESCRIPTION
Fixing the following:
`Library 'E:\Horde\Work\Blah\Sync\BLAH\Plugins\External\SentryUnrealPlugin\Binaries\Linux\libsentry.so' was not resolvable to a file when used in Module 'Sentry', assuming it is a filename and will search library paths for it. This is slow and dependency checking will not work for it. Please update reference to be fully qualified alternatively use PublicSystemLibraryPaths if you do intended to use this slow path to suppress this warning.  [...]`

While the RuntimeDependencies does mark this file correctly, it doesn't copy it in time for PublicAdditionalLibraries to use it. 