### PR TITLE
Update plugin settings names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 - Fix Linux Compile/Staging Error ([#327](https://github.com/getsentry/sentry-unreal/pull/327))
 - Fix UE 5.3 compatibility issues ([#348](https://github.com/getsentry/sentry-unreal/pull/348))
+- Fix plugin settings names ([#350](https://github.com/getsentry/sentry-unreal/pull/350))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -54,11 +54,11 @@ public class SentryBridgeJava {
 							return onBeforeSend(beforeSendHandler, event, hint);
 						}
 					});
-					JSONArray Includes = settingJson.getJSONArray("inAppIncludes");
+					JSONArray Includes = settingJson.getJSONArray("inAppInclude");
 					for (int i = 0; i < Includes.length(); i++) {
 						options.addInAppInclude(Includes.getString(i));
 					}
-					JSONArray Excludes = settingJson.getJSONArray("inAppExcludes");
+					JSONArray Excludes = settingJson.getJSONArray("inAppExclude");
 					for (int i = 0; i < Excludes.length(); i++) {
 						options.addInAppExclude(Excludes.getString(i));
 					}

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
@@ -29,21 +29,21 @@
 void SentrySubsystemAndroid::InitWithSettings(const USentrySettings* settings, USentryBeforeSendHandler* beforeSendHandler)
 {
 	TSharedPtr<FJsonObject> SettingsJson = MakeShareable(new FJsonObject);
-	SettingsJson->SetStringField(TEXT("dsn"), settings->DsnUrl);
+	SettingsJson->SetStringField(TEXT("dsn"), settings->Dsn);
 	SettingsJson->SetStringField(TEXT("release"), settings->OverrideReleaseName
 		? settings->Release
 		: settings->GetFormattedReleaseName());
 	SettingsJson->SetStringField(TEXT("environment"), settings->Environment);
 	SettingsJson->SetBoolField(TEXT("autoSessionTracking"), settings->EnableAutoSessionTracking);
 	SettingsJson->SetNumberField(TEXT("sessionTimeout"), settings->SessionTimeout);
-	SettingsJson->SetBoolField(TEXT("enableStackTrace"), settings->EnableStackTrace);
-	SettingsJson->SetBoolField(TEXT("debug"), settings->EnableVerboseLogging);
+	SettingsJson->SetBoolField(TEXT("enableStackTrace"), settings->AttachStacktrace);
+	SettingsJson->SetBoolField(TEXT("debug"), settings->Debug);
 	SettingsJson->SetNumberField(TEXT("sampleRate"), settings->SampleRate);
 	SettingsJson->SetNumberField(TEXT("maxBreadcrumbs"), settings->MaxBreadcrumbs);
-	SettingsJson->SetBoolField(TEXT("attachScreenshot"), settings->AttachScreenshots);
-	SettingsJson->SetArrayField(TEXT("inAppIncludes"), SentryConvertorsAndroid::StrinArrayToJsonArray(settings->InAppIncludes));
-	SettingsJson->SetArrayField(TEXT("inAppExcludes"), SentryConvertorsAndroid::StrinArrayToJsonArray(settings->InAppExcludes));
-	SettingsJson->SetBoolField(TEXT("sendDefaultPii"), settings->SendDafaultPii);
+	SettingsJson->SetBoolField(TEXT("attachScreenshot"), settings->AttachScreenshot);
+	SettingsJson->SetArrayField(TEXT("inAppInclude"), SentryConvertorsAndroid::StrinArrayToJsonArray(settings->InAppInclude));
+	SettingsJson->SetArrayField(TEXT("inAppExclude"), SentryConvertorsAndroid::StrinArrayToJsonArray(settings->InAppExclude));
+	SettingsJson->SetBoolField(TEXT("sendDefaultPii"), settings->SendDefaultPii);
 
 	FString SettingsJsonStr;
 	TSharedRef<TJsonWriter<>> JsonWriter = TJsonWriterFactory<>::Create(&SettingsJsonStr);

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
@@ -29,20 +29,20 @@ void SentrySubsystemApple::InitWithSettings(const USentrySettings* settings, USe
 	[SENTRY_APPLE_CLASS(PrivateSentrySDKOnly) setSdkName:@"sentry.cocoa.unreal"];
 
 	[SENTRY_APPLE_CLASS(SentrySDK) startWithConfigureOptions:^(SentryOptions *options) {
-		options.dsn = settings->DsnUrl.GetNSString();
+		options.dsn = settings->Dsn.GetNSString();
 		options.environment = settings->Environment.GetNSString();
 		options.enableAutoSessionTracking = settings->EnableAutoSessionTracking;
 		options.sessionTrackingIntervalMillis = settings->SessionTimeout;
 		options.releaseName = settings->OverrideReleaseName
 			? settings->Release.GetNSString()
 			: settings->GetFormattedReleaseName().GetNSString();
-		options.attachStacktrace = settings->EnableStackTrace;
-		options.debug = settings->EnableVerboseLogging;
+		options.attachStacktrace = settings->AttachStacktrace;
+		options.debug = settings->Debug;
 		options.sampleRate = [NSNumber numberWithFloat:settings->SampleRate];
 		options.maxBreadcrumbs = settings->MaxBreadcrumbs;
-		options.sendDefaultPii = settings->SendDafaultPii;
+		options.sendDefaultPii = settings->SendDefaultPii;
 #if PLATFORM_IOS
-		options.attachScreenshot = settings->AttachScreenshots;
+		options.attachScreenshot = settings->AttachScreenshot;
 #endif
 		options.initialScope = ^(SentryScope *scope) {
 			if(settings->EnableAutoLogAttachment) {
@@ -57,11 +57,11 @@ void SentrySubsystemApple::InitWithSettings(const USentrySettings* settings, USe
 			EventToProcess->InitWithNativeImpl(MakeShareable(new SentryEventApple(event)));
 			return beforeSendHandler->HandleBeforeSend(EventToProcess, nullptr) ? event : nullptr;
 		};
-		for (auto it = settings->InAppIncludes.CreateConstIterator(); it; ++it)
+		for (auto it = settings->InAppInclude.CreateConstIterator(); it; ++it)
 		{
 			[options addInAppInclude:it->GetNSString()];
 		}
-		for (auto it = settings->InAppExcludes.CreateConstIterator(); it; ++it)
+		for (auto it = settings->InAppExclude.CreateConstIterator(); it; ++it)
 		{
 			[options addInAppExclude:it->GetNSString()];
 		}

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -119,10 +119,10 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings, U
 		? *settings->Release
 		: *settings->GetFormattedReleaseName()));
 
-	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->DsnUrl));
+	sentry_options_set_dsn(options, TCHAR_TO_ANSI(*settings->Dsn));
 	sentry_options_set_environment(options, TCHAR_TO_ANSI(*settings->Environment));
 	sentry_options_set_logger(options, PrintVerboseLog, nullptr);
-	sentry_options_set_debug(options, settings->EnableVerboseLogging);
+	sentry_options_set_debug(options, settings->Debug);
 	sentry_options_set_auto_session_tracking(options, settings->EnableAutoSessionTracking);
 	sentry_options_set_sample_rate(options, settings->SampleRate);
 	sentry_options_set_max_breadcrumbs(options, settings->MaxBreadcrumbs);
@@ -146,7 +146,7 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings, U
 	}
 #endif
 
-	isStackTraceEnabled = settings->EnableStackTrace;
+	isStackTraceEnabled = settings->AttachStacktrace;
 
 	crashReporter->SetRelease(settings->Release);
 	crashReporter->SetEnvironment(settings->Environment);

--- a/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryTransport.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Transport/SentryTransport.cpp
@@ -58,7 +58,7 @@ void FSentryTransport::Send(sentry_envelope_t* envelope)
 
 	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
 
-	const SentryDsnUrl DsnUrl(Settings->DsnUrl);
+	const SentryDsnUrl DsnUrl(Settings->Dsn);
 
 	TSharedRef<IHttpRequest, ESPMode::ThreadSafe> HttpRequest = FHttpModule::Get().CreateRequest();
 

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -10,18 +10,18 @@
 
 USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
-	, DsnUrl()
+	, Dsn()
 	, InitAutomatically(true)
-	, EnableVerboseLogging(true)
+	, Debug(true)
 	, EnableAutoCrashCapturing(true)
 	, EnableAutoLogAttachment(false)
-	, EnableStackTrace(true)
+	, AttachStacktrace(true)
 	, UseProxy(false) 
 	, ProxyUrl()
 	, SampleRate(1.0f)
 	, MaxBreadcrumbs(100)
-	, AttachScreenshots(false)
-	, SendDafaultPii(false)
+	, AttachScreenshot(false)
+	, SendDefaultPii(false)
 	, EnableAutoSessionTracking(true)
 	, SessionTimeout(30000)
 	, OverrideReleaseName(false)
@@ -41,13 +41,15 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 #endif
 
 	LoadDebugSymbolsProperties();
+
+	CheckLegacySettings();
 }
 
-FString USentrySettings::GetFormattedReleaseName() const
+FString USentrySettings::GetFormattedReleaseName()
 {
 	FString FormattedReleaseName = FApp::GetProjectName();
 
-	FString Version;
+	FString Version = TEXT("");
 	GConfig->GetString(TEXT("/Script/EngineSettings.GeneralProjectSettings"), TEXT("ProjectVersion"), Version, GGameIni);
 	if(!Version.IsEmpty())
 	{
@@ -69,5 +71,52 @@ void USentrySettings::LoadDebugSymbolsProperties()
 		PropertiesFile.GetString(TEXT("Sentry"), TEXT("defaults.project"), ProjectName);
 		PropertiesFile.GetString(TEXT("Sentry"), TEXT("defaults.org"), OrgName);
 		PropertiesFile.GetString(TEXT("Sentry"), TEXT("auth.token"), AuthToken);
+	}
+}
+
+void USentrySettings::CheckLegacySettings()
+{
+	bool IsSettingsDirty = false;
+
+	const FString SentrySection = TEXT("/Script/Sentry.SentrySettings");
+	const FString ConfigFilename = GetDefaultConfigFilename();
+
+	// Settings renamed in 0.9.0
+
+	const FString DsnLegacyKey = TEXT("DsnUrl");
+	FString DsnLegacyValue = TEXT("");
+	if(GConfig->GetString(*SentrySection, *DsnLegacyKey, DsnLegacyValue, *ConfigFilename))
+	{
+		Dsn = DsnLegacyValue;
+		GConfig->SetString(*SentrySection, TEXT("Dsn"), *Dsn, *ConfigFilename);
+		GConfig->RemoveKey(*SentrySection, *DsnLegacyKey, *ConfigFilename);
+		IsSettingsDirty = true;
+	}
+
+	const FString DebugLegacyKey = TEXT("EnableVerboseLogging");
+	bool DebugLegacyValue;
+	if(GConfig->GetBool(*SentrySection, *DebugLegacyKey, DebugLegacyValue, *ConfigFilename))
+	{
+		Debug = DebugLegacyValue;
+		GConfig->SetBool(*SentrySection, TEXT("Debug"), Debug, *ConfigFilename);
+		GConfig->RemoveKey(*SentrySection, *DebugLegacyKey, *ConfigFilename);
+		IsSettingsDirty = true;
+	}
+
+	const FString AttachStacktraceLegacyKey = TEXT("EnableStackTrace");
+	bool AttachStacktraceLegacyValue;
+	if(GConfig->GetBool(*SentrySection, *AttachStacktraceLegacyKey, AttachStacktraceLegacyValue, *ConfigFilename))
+	{
+		AttachStacktrace = AttachStacktraceLegacyValue;
+		GConfig->SetBool(*SentrySection, TEXT("AttachStacktrace"), AttachStacktrace, *ConfigFilename);
+		GConfig->RemoveKey(*SentrySection, *AttachStacktraceLegacyKey, *ConfigFilename);
+		IsSettingsDirty = true;
+	}
+
+	// Place newly renamed settings here specifying the release for which changes take place
+
+	if (IsSettingsDirty)
+	{
+		GConfig->Flush(false, *ConfigFilename);
 	}
 }

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -59,7 +59,7 @@ void USentrySubsystem::Initialize()
 {
 	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
 
-	if(Settings->DsnUrl.IsEmpty())
+	if(Settings->Dsn.IsEmpty())
 	{
 		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry requires minimal configuration for its initialization - please provide the DSN in plugin settings."));
 		return;

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -127,7 +127,7 @@ class SENTRY_API USentrySettings : public UObject
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Core",
 		Meta = (DisplayName = "DSN", ToolTip = "The DSN (Data Source Name) tells the SDK where to send the events to. Get your DSN in the Sentry dashboard."))
-	FString DsnUrl;
+	FString Dsn;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Core",
 		Meta = (DisplayName = "Environment", ToolTip = "Environment which will be used for enriching events."))
@@ -139,7 +139,7 @@ class SENTRY_API USentrySettings : public UObject
 
 	UPROPERTY(Config, EditAnywhere, Category = "Misc",
 		Meta = (DisplayName = "Enable verbose logging", ToolTip = "Flag indicating whether to enable verbose logging on desktop."))
-	bool EnableVerboseLogging;
+	bool Debug;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
 		Meta = (DisplayName = "Enable for Build Configurations"))
@@ -167,7 +167,7 @@ class SENTRY_API USentrySettings : public UObject
 
 	UPROPERTY(Config, EditAnywhere, Category = "Misc",
 		Meta = (DisplayName = "Attach stack trace to captured events", ToolTip = "Flag indicating whether to attach stack trace automatically to captured events."))
-	bool EnableStackTrace;
+	bool AttachStacktrace;
 
 	UPROPERTY(Config, EditAnywhere, Category = "Misc",
 		Meta = (InlineEditConditionToggle))
@@ -187,19 +187,19 @@ class SENTRY_API USentrySettings : public UObject
 
 	UPROPERTY(Config, EditAnywhere, Category = "Misc",
 		Meta = (DisplayName = "Attach screenshots (for iOS only)", ToolTip = "Flag indicating whether to attach screenshot of the application when an error occurs."))
-	bool AttachScreenshots;
+	bool AttachScreenshot;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
 		Meta = (DisplayName = "In-app includes (for Android/Apple only)", Tooltip = "A list of string prefixes of module names that belong to the app."))
-	TArray<FString> InAppIncludes;
+	TArray<FString> InAppInclude;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
 		Meta = (DisplayName = "In-app exludes (for Android/Apple only)", Tooltip = "A list of string prefixes of module names that don't belong to the app."))
