### PR TITLE
Fix plugin build errors when `sentry-native` is disabled on Win/Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Fix Linux Compile/Staging Error ([#327](https://github.com/getsentry/sentry-unreal/pull/327))
 - Fix UE 5.3 compatibility issues ([#348](https://github.com/getsentry/sentry-unreal/pull/348))
 - Fix plugin settings names ([#350](https://github.com/getsentry/sentry-unreal/pull/350))
+- Fix plugin build errors when `sentry-native` is disabled on Win/Linux ([#359](https://github.com/getsentry/sentry-unreal/pull/359))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/SentryBreadcrumb.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryBreadcrumb.cpp
@@ -20,7 +20,7 @@ USentryBreadcrumb::USentryBreadcrumb()
 		BreadcrumbNativeImpl = MakeShareable(new SentryBreadcrumbAndroid());
 #elif PLATFORM_IOS || PLATFORM_MAC
 		BreadcrumbNativeImpl = MakeShareable(new SentryBreadcrumbApple());
-#elif PLATFORM_WINDOWS || PLATFORM_LINUX
+#elif (PLATFORM_WINDOWS || PLATFORM_LINUX) && USE_SENTRY_NATIVE
 		BreadcrumbNativeImpl = MakeShareable(new SentryBreadcrumbDesktop());
 #endif
 	}

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -20,7 +20,7 @@ USentryEvent::USentryEvent()
 		EventNativeImpl = MakeShareable(new SentryEventAndroid());
 #elif PLATFORM_IOS || PLATFORM_MAC
 		EventNativeImpl = MakeShareable(new SentryEventApple());
-#elif PLATFORM_WINDOWS || PLATFORM_LINUX
+#elif (PLATFORM_WINDOWS || PLATFORM_LINUX) && USE_SENTRY_NATIVE
 		EventNativeImpl = MakeShareable(new SentryEventDesktop());
 #endif
 	}

--- a/plugin-dev/Source/Sentry/Private/SentryId.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryId.cpp
@@ -20,7 +20,7 @@ USentryId::USentryId()
 		SentryIdNativeImpl = MakeShareable(new SentryIdAndroid());
 #elif PLATFORM_IOS || PLATFORM_MAC
 		SentryIdNativeImpl = MakeShareable(new SentryIdApple());
-#elif PLATFORM_WINDOWS || PLATFORM_LINUX
+#elif (PLATFORM_WINDOWS || PLATFORM_LINUX) && USE_SENTRY_NATIVE
 		SentryIdNativeImpl = MakeShareable(new SentryIdDesktop());
 #endif
 	}

--- a/plugin-dev/Source/Sentry/Private/SentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryScope.cpp
@@ -22,7 +22,7 @@ USentryScope::USentryScope()
 		ScopeNativeImpl = MakeShareable(new SentryScopeAndroid());
 #elif PLATFORM_IOS || PLATFORM_MAC
 		ScopeNativeImpl = MakeShareable(new SentryScopeApple());
-#elif PLATFORM_WINDOWS || PLATFORM_LINUX
+#elif (PLATFORM_WINDOWS || PLATFORM_LINUX) && USE_SENTRY_NATIVE
 		ScopeNativeImpl = MakeShareable(new SentryScopeDesktop());
 #endif
 	}

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -36,7 +36,7 @@ void USentrySubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	SubsystemNativeImpl = MakeShareable(new SentrySubsystemAndroid());
 #elif PLATFORM_IOS || PLATFORM_MAC
 	SubsystemNativeImpl = MakeShareable(new SentrySubsystemApple());
-#elif PLATFORM_WINDOWS || PLATFORM_LINUX
+#elif (PLATFORM_WINDOWS || PLATFORM_LINUX) && USE_SENTRY_NATIVE
 	SubsystemNativeImpl = MakeShareable(new SentrySubsystemDesktop());
 #endif
 
@@ -297,6 +297,9 @@ void USentrySubsystem::AddDefaultContext()
 
 void USentrySubsystem::AddGpuContext()
 {
+	if (!SubsystemNativeImpl)
+		return;
+
 	FGPUDriverInfo GpuDriverInfo = FPlatformMisc::GetGPUDriverInfo(FPlatformMisc::GetPrimaryGPUBrand());
 
 	TMap<FString, FString> GpuContext;
@@ -309,6 +312,9 @@ void USentrySubsystem::AddGpuContext()
 
 void USentrySubsystem::AddDeviceContext()
 {
+	if (!SubsystemNativeImpl)
+		return;
+
 	const FPlatformMemoryConstants& MemoryConstants = FPlatformMemory::GetConstants();
 
 	TMap<FString, FString> DeviceContext;

--- a/plugin-dev/Source/Sentry/Private/SentryUser.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryUser.cpp
@@ -20,7 +20,7 @@ USentryUser::USentryUser()
 		UserNativeImpl = MakeShareable(new SentryUserAndroid());
 #elif PLATFORM_IOS || PLATFORM_MAC
 		UserNativeImpl = MakeShareable(new SentryUserApple());
-#elif PLATFORM_WINDOWS || PLATFORM_LINUX
+#elif (PLATFORM_WINDOWS || PLATFORM_LINUX) && USE_SENTRY_NATIVE
 		UserNativeImpl = MakeShareable(new SentryUserDesktop());
 #endif
 	}

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryScope.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryScope.spec.cpp
@@ -141,7 +141,7 @@ void SentryScopeSpec::Define()
 		});
 	});
 
-#if PLATFORM_WINDOWS || PLATFORM_LINUX
+#if (PLATFORM_WINDOWS || PLATFORM_LINUX) && USE_SENTRY_NATIVE
 	Describe("Scope params", [this]()
 	{
 		It("should be applied to event", [this]()

--- a/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
@@ -30,7 +30,7 @@ void SentrySubsystemSpec::Define()
 	{
 		// Subsystem implementation is used in order to avoid unnecessary complications with proper USentrySubsystem instantiation
 
-#if PLATFORM_WINDOWS || PLATFORM_LINUX
+#if (PLATFORM_WINDOWS || PLATFORM_LINUX) && USE_SENTRY_NATIVE
 		SentrySubsystemImpl = MakeShareable(new SentrySubsystemDesktop());
 #elif PLATFORM_MAC
 		SentrySubsystemImpl = MakeShareable(new SentrySubsystemApple());


### PR DESCRIPTION
This PR adds extra `USE_SENTRY_NATIVE ` define checks to prevent build errors if one was disabled programmatically.

Closes #353 