### PR TITLE
Add scope support for Windows/Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add HTTP proxy for desktop ([#322](https://github.com/getsentry/sentry-unreal/pull/322))
+- Add scope support for Windows/Linux ([#328](https://github.com/getsentry/sentry-unreal/pull/328))
 
 ## 0.8.0
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/Infrastructure/SentryConvertorsDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Infrastructure/SentryConvertorsDesktop.h
@@ -16,11 +16,14 @@ public:
 	/** Conversions to native desktop (Windows/Mac) types */
 	static sentry_level_e SentryLevelToNative(ESentryLevel level);
 	static sentry_value_t StringMapToNative(const TMap<FString, FString>& map);
+	static sentry_value_t StringArrayToNative(const TArray<FString>& array );
 
 	/** Conversions from native desktop (Windows/Mac) types */
 	static ESentryLevel SentryLevelToUnreal(sentry_value_t level);
+	static ESentryLevel SentryLevelToUnreal(sentry_level_t level);
 	static USentryId* SentryIdToUnreal(sentry_uuid_t id);
 	static TMap<FString, FString> StringMapToUnreal(sentry_value_t map);
+	static TArray<FString> StringArrayToUnreal(sentry_value_t array);
 
 	/** Other conversions */
 	static FString SentryLevelToString(ESentryLevel level);

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
@@ -1,0 +1,184 @@
+﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+
+#include "SentryScopeDesktop.h"
+#include "SentryBreadcrumbDesktop.h"
+#include "SentryEventDesktop.h"
+
+#include "SentryBreadcrumb.h"
+#include "SentryAttachment.h"
+#include "SentryEvent.h"
+
+#include "Infrastructure/SentryConvertorsDesktop.h"
+
+#if USE_SENTRY_NATIVE
+
+SentryScopeDesktop::SentryScopeDesktop()
+	: LevelDesktop(ESentryLevel::Debug)
+{
+}
+
+SentryScopeDesktop::~SentryScopeDesktop()
+{
+}
+
+void SentryScopeDesktop::AddBreadcrumb(USentryBreadcrumb* breadcrumb)
+{
+	BreadcrumbsDesktop.Add(breadcrumb->GetNativeImpl());
+}
+
+void SentryScopeDesktop::ClearBreadcrumbs()
+{
+	BreadcrumbsDesktop.Empty();
+}
+
+void SentryScopeDesktop::AddAttachment(USentryAttachment* attachment)
+{
+	// Not available for desktop
+}
+
+void SentryScopeDesktop::ClearAttachments()
+{
+	// Not available for desktop
+}
+
+void SentryScopeDesktop::SetTagValue(const FString& key, const FString& value)
+{
+	TagsDesktop.Add(key, value);
+}
+
+FString SentryScopeDesktop::GetTagValue(const FString& key) const
+{
+	if(!TagsDesktop.Contains(key))
+		return FString();
+
+	return TagsDesktop[key];
+}
+
+void SentryScopeDesktop::RemoveTag(const FString& key)
+{
+	TagsDesktop.Remove(key);
+}
+
+void SentryScopeDesktop::SetTags(const TMap<FString, FString>& tags)
+{
+	TagsDesktop.Append(tags);
+}
+
+TMap<FString, FString> SentryScopeDesktop::GetTags() const
+{
+	return TagsDesktop;
+}
+
+void SentryScopeDesktop::SetDist(const FString& dist)
+{
+	Dist = dist;
+}
+
+FString SentryScopeDesktop::GetDist() const
+{
+	return Dist;
+}
+
+void SentryScopeDesktop::SetEnvironment(const FString& environment)
+{
+	Environment = environment;
+}
+
+FString SentryScopeDesktop::GetEnvironment() const
+{
+	return Environment;
+}
+
+void SentryScopeDesktop::SetFingerprint(const TArray<FString>& fingerprint)
+{
+	FingerprintDesktop = fingerprint;
+}
+
+TArray<FString> SentryScopeDesktop::GetFingerprint() const
+{
+	return FingerprintDesktop;
+}
+
+void SentryScopeDesktop::SetLevel(ESentryLevel level)
+{
+	LevelDesktop = level;
+}
+
+ESentryLevel SentryScopeDesktop::GetLevel() const
+{
+
+	return LevelDesktop;
+}
+
+void SentryScopeDesktop::SetContext(const FString& key, const TMap<FString, FString>& values)
+{
+	ContextsDesktop.Add(key, values);
+}
+
+void SentryScopeDesktop::RemoveContext(const FString& key)
+{
+	if(!ContextsDesktop.Contains(key))
+		return;
+
+	ContextsDesktop.Remove(key);
+}
+
+void SentryScopeDesktop::SetExtraValue(const FString& key, const FString& value)
+{
+	ExtraDesktop.Add(key, value);
+}
+
+FString SentryScopeDesktop::GetExtraValue(const FString& key) const
+{
+	if(!ExtraDesktop.Contains(key))
+		return FString();
+
+	return ExtraDesktop[key];
+}
+
+void SentryScopeDesktop::RemoveExtra(const FString& key)
+{
+	if(!ExtraDesktop.Contains(key))
+		return;
+
+	ExtraDesktop.Remove(key);
+}
+
+void SentryScopeDesktop::SetExtras(const TMap<FString, FString>& extras)
+{
+	ExtraDesktop.Append(extras);
+}
+
+TMap<FString, FString> SentryScopeDesktop::GetExtras() const
+{
+	return ExtraDesktop;
+}
+
+void SentryScopeDesktop::Clear()
+{
+	Dist = FString();
+	Environment = FString();
+	FingerprintDesktop.Empty();
+	TagsDesktop.Empty();
+	ExtraDesktop.Empty();
+	ContextsDesktop.Empty();
+	BreadcrumbsDesktop.Empty();
+	LevelDesktop = ESentryLevel::Debug;
+}
+
+void SentryScopeDesktop::Apply(USentryEvent* event)
+{
+	TSharedPtr<SentryEventDesktop> eventDesktop = StaticCastSharedPtr<SentryEventDesktop>(event->GetNativeImpl());
+
+	sentry_value_t nativeEvent = eventDesktop->GetNativeObject();
+
+	if(!Dist.IsEmpty())
+		sentry_value_set_by_key(nativeEvent, "dist", sentry_value_new_string(TCHAR_TO_ANSI(*Dist)));
+	if(!Environment.IsEmpty())
+		sentry_value_set_by_key(nativeEvent, "environment", sentry_value_new_string(TCHAR_TO_ANSI(*Environment)));
+
+	if(!FingerprintDesktop.IsEmpty())
+		sentry_value_set_by_key(nativeEvent, "fingerprint", SentryConvertorsDesktop::StringArrayToNative(FingerprintDesktop));
+}
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
@@ -172,6 +172,12 @@ void SentryScopeDesktop::Apply(USentryEvent* event)
 
 	sentry_value_t nativeEvent = eventDesktop->GetNativeObject();
 
+	FString levelStr = SentryConvertorsDesktop::SentryLevelToString(LevelDesktop).ToLower();
+	if (!levelStr.IsEmpty())
+	{
+		sentry_value_set_by_key(nativeEvent, "level", sentry_value_new_string(TCHAR_TO_ANSI(*levelStr)));
+	}
+
 	if(!Dist.IsEmpty())
 	{
 		sentry_value_set_by_key(nativeEvent, "dist", sentry_value_new_string(TCHAR_TO_ANSI(*Dist)));

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.h
@@ -1,0 +1,60 @@
+﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+
+#pragma once
+
+#include "Interface/SentryScopeInterface.h"
+
+#if USE_SENTRY_NATIVE
+
+class USentryEvent;
+class USentryBreadcrumb;
+class USentryAttachment;
+
+class ISentryBreadcrumb;
+
+class SentryScopeDesktop : public ISentryScope
+{
+public:
+	SentryScopeDesktop();
+	virtual ~SentryScopeDesktop() override;
+
+	virtual void AddBreadcrumb(USentryBreadcrumb* breadcrumb) override;
+	virtual void ClearBreadcrumbs() override;
+	virtual void AddAttachment(USentryAttachment* attachment) override;
+	virtual void ClearAttachments() override;
+	virtual void SetTagValue(const FString& key, const FString& value) override;
+	virtual FString GetTagValue(const FString& key) const override;
+	virtual void RemoveTag(const FString& key) override;
+	virtual void SetTags(const TMap<FString, FString>& tags) override;
+	virtual TMap<FString, FString> GetTags() const override;
+	virtual void SetDist(const FString& dist) override;
+	virtual FString GetDist() const override;
+	virtual void SetEnvironment(const FString& environment) override;
+	virtual FString GetEnvironment() const override;
+	virtual void SetFingerprint(const TArray<FString>& fingerprint) override;
+	virtual TArray<FString> GetFingerprint() const override;
+	virtual void SetLevel(ESentryLevel level) override;
+	virtual ESentryLevel GetLevel() const override;
+	virtual void SetContext(const FString& key, const TMap<FString, FString>& values) override;
+	virtual void RemoveContext(const FString& key) override;
+	virtual void SetExtraValue(const FString& key, const FString& value) override;
+	virtual FString GetExtraValue(const FString& key) const override;
+	virtual void RemoveExtra(const FString& key) override;
+	virtual void SetExtras(const TMap<FString, FString>& extras) override;
+	virtual TMap<FString, FString> GetExtras() const override;
+	virtual void Clear() override;
+
+	void Apply(USentryEvent* event);
+
+private:
+	FString Dist;
+	FString Environment;
+	TArray<FString> FingerprintDesktop;
+	TMap<FString, FString> TagsDesktop;
+	TMap<FString, FString> ExtraDesktop;
+	TMap<FString, TMap<FString, FString>> ContextsDesktop;
+	TArray<TSharedPtr<ISentryBreadcrumb>> BreadcrumbsDesktop;
+	ESentryLevel LevelDesktop;
+};
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.h
@@ -10,7 +10,7 @@ class USentryEvent;
 class USentryBreadcrumb;
 class USentryAttachment;
 
-class ISentryBreadcrumb;
+class SentryBreadcrumbDesktop;
 
 class SentryScopeDesktop : public ISentryScope
 {
@@ -49,11 +49,16 @@ public:
 private:
 	FString Dist;
 	FString Environment;
+
 	TArray<FString> FingerprintDesktop;
+
 	TMap<FString, FString> TagsDesktop;
 	TMap<FString, FString> ExtraDesktop;
+
 	TMap<FString, TMap<FString, FString>> ContextsDesktop;
-	TArray<TSharedPtr<ISentryBreadcrumb>> BreadcrumbsDesktop;
+
+	TArray<TSharedPtr<SentryBreadcrumbDesktop>> BreadcrumbsDesktop;
+
 	ESentryLevel LevelDesktop;
 };
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -4,8 +4,9 @@
 #include "SentryEventDesktop.h"
 #include "SentryBreadcrumbDesktop.h"
 #include "SentryUserDesktop.h"
-#include "SentryDefines.h"
+#include "SentryScopeDesktop.h"
 
+#include "SentryDefines.h"
 #include "SentrySettings.h"
 #include "SentryEvent.h"
 #include "SentryBreadcrumb.h"
@@ -19,6 +20,7 @@
 #include "Transport/SentryTransport.h"
 
 #include "Misc/Paths.h"
+#include "Misc/ScopeLock.h"
 #include "HAL/FileManager.h"
 #include "Launch/Resources/Version.h"
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
@@ -39,16 +41,29 @@ void PrintVerboseLog(sentry_level_t level, const char *message, va_list args, vo
 
 sentry_value_t HandleBeforeSend(sentry_value_t event, void *hint, void *closure)
 {
-	USentryBeforeSendHandler* handler = static_cast<USentryBeforeSendHandler*>(closure);
+	SentrySubsystemDesktop* SentrySubsystem = static_cast<SentrySubsystemDesktop*>(closure);
 
 	USentryEvent* EventToProcess = NewObject<USentryEvent>();
 	EventToProcess->InitWithNativeImpl(MakeShareable(new SentryEventDesktop(event)));
 
-	return handler->HandleBeforeSend(EventToProcess, nullptr) ? event : sentry_value_new_null();
+	TSharedPtr<SentryScopeDesktop> Scope = SentrySubsystem->GetCurrentScope();
+	if(Scope)
+	{
+		Scope->Apply(EventToProcess);
+	}
+
+	USentryBeforeSendHandler* Handler = SentrySubsystem->GetBeforeSendHandler();
+	if(!Handler)
+	{
+		return event;
+	}
+
+	return Handler->HandleBeforeSend(EventToProcess, nullptr) ? event : sentry_value_new_null();
 }
 
 SentrySubsystemDesktop::SentrySubsystemDesktop()
-	: crashReporter(MakeShareable(new SentryCrashReporter))
+	: beforeSend(nullptr)
+	, crashReporter(MakeShareable(new SentryCrashReporter))
 	, isEnabled(false)
 	, isStackTraceEnabled(true)
 {
@@ -56,6 +71,10 @@ SentrySubsystemDesktop::SentrySubsystemDesktop()
 
 void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings, USentryBeforeSendHandler* beforeSendHandler)
 {
+	beforeSend = beforeSendHandler;
+
+	scopeStack.Push(MakeShareable(new SentryScopeDesktop()));
+
 #if PLATFORM_WINDOWS
 	const FString HandlerExecutableName = TEXT("crashpad_handler.exe");
 #elif PLATFORM_LINUX
@@ -100,7 +119,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings, U
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
 	sentry_options_set_debug(options, settings->EnableVerboseLogging);
 	sentry_options_set_auto_session_tracking(options, settings->EnableAutoSessionTracking);
-	sentry_options_set_before_send(options, HandleBeforeSend, beforeSendHandler);
+	sentry_options_set_before_send(options, HandleBeforeSend, this);
 
 #if PLATFORM_LINUX
 	sentry_options_set_transport(options, FSentryTransport::Create());
@@ -129,6 +148,8 @@ void SentrySubsystemDesktop::Close()
 {
 	isEnabled = false;
 
+	scopeStack.Empty();
+
 	sentry_close();
 }
 
@@ -139,14 +160,12 @@ bool SentrySubsystemDesktop::IsEnabled()
 
 void SentrySubsystemDesktop::AddBreadcrumb(USentryBreadcrumb* breadcrumb)
 {
-	TSharedPtr<SentryBreadcrumbDesktop> breadcrumbDesktop = StaticCastSharedPtr<SentryBreadcrumbDesktop>(breadcrumb->GetNativeImpl());
-
-	sentry_add_breadcrumb(breadcrumbDesktop->GetNativeObject());
+	GetCurrentScope()->AddBreadcrumb(breadcrumb);
 }
 
 void SentrySubsystemDesktop::ClearBreadcrumbs()
 {
-	UE_LOG(LogSentrySdk, Log, TEXT("ClearBreadcrumbs method is not supported for the current platform."));
+	GetCurrentScope()->ClearBreadcrumbs();
 }
 
 USentryId* SentrySubsystemDesktop::CaptureMessage(const FString& message, ESentryLevel level)
@@ -164,8 +183,22 @@ USentryId* SentrySubsystemDesktop::CaptureMessage(const FString& message, ESentr
 
 USentryId* SentrySubsystemDesktop::CaptureMessageWithScope(const FString& message, const FConfigureScopeDelegate& onScopeConfigure, ESentryLevel level)
 {
-	UE_LOG(LogSentrySdk, Log, TEXT("CaptureMessageWithScope method is not supported for the current platform."));
-	return nullptr;
+	FScopeLock Lock(&CriticalSection);
+
+	TSharedPtr<SentryScopeDesktop> NewLocalScope = MakeShareable(new SentryScopeDesktop(*GetCurrentScope()));
+
+	scopeStack.Push(NewLocalScope);
+
+	USentryScope* scope = NewObject<USentryScope>();
+	scope->InitWithNativeImpl(NewLocalScope);
+
+	onScopeConfigure.ExecuteIfBound(scope);
+
+	USentryId* Id = CaptureMessage(message, level);
+
+	scopeStack.Pop();
+
+	return Id;
 }
 
 USentryId* SentrySubsystemDesktop::CaptureEvent(USentryEvent* event)
@@ -185,8 +218,22 @@ USentryId* SentrySubsystemDesktop::CaptureEvent(USentryEvent* event)
 
 USentryId* SentrySubsystemDesktop::CaptureEventWithScope(USentryEvent* event, const FConfigureScopeDelegate& onScopeConfigure)
 {
-	UE_LOG(LogSentrySdk, Log, TEXT("CaptureEventWithScope method is not supported for the current platform."));
-	return nullptr;
+	FScopeLock Lock(&CriticalSection);
+
+	TSharedPtr<SentryScopeDesktop> NewLocalScope = MakeShareable(new SentryScopeDesktop(*GetCurrentScope()));
+
+	scopeStack.Push(NewLocalScope);
+
+	USentryScope* scope = NewObject<USentryScope>();
+	scope->InitWithNativeImpl(NewLocalScope);
+
+	onScopeConfigure.ExecuteIfBound(scope);
+
+	USentryId* Id = CaptureEvent(event);
+
+	scopeStack.Pop();
+
+	return Id;
 }
 
 void SentrySubsystemDesktop::CaptureUserFeedback(USentryUserFeedback* userFeedback)
@@ -211,33 +258,34 @@ void SentrySubsystemDesktop::RemoveUser()
 
 void SentrySubsystemDesktop::ConfigureScope(const FConfigureScopeDelegate& onConfigureScope)
 {
-	UE_LOG(LogSentrySdk, Log, TEXT("CaptureUserFeedback method is not supported for the current platform."));
+	USentryScope* scope = NewObject<USentryScope>();
+	scope->InitWithNativeImpl(GetCurrentScope());
+
+	onConfigureScope.ExecuteIfBound(scope);
 }
 
 void SentrySubsystemDesktop::SetContext(const FString& key, const TMap<FString, FString>& values)
 {
-	sentry_set_context(TCHAR_TO_ANSI(*key), SentryConvertorsDesktop::StringMapToNative(values));
-
-	crashReporter->SetContext(key, values);
+	GetCurrentScope()->SetContext(key, values);
 }
 
 void SentrySubsystemDesktop::SetTag(const FString& key, const FString& value)
 {
-	sentry_set_tag(TCHAR_TO_ANSI(*key), TCHAR_TO_ANSI(*value));
+	GetCurrentScope()->SetTagValue(key, value);
 
 	crashReporter->SetTag(key, value);
 }
 
 void SentrySubsystemDesktop::RemoveTag(const FString& key)
 {
-	sentry_remove_tag(TCHAR_TO_ANSI(*key));
+	GetCurrentScope()->RemoveTag(key);
 
 	crashReporter->RemoveTag(key);
 }
 
 void SentrySubsystemDesktop::SetLevel(ESentryLevel level)
 {
-	sentry_set_level(SentryConvertorsDesktop::SentryLevelToNative(level));
+	GetCurrentScope()->SetLevel(level);
 }
 
 void SentrySubsystemDesktop::StartSession()
@@ -248,6 +296,22 @@ void SentrySubsystemDesktop::StartSession()
 void SentrySubsystemDesktop::EndSession()
 {
 	sentry_end_session();
+}
+
+USentryBeforeSendHandler* SentrySubsystemDesktop::GetBeforeSendHandler()
+{
+	return beforeSend;
+}
+
+TSharedPtr<SentryScopeDesktop> SentrySubsystemDesktop::GetCurrentScope()
+{
+	if(scopeStack.IsEmpty())
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Scope stack is empty."));
+		return nullptr;
+	}
+
+	return scopeStack.Top();
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -189,10 +189,10 @@ USentryId* SentrySubsystemDesktop::CaptureMessageWithScope(const FString& messag
 
 	scopeStack.Push(NewLocalScope);
 
-	USentryScope* scope = NewObject<USentryScope>();
-	scope->InitWithNativeImpl(NewLocalScope);
+	USentryScope* Scope = NewObject<USentryScope>();
+	Scope->InitWithNativeImpl(NewLocalScope);
 
-	onScopeConfigure.ExecuteIfBound(scope);
+	onScopeConfigure.ExecuteIfBound(Scope);
 
 	USentryId* Id = CaptureMessage(message, level);
 
@@ -224,10 +224,10 @@ USentryId* SentrySubsystemDesktop::CaptureEventWithScope(USentryEvent* event, co
 
 	scopeStack.Push(NewLocalScope);
 
-	USentryScope* scope = NewObject<USentryScope>();
-	scope->InitWithNativeImpl(NewLocalScope);
+	USentryScope* Scope = NewObject<USentryScope>();
+	Scope->InitWithNativeImpl(NewLocalScope);
 
-	onScopeConfigure.ExecuteIfBound(scope);
+	onScopeConfigure.ExecuteIfBound(Scope);
 
 	USentryId* Id = CaptureEvent(event);
 
@@ -258,10 +258,10 @@ void SentrySubsystemDesktop::RemoveUser()
 
 void SentrySubsystemDesktop::ConfigureScope(const FConfigureScopeDelegate& onConfigureScope)
 {
-	USentryScope* scope = NewObject<USentryScope>();
-	scope->InitWithNativeImpl(GetCurrentScope());
+	USentryScope* Scope = NewObject<USentryScope>();
+	Scope->InitWithNativeImpl(GetCurrentScope());
 
-	onConfigureScope.ExecuteIfBound(scope);
+	onConfigureScope.ExecuteIfBound(Scope);
 }
 
 void SentrySubsystemDesktop::SetContext(const FString& key, const TMap<FString, FString>& values)

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -146,7 +146,7 @@ void SentrySubsystemDesktop::AddBreadcrumb(USentryBreadcrumb* breadcrumb)
 
 void SentrySubsystemDesktop::ClearBreadcrumbs()
 {
-	UE_LOG(LogSentrySdk, Log, TEXT("CaptureMessageWithScope method is not supported for the current platform."));
+	UE_LOG(LogSentrySdk, Log, TEXT("ClearBreadcrumbs method is not supported for the current platform."));
 }
 
 USentryId* SentrySubsystemDesktop::CaptureMessage(const FString& message, ESentryLevel level)

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -253,6 +253,8 @@ void SentrySubsystemDesktop::ConfigureScope(const FConfigureScopeDelegate& onCon
 void SentrySubsystemDesktop::SetContext(const FString& key, const TMap<FString, FString>& values)
 {
 	GetCurrentScope()->SetContext(key, values);
+
+	crashReporter->SetContext(key, values);
 }
 
 void SentrySubsystemDesktop::SetTag(const FString& key, const FString& value)

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
@@ -2,8 +2,11 @@
 
 #pragma once
 
+#include "HAL/CriticalSection.h"
+
 #include "Interface/SentrySubsystemInterface.h"
 
+class SentryScopeDesktop;
 class SentryCrashReporter;
 
 #if USE_SENTRY_NATIVE
@@ -33,12 +36,22 @@ public:
 	virtual void StartSession() override;
 	virtual void EndSession() override;
 
+	USentryBeforeSendHandler* GetBeforeSendHandler();
+
+	TSharedPtr<SentryScopeDesktop> GetCurrentScope();
+
 private:
+	USentryBeforeSendHandler* beforeSend;
+
 	TSharedPtr<SentryCrashReporter> crashReporter;
+
+	TArray<TSharedPtr<SentryScopeDesktop, ESPMode::ThreadSafe>> scopeStack;
 
 	bool isEnabled;
 
 	bool isStackTraceEnabled;
+
+	FCriticalSection CriticalSection;
 };
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/SentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryScope.cpp
@@ -10,6 +10,8 @@
 #include "Android/SentryScopeAndroid.h"
 #elif PLATFORM_IOS || PLATFORM_MAC
 #include "Apple/SentryScopeApple.h"
+#elif PLATFORM_WINDOWS || PLATFORM_LINUX
+#include "Desktop/SentryScopeDesktop.h"
 #endif
 
 USentryScope::USentryScope()
@@ -20,6 +22,8 @@ USentryScope::USentryScope()
 		ScopeNativeImpl = MakeShareable(new SentryScopeAndroid());
 #elif PLATFORM_IOS || PLATFORM_MAC
 		ScopeNativeImpl = MakeShareable(new SentryScopeApple());
+#elif PLATFORM_WINDOWS || PLATFORM_LINUX
+		ScopeNativeImpl = MakeShareable(new SentryScopeDesktop());
 #endif
 	}
 }

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryScope.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryScope.spec.cpp
@@ -1,0 +1,188 @@
+﻿// Copyright (c) 2022 Sentry. All Rights Reserved.
+
+#include "SentryScope.h"
+#include "SentryEvent.h"
+
+#include "SentryDataTypes.h"
+
+#include "Interface/SentryScopeInterface.h"
+#include "Interface/SentryEventInterface.h"
+
+#include "Misc/AutomationTest.h"
+
+#if PLATFORM_WINDOWS || PLATFORM_LINUX
+#include "Desktop/SentryScopeDesktop.h"
+#include "Desktop/SentryEventDesktop.h"
+#include "Desktop/Infrastructure/SentryConvertorsDesktop.h"
+#endif
+
+#if WITH_AUTOMATION_TESTS
+
+BEGIN_DEFINE_SPEC(SentryScopeSpec, "Sentry.SentryScope", EAutomationTestFlags::ProductFilter | EAutomationTestFlags::ApplicationContextMask)
+	USentryScope* SentryScope;
+	FString TestDist;
+	FString TestEnvironment;
+	TMap<FString, FString> TestTags;
+	TMap<FString, FString> TestExtras;
+	TMap<FString, FString> TestContext;
+	TArray<FString> TestFingerprint;
+END_DEFINE_SPEC(SentryScopeSpec)
+
+void SentryScopeSpec::Define()
+{
+	BeforeEach([this]()
+	{
+		SentryScope = NewObject<USentryScope>();
+
+		TestDist = TEXT("dist_str");
+		TestEnvironment = TEXT("env_str");
+
+		TestTags.Add(TEXT("TagsKey1"), TEXT("TagsVal1"));
+		TestTags.Add(TEXT("TagsKey2"), TEXT("TagsVal2"));
+
+		TestExtras.Add(TEXT("ExtrasKey1"), TEXT("ExtrasVal1"));
+		TestExtras.Add(TEXT("ExtrasKey2"), TEXT("ExtrasVal2"));
+
+		TestContext.Add(TEXT("ContextKey1"), TEXT("ContextVal1"));
+		TestContext.Add(TEXT("ContextKey2"), TEXT("ContextVal2"));
+
+		TestFingerprint = { TEXT("F1"), TEXT("F2"), TEXT("F3") };
+	});
+
+	Describe("Scope tags", [this]()
+	{
+		It("should persist value when single item set", [this]()
+		{
+			SentryScope->SetTagValue(TEXT("Key1"), TEXT("Val1"));
+
+			TestEqual("Tag exists", SentryScope->GetTagValue(TEXT("Key1")), TEXT("Val1"));
+		});
+
+		It("should persist value when multiple items set", [this]()
+		{
+			SentryScope->SetTags(TestTags);
+
+			TMap<FString, FString> ReceivedTags = SentryScope->GetTags();
+			TestEqual("Tag 1 exists", ReceivedTags[TEXT("TagsKey1")], TestTags[TEXT("TagsKey1")]);
+			TestEqual("Tag 2 exists", ReceivedTags[TEXT("TagsKey2")], TestTags[TEXT("TagsKey2")]);
+		});
+
+		It("should be removable", [this]()
+		{
+			SentryScope->SetTagValue(TEXT("Key1"), TEXT("Val1"));
+
+			SentryScope->RemoveTag(TEXT("Key1"));
+
+			TestEqual("Tag removed", SentryScope->GetTagValue(TEXT("Key1")), TEXT(""));
+		});
+	});
+
+	Describe("Scope extras", [this]()
+	{
+		It("should persist value when single item set", [this]()
+		{
+			SentryScope->SetExtraValue(TEXT("Key1"), TEXT("Val1"));
+
+			TestEqual("Extra value exists", SentryScope->GetExtraValue(TEXT("Key1")), TEXT("Val1"));
+		});
+
+		It("should persist value when multiple items set", [this]()
+		{
+			SentryScope->SetExtras(TestExtras);
+
+			TMap<FString, FString> ReceivedExtras = SentryScope->GetExtras();
+			TestEqual("Extra 1 exists", ReceivedExtras[TEXT("ExtrasKey1")], TestExtras[TEXT("ExtrasKey1")]);
+			TestEqual("Extra 2 exists", ReceivedExtras[TEXT("ExtrasKey2")], TestExtras[TEXT("ExtrasKey2")]);
+		});
+
+		It("should be removable", [this]()
+		{
+			SentryScope->SetTagValue(TEXT("Key1"), TEXT("Val1"));
+
+			SentryScope->RemoveTag(TEXT("Key1"));
+
+			TestEqual("Extra value removed", SentryScope->GetTagValue(TEXT("Key1")), TEXT(""));
+		});
+	});
+
+	Describe("Scope params", [this]()
+	{
+		It("should persist their values", [this]()
+		{
+			SentryScope->SetLevel(ESentryLevel::Fatal);
+			SentryScope->SetDist(TestDist);
+			SentryScope->SetEnvironment(TestEnvironment);
+			SentryScope->SetFingerprint(TestFingerprint);
+
+			TestEqual("Scope level", SentryScope->GetLevel(), ESentryLevel::Fatal);
+			TestEqual("Scope dist", SentryScope->GetDist(), TestDist);
+			TestEqual("Scope environment", SentryScope->GetEnvironment(), TestEnvironment);
+			TestEqual("Scope fingerprint", SentryScope->GetFingerprint(), TestFingerprint);
+		});
+	});
+
+	Describe("Scope params", [this]()
+	{
+		It("should be possible to clear", [this]()
+		{
+			SentryScope->SetDist(TestDist);
+			SentryScope->SetEnvironment(TestEnvironment);
+			SentryScope->SetFingerprint(TestFingerprint);
+			SentryScope->SetTags(TestTags);
+			SentryScope->SetExtras(TestExtras);
+
+			SentryScope->Clear();
+
+			TestTrue("Scope dist", SentryScope->GetDist().IsEmpty());
+			TestTrue("Scope environment", SentryScope->GetEnvironment().IsEmpty());
+			TestTrue("Scope fingerprint", SentryScope->GetFingerprint().IsEmpty());
+			TestTrue("Scope tags", SentryScope->GetTags().IsEmpty());
+			TestTrue("Scope extras", SentryScope->GetExtras().IsEmpty());
+		});
+	});
+
+#if PLATFORM_WINDOWS || PLATFORM_LINUX
+	Describe("Scope params", [this]()
+	{
+		It("should be applied to event", [this]()
+		{
+			SentryScope->SetLevel(ESentryLevel::Fatal);
+			SentryScope->SetDist(TestDist);
+			SentryScope->SetEnvironment(TestEnvironment);
+			SentryScope->SetFingerprint(TestFingerprint);
+			SentryScope->SetTags(TestTags);
+			SentryScope->SetExtras(TestExtras);
+			SentryScope->SetContext(TEXT("TestContext"), TestContext);
+
+			USentryEvent* SentryEvent = NewObject<USentryEvent>();
+
+			StaticCastSharedPtr<SentryScopeDesktop>(SentryScope->GetNativeImpl())->Apply(SentryEvent);
+
+			sentry_value_t NativeEvent = StaticCastSharedPtr<SentryEventDesktop>(SentryEvent->GetNativeImpl())->GetNativeObject();
+
+			sentry_value_t level = sentry_value_get_by_key(NativeEvent, "level");
+			sentry_value_t dist = sentry_value_get_by_key(NativeEvent, "dist");
+			sentry_value_t environment = sentry_value_get_by_key(NativeEvent, "environment");
+			sentry_value_t fingerprint = sentry_value_get_by_key(NativeEvent, "fingerprint");
+			sentry_value_t tags = sentry_value_get_by_key(NativeEvent, "tags");
+			sentry_value_t extra = sentry_value_get_by_key(NativeEvent, "extra");
+
+			sentry_value_t contexts = sentry_value_get_by_key(NativeEvent, "contexts");
+			sentry_value_t testContext = sentry_value_get_by_key(contexts, "TestContext");
+
+			TestEqual("Event level", SentryConvertorsDesktop::SentryLevelToUnreal(level), ESentryLevel::Fatal);
+			TestEqual("Event dist", FString(sentry_value_as_string(dist)), TestDist);
+			TestEqual("Event environment", FString(sentry_value_as_string(environment)), TestEnvironment);
+			TestEqual("Event fingerprint", SentryConvertorsDesktop::StringArrayToUnreal(fingerprint), TestFingerprint);
+			TestEqual("Event tags 1", SentryConvertorsDesktop::StringMapToUnreal(tags)[TEXT("TagsKey1")], TestTags[TEXT("TagsKey1")]);
+			TestEqual("Event tags 2", SentryConvertorsDesktop::StringMapToUnreal(tags)[TEXT("TagsKey2")], TestTags[TEXT("TagsKey2")]);
+			TestEqual("Event extra 1", SentryConvertorsDesktop::StringMapToUnreal(extra)[TEXT("ExtrasKey1")], TestExtras[TEXT("ExtrasKey1")]);
+			TestEqual("Event extra 2", SentryConvertorsDesktop::StringMapToUnreal(extra)[TEXT("ExtrasKey2")], TestExtras[TEXT("ExtrasKey2")]);
+			TestEqual("Event context 1", SentryConvertorsDesktop::StringMapToUnreal(testContext)[TEXT("ContextKey1")], TestContext[TEXT("ContextKey1")]);
+			TestEqual("Event context 2", SentryConvertorsDesktop::StringMapToUnreal(testContext)[TEXT("ContextKey2")], TestContext[TEXT("ContextKey2")]);
+		});
+	});
+#endif
+}
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
@@ -55,15 +55,11 @@ void SentrySubsystemSpec::Define()
 			TestNotNull("Event ID is non-null", eventId);
 		});
 
-		It("should always return null if scoped version used", [this]()
+		It("should always return non-null Event ID if scoped version used", [this]()
 		{
 			const FConfigureScopeDelegate testDelegate;
 			const USentryId* eventId = SentrySubsystemImpl->CaptureMessageWithScope(FString(TEXT("Automation: Sentry test message with scope")), testDelegate, ESentryLevel::Debug);
-#if PLATFORM_WINDOWS || PLATFORM_LINUX
-			TestNull("Event ID is null", eventId);
-#elif PLATFORM_MAC
 			TestNotNull("Event ID is non-null", eventId);
-#endif
 		});
 	});
 
@@ -78,7 +74,7 @@ void SentrySubsystemSpec::Define()
 			TestNotNull("Event ID is non-null", eventId);
 		});
 
-		It("should always return null if scoped version used", [this]()
+		It("should always return non-null Event ID if scoped version used", [this]()
 		{
 			USentryEvent* testEvent = NewObject<USentryEvent>();
 			testEvent->SetMessage(TEXT("Automation: Sentry test event message"));
@@ -86,11 +82,7 @@ void SentrySubsystemSpec::Define()
 			const FConfigureScopeDelegate testDelegate;
 
 			const USentryId* eventId = SentrySubsystemImpl->CaptureEventWithScope(testEvent, testDelegate);
-#if PLATFORM_WINDOWS || PLATFORM_LINUX
-			TestNull("Event ID is null", eventId);
-#elif PLATFORM_MAC
 			TestNotNull("Event ID is non-null", eventId);
-#endif
 		});
 	});
 

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -85,6 +85,8 @@ Source/Sentry/Private/Desktop/SentryEventDesktop.cpp
 Source/Sentry/Private/Desktop/SentryEventDesktop.h
 Source/Sentry/Private/Desktop/SentryIdDesktop.cpp
 Source/Sentry/Private/Desktop/SentryIdDesktop.h
+Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
+Source/Sentry/Private/Desktop/SentryScopeDesktop.h
 Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
 Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
 Source/Sentry/Private/Desktop/SentryUserDesktop.cpp

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -123,6 +123,7 @@ Source/Sentry/Private/SentryUserFeedback.cpp
 Source/Sentry/Private/Tests/
 Source/Sentry/Private/Tests/SentryBreadcrumb.spec.cpp
 Source/Sentry/Private/Tests/SentryEvent.spec.cpp
+Source/Sentry/Private/Tests/SentryScope.spec.cpp
 Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
 Source/Sentry/Private/Tests/SentryUser.spec.cpp
 Source/Sentry/Private/Utils/


### PR DESCRIPTION
This PR introduces scope class implementation that works on Windows/Linux. Since `sentry-native` doesn't expose any API for working with multiple scopes (there is only one global scope), the UE plugin offers its own abstraction similar to those provided by Android/iOS SDKs.