-	TArray<FString> InAppExcludes;
+	TArray<FString> InAppExclude;
 
 	UPROPERTY(Config, EditAnywhere, Category = "Misc",
-		Meta = (DisplayName = "Attach personally identifiable information (for Android/Apple only)", ToolTip = "Flag indicating whether to attach personally identifiable information (PII) to captured events."))
-	bool SendDafaultPii;
+		Meta = (DisplayName = "Attach personally identifiable information", ToolTip = "Flag indicating whether to attach personally identifiable information (PII) to captured events."))
+	bool SendDefaultPii;
 
 	UPROPERTY(Config, EditAnywhere, Category = "Release & Health",
 		Meta = (DisplayName = "Enable automatic session tracking ", ToolTip = "Flag indicating whether the SDK should automatically start a new session when it is initialized."))
@@ -246,8 +246,9 @@ class SENTRY_API USentrySettings : public UObject
 	TSubclassOf<USentryBeforeSendHandler> BeforeSendHandler;
 
 public:
-	FString GetFormattedReleaseName() const;
+	static FString GetFormattedReleaseName();
 
 private:
 	void LoadDebugSymbolsProperties();
+	void CheckLegacySettings();
 };

--- a/sample/Config/DefaultEngine.ini
+++ b/sample/Config/DefaultEngine.ini
@@ -202,6 +202,6 @@ bGeneratedSYMFile=True
 bGeneratedSYMBundle=True
 
 [/Script/Sentry.SentrySettings]
-DsnUrl="https://93c7a68867db43539980de54f09b139a@o447951.ingest.sentry.io/6253052"
 CrashReporterUrl="https://o447951.ingest.sentry.io/api/6253052/unreal/93c7a68867db43539980de54f09b139a/"
+Dsn="https://93c7a68867db43539980de54f09b139a@o447951.ingest.sentry.io/6253052"
 

--- a/sample/Source/SentryPlayground/CppBeforeSendHandler.h
+++ b/sample/Source/SentryPlayground/CppBeforeSendHandler.h
@@ -14,5 +14,5 @@ class SENTRYPLAYGROUND_API UCppBeforeSendHandler : public USentryBeforeSendHandl
 	GENERATED_BODY()
 
 public:
-	virtual USentryEvent* HandleBeforeSend_Implementation(USentryEvent* Event, USentryHint* Hint);
+	virtual USentryEvent* HandleBeforeSend_Implementation(USentryEvent* Event, USentryHint* Hint) override;
 };


### PR DESCRIPTION
This PR updates names for some plugin settings in order to align them with other Sentry SDKs. Also, it adds a tool that is supposed to ensure proper project configuration migration.