### PR TITLE
Update event context categories for desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add scope support for Windows/Linux ([#328](https://github.com/getsentry/sentry-unreal/pull/328))
 - Add extra crash context for native integration ([#342](https://github.com/getsentry/sentry-unreal/pull/342))
 - Add missing plugin settings ([#335](https://github.com/getsentry/sentry-unreal/pull/335))
+- Update event context categories for desktop ([#356](https://github.com/getsentry/sentry-unreal/pull/356))
 
 ### Fixes
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
@@ -30,15 +30,10 @@ void FSentryCrashContext::Apply(TSharedPtr<SentryScopeDesktop> Scope)
 	Scope->SetExtraValue("Crash GUID", SessionContext.CrashGUIDRoot);
 	Scope->SetExtraValue("Executable Name", SessionContext.ExecutableName);
 	Scope->SetExtraValue("Game Name", SessionContext.GameName);
-	Scope->SetExtraValue("CPU Brand", SessionContext.CPUBrand);
-	Scope->SetExtraValue("CPU Vendor", SessionContext.CPUVendor);
-	Scope->SetExtraValue("Number of Cores", FString::FromInt(SessionContext.NumberOfCores));
-	Scope->SetExtraValue("Number of Cores including Hyperthreads", FString::FromInt(SessionContext.NumberOfCoresIncludingHyperthreads));
 	Scope->SetExtraValue("Process Id", FString::FromInt(SessionContext.ProcessId));
 	Scope->SetExtraValue("Seconds Since Start", FString::FromInt(SessionContext.SecondsSinceStart));
 	Scope->SetExtraValue("Command Line", SessionContext.CommandLine);
 	Scope->SetExtraValue("Memory Stats Page Size", FString::FromInt(SessionContext.MemoryStats.PageSize));
-	Scope->SetExtraValue("Memory Stats Total Physical GB", FString::FromInt(SessionContext.MemoryStats.TotalPhysicalGB));
 	Scope->SetExtraValue("Memory Stats Total Virtual", FString::Printf(TEXT("%lld"), SessionContext.MemoryStats.TotalVirtual));
 
 	if(Settings->SendDefaultPii)

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
@@ -1,12 +1,9 @@
 ﻿#include "SentryCrashContext.h"
 
+#include "SentrySettings.h"
+#include "SentryModule.h"
+
 #include "Desktop/SentryScopeDesktop.h"
-
-#include "GenericPlatform/GenericPlatformDriver.h"
-
-#if PLATFORM_WINDOWS
-#include "Windows/WindowsPlatformMisc.h"
-#endif
 
 #if USE_SENTRY_NATIVE
 
@@ -17,6 +14,8 @@ FSentryCrashContext::FSentryCrashContext(const FSharedCrashContext& Context)
 
 void FSentryCrashContext::Apply(TSharedPtr<SentryScopeDesktop> Scope)
 {
+	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
+
 	const FSessionContext& SessionContext = CrashContext.SessionContext;
 
 	Scope->SetExtraValue("Crash Type", FGenericCrashContext::GetCrashTypeString(CrashContext.CrashType));
@@ -29,8 +28,6 @@ void FSentryCrashContext::Apply(TSharedPtr<SentryScopeDesktop> Scope)
 	Scope->SetExtraValue("Base Dir", SessionContext.BaseDir);
 	Scope->SetExtraValue("Is Source Distribution", SessionContext.bIsSourceDistribution ? TEXT("true") : TEXT("false"));
 	Scope->SetExtraValue("Crash GUID", SessionContext.CrashGUIDRoot);
-	Scope->SetExtraValue("Epic Account Id", SessionContext.EpicAccountId);
-	Scope->SetExtraValue("Login Id", SessionContext.LoginIdStr);
 	Scope->SetExtraValue("Executable Name", SessionContext.ExecutableName);
 	Scope->SetExtraValue("Game Name", SessionContext.GameName);
 	Scope->SetExtraValue("CPU Brand", SessionContext.CPUBrand);
@@ -44,14 +41,11 @@ void FSentryCrashContext::Apply(TSharedPtr<SentryScopeDesktop> Scope)
 	Scope->SetExtraValue("Memory Stats Total Physical GB", FString::FromInt(SessionContext.MemoryStats.TotalPhysicalGB));
 	Scope->SetExtraValue("Memory Stats Total Virtual", FString::Printf(TEXT("%lld"), SessionContext.MemoryStats.TotalVirtual));
 
-	FGPUDriverInfo GpuDriverInfo = FPlatformMisc::GetGPUDriverInfo(FPlatformMisc::GetPrimaryGPUBrand());
-
-	TMap<FString, FString> GpuContext;
-	GpuContext.Add(TEXT("name"), GpuDriverInfo.DeviceDescription);
-	GpuContext.Add(TEXT("vendor_name"), GpuDriverInfo.ProviderName);
-	GpuContext.Add(TEXT("driver_version"), GpuDriverInfo.UserDriverVersion);
-
-	Scope->SetContext(TEXT("gpu"), GpuContext);
+	if(Settings->SendDefaultPii)
+	{
+		Scope->SetExtraValue("Epic Account Id", SessionContext.EpicAccountId);
+		Scope->SetExtraValue("Login Id", SessionContext.LoginIdStr);
+	}
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -15,6 +15,7 @@
 #include "Misc/EngineVersion.h"
 #include "Misc/CoreDelegates.h"
 #include "Misc/App.h"
+#include "GenericPlatform/GenericPlatformDriver.h"
 #include "GenericPlatform/GenericPlatformMisc.h"
 
 #include "Interface/SentrySubsystemInterface.h"
@@ -89,6 +90,11 @@ void USentrySubsystem::Initialize()
 	}
 
 	AddDefaultContext();
+
+#if PLATFORM_WINDOWS || PLATFORM_LINUX || PLATFORM_MAC
+	AddGpuContext();
+#endif
+
 	PromoteTags();
 	ConfigureBreadcrumbs();
 }
@@ -286,6 +292,18 @@ void USentrySubsystem::AddDefaultContext()
 	DefaultContext.Add(TEXT("Game name"), FApp::GetName());
 
 	SubsystemNativeImpl->SetContext(TEXT("Unreal Engine"), DefaultContext);
+}
+
+void USentrySubsystem::AddGpuContext()
+{
+	FGPUDriverInfo GpuDriverInfo = FPlatformMisc::GetGPUDriverInfo(FPlatformMisc::GetPrimaryGPUBrand());
+
+	TMap<FString, FString> GpuContext;
+	GpuContext.Add(TEXT("name"), GpuDriverInfo.DeviceDescription);
+	GpuContext.Add(TEXT("vendor_name"), GpuDriverInfo.ProviderName);
+	GpuContext.Add(TEXT("driver_version"), GpuDriverInfo.UserDriverVersion);
+
+	SubsystemNativeImpl->SetContext(TEXT("gpu"), GpuContext);
 }
 
 void USentrySubsystem::PromoteTags()

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -93,6 +93,7 @@ void USentrySubsystem::Initialize()
 
 #if PLATFORM_WINDOWS || PLATFORM_LINUX || PLATFORM_MAC
 	AddGpuContext();
+	AddDeviceContext();
 #endif
 
 	PromoteTags();
@@ -304,6 +305,19 @@ void USentrySubsystem::AddGpuContext()
 	GpuContext.Add(TEXT("driver_version"), GpuDriverInfo.UserDriverVersion);
 
 	SubsystemNativeImpl->SetContext(TEXT("gpu"), GpuContext);
+}
+
+void USentrySubsystem::AddDeviceContext()
+{
+	const FPlatformMemoryConstants& MemoryConstants = FPlatformMemory::GetConstants();
+
+	TMap<FString, FString> DeviceContext;
+	DeviceContext.Add(TEXT("cpu_description"), FPlatformMisc::GetCPUBrand());
+	DeviceContext.Add(TEXT("number_of_cores"), FString::FromInt(FPlatformMisc::NumberOfCores()));
+	DeviceContext.Add(TEXT("number_of_cores_including_hyperthreads"), FString::FromInt(FPlatformMisc::NumberOfCoresIncludingHyperthreads()));
+	DeviceContext.Add(TEXT("physical_memory_size_gb"), FString::FromInt(MemoryConstants.TotalPhysicalGB));
+
+	SubsystemNativeImpl->SetContext(TEXT("device"), DeviceContext);
 }
 
 void USentrySubsystem::PromoteTags()

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -237,6 +237,9 @@ private:
 	/** Adds GPU context data for all events captured by Sentry SDK. */
 	void AddGpuContext();
 
+	/** Adds GPU context data for all events captured by Sentry SDK. */
+	void AddDeviceContext();
+
 	/** Promote specified values to tags for all events captured by Sentry SDK. */
 	void PromoteTags();
 

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -234,6 +234,9 @@ private:
 	/** Adds default context data for all events captured by Sentry SDK. */
 	void AddDefaultContext();
 
+	/** Adds GPU context data for all events captured by Sentry SDK. */
+	void AddGpuContext();
+
 	/** Promote specified values to tags for all events captured by Sentry SDK. */
 	void PromoteTags();
 


### PR DESCRIPTION
This PR updates the event data by putting certain properties into more relevant context categories according to [spec](https://develop.sentry.dev/sdk/event-payloads/contexts/#device-context).