### PR TITLE
Adding enhanced options for Sentry Plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add extra crash context for native integration ([#342](https://github.com/getsentry/sentry-unreal/pull/342))
 - Add missing plugin settings ([#335](https://github.com/getsentry/sentry-unreal/pull/335))
 - Update event context categories for desktop ([#356](https://github.com/getsentry/sentry-unreal/pull/356))
+- Added Options for enabling platforms & Promoted Builds via the GUI
 
 ### Fixes
 

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -1,7 +1,7 @@
 // Copyright (c) 2022 Sentry. All Rights Reserved.
 
 #include "SentrySettings.h"
-
+#include "SentryDefines.h"
 #include "SentryBeforeSendHandler.h"
 
 #include "Misc/Paths.h"
@@ -13,6 +13,7 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 	, Dsn()
 	, InitAutomatically(true)
 	, Debug(true)
+	, EnableForPromotedBuildsOnly(true)
 	, EnableAutoCrashCapturing(true)
 	, EnableAutoLogAttachment(false)
 	, AttachStacktrace(true)
@@ -72,6 +73,10 @@ void USentrySettings::LoadDebugSymbolsProperties()
 		PropertiesFile.GetString(TEXT("Sentry"), TEXT("defaults.org"), OrgName);
 		PropertiesFile.GetString(TEXT("Sentry"), TEXT("auth.token"), AuthToken);
 	}
+	else
+	{
+		UE_LOG(LogSentrySdk, Error, TEXT("Sentry plugin can't find properties file"));
+	}
 }
 
 void USentrySettings::CheckLegacySettings()
@@ -117,6 +122,7 @@ void USentrySettings::CheckLegacySettings()
 
 	if (IsSettingsDirty)
 	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry settings where marked as dirty"));
 		GConfig->Flush(false, *ConfigFilename);
 	}
 }

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -122,7 +122,7 @@ void USentrySettings::CheckLegacySettings()
 
 	if (IsSettingsDirty)
 	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry settings where marked as dirty"));
+		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry settings where marked as dirty - If not checked out in Perforce, you'll need to update these manually"));
 		GConfig->Flush(false, *ConfigFilename);
 	}
 }

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -31,16 +31,35 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 	, CrashReporterUrl()
 	, BeforeSendHandler(USentryBeforeSendHandler::StaticClass())
 {
+	bool SetEnv = false;
+
 #if WITH_EDITOR
-	Environment = TEXT("Editor");
-	LoadDebugSymbolsProperties();
-#elif UE_BUILD_SHIPPING
-	Environment = TEXT("Release");
-#elif UE_BUILD_DEVELOPMENT
-	Environment = TEXT("Development");
-#elif UE_BUILD_DEBUG
-	Environment = TEXT("Debug");
+	// The #if WITH_EDITOR and WITH_EDITORONLY_DATA tags don't sufficiently verify the status of the editor 
+	if (GIsEditor)
+	{
+		SetEnv = true;
+		Environment = TEXT("Editor");
+	}
 #endif
+
+	if (!SetEnv)
+	{
+#if UE_BUILD_TEST
+		Environment = TEXT("Test");
+#elif UE_BUILD_SHIPPING
+		Environment = TEXT("Release");
+#elif UE_BUILD_DEVELOPMENT
+		Environment = TEXT("Development");
+#elif UE_BUILD_DEBUG
+		Environment = TEXT("Debug");
+#endif
+	}
+
+	if (GIsEditor)
+	{
+		LoadDebugSymbolsProperties();
+	}
+
 	CheckLegacySettings();
 }
 
@@ -73,7 +92,7 @@ void USentrySettings::LoadDebugSymbolsProperties()
 	}
 	else
 	{
-		UE_LOG(LogSentrySdk, Error, TEXT("Sentry plugin can't find properties file"));
+		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry plugin can't find properties file"));
 	}
 }
 

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -33,6 +33,7 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 {
 #if WITH_EDITOR
 	Environment = TEXT("Editor");
+	LoadDebugSymbolsProperties();
 #elif UE_BUILD_SHIPPING
 	Environment = TEXT("Release");
 #elif UE_BUILD_DEVELOPMENT
@@ -40,9 +41,6 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 #elif UE_BUILD_DEBUG
 	Environment = TEXT("Debug");
 #endif
-
-	LoadDebugSymbolsProperties();
-
 	CheckLegacySettings();
 }
 

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -44,6 +44,11 @@ void USentrySubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	if (Settings->InitAutomatically)
 	{
 		Initialize();
+		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry plugin will auto initlaize."));
+	}
+	else
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry plugin won't auto initlaize."));
 	}
 }
 
@@ -66,9 +71,9 @@ void USentrySubsystem::Initialize()
 		return;
 	}
 
-	if(!IsCurrentBuildConfigurationEnabled() || !IsCurrentBuildTargetEnabled())
+	if(!IsCurrentBuildConfigurationEnabled() || !IsCurrentBuildTargetEnabled() || !IsCurrentPlatformEnabled() || !IsPromotedBuild())
 	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization skipped since event capturing is disabled for the current build configuration/target in plugin settings."));
+		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization skipped since event capturing is disabled for the current configuration/target/platform/build in plugin settings."));
 		return;
 	}
 
@@ -88,6 +93,9 @@ void USentrySubsystem::Initialize()
 		UE_LOG(LogSentrySdk, Error, TEXT("Sentry initialization failed."));
 		return;
 	}
+
+	UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization complete."));
+
 
 	AddDefaultContext();
 
@@ -488,4 +496,42 @@ bool USentrySubsystem::IsCurrentBuildTargetEnabled()
 	}
 
 	return IsBuildTargetTypeEnabled;
+}
+
+bool USentrySubsystem::IsCurrentPlatformEnabled()
+{	
+	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
+
+	bool IsBuildPlatformEnabled = false;
+	
+#if PLATFORM_LINUX
+	IsBuildPlatformEnable = Settings->EnableBuildPlatforms.bEnableLinux;
+#elif PLATFORM_IOS
+	IsBuildPlatformEnabled = Settings->EnableBuildPlatforms.bEnableIOS;
+#elif PLATFORM_WINDOWS
+	IsBuildPlatformEnabled = Settings->EnableBuildPlatforms.bEnableWindows;
+#elif PLATFORM_ANDROID
+	IsBuildPlatformEnabled = Settings->EnableBuildPlatforms.bEnableAndroid;
+#elif PLATFORM_MAC
+	IsBuildPlatformEnabled = Settings->EnableBuildPlatforms.bEnableMac;
+#endif
+	return IsBuildPlatformEnabled;
+}
+
+bool USentrySubsystem::IsPromotedBuild()
+{
+	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
+
+	if (Settings->EnableForPromotedBuildsOnly)
+	{
+		if (FApp::GetEngineIsPromotedBuild())
+		{
+			return true;
+		}
+		else
+		{
+			return false;
+		}
+	}
+	return true;
 }

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -44,11 +44,11 @@ void USentrySubsystem::Initialize(FSubsystemCollectionBase& Collection)
 	if (Settings->InitAutomatically)
 	{
 		Initialize();
-		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry plugin will auto initlaize."));
+		UE_LOG(LogSentrySdk, Log, TEXT("Sentry plugin will auto initlaize."));
 	}
 	else
 	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry plugin won't auto initlaize."));
+		UE_LOG(LogSentrySdk, Log, TEXT("Sentry plugin won't auto initlaize."));
 	}
 }
 
@@ -71,9 +71,15 @@ void USentrySubsystem::Initialize()
 		return;
 	}
 
-	if(!IsCurrentBuildConfigurationEnabled() || !IsCurrentBuildTargetEnabled() || !IsCurrentPlatformEnabled() || !IsPromotedBuild())
+	if(!IsCurrentBuildConfigurationEnabled() || !IsCurrentBuildTargetEnabled() || !IsCurrentPlatformEnabled())
 	{
 		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization skipped since event capturing is disabled for the current configuration/target/platform/build in plugin settings."));
+		return;
+	}
+
+	if(Settings->EnableForPromotedBuildsOnly && !FApp::GetEngineIsPromotedBuild())
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization skipped since event capturing is disabled for the non-promoted builds in plugin settings."));
 		return;
 	}
 
@@ -483,6 +489,7 @@ bool USentrySubsystem::IsCurrentBuildTargetEnabled()
 		IsBuildTargetTypeEnabled = Settings->EnableBuildTargets.bEnableClient;
 		break;
 	case EBuildTargetType::Editor:
+		// Note: If this gives false flags (It shouldn't be possible, but check GIsEditor)
 		IsBuildTargetTypeEnabled = Settings->EnableBuildTargets.bEnableEditor;
 		break;
 	case EBuildTargetType::Program:

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -505,7 +505,7 @@ bool USentrySubsystem::IsCurrentPlatformEnabled()
 	bool IsBuildPlatformEnabled = false;
 	
 #if PLATFORM_LINUX
-	IsBuildPlatformEnable = Settings->EnableBuildPlatforms.bEnableLinux;
+	IsBuildPlatformEnabled = Settings->EnableBuildPlatforms.bEnableLinux;
 #elif PLATFORM_IOS
 	IsBuildPlatformEnabled = Settings->EnableBuildPlatforms.bEnableIOS;
 #elif PLATFORM_WINDOWS

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -94,9 +94,6 @@ void USentrySubsystem::Initialize()
 		return;
 	}
 
-	UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization complete."));
-
-
 	AddDefaultContext();
 
 #if PLATFORM_WINDOWS || PLATFORM_LINUX || PLATFORM_MAC

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -117,6 +117,32 @@ struct FEnableBuildTargets
 	bool bEnableProgram = true;
 };
 
+USTRUCT(BlueprintType)
+struct FEnableBuildPlatforms
+{
+	GENERATED_BODY()
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Linux", ToolTip = "Flag indicating whether event capturing should be enabled for the Linux platform type."))
+	bool bEnableLinux = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Windows", ToolTip = "Flag indicating whether event capturing should be enabled for the Windows platform type."))
+	bool bEnableWindows = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "IOS", ToolTip = "Flag indicating whether event capturing should be enabled for the IOS platform type."))
+	bool bEnableIOS = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+		Meta = (DisplayName = "Android", ToolTip = "Flag indicating whether event capturing should be enabled for the Android platform type."))
+	bool bEnableAndroid = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+	Meta = (DisplayName = "Mac", ToolTip = "Flag indicating whether event capturing should be enabled for the Mac platform type."))
+	bool bEnableMac = true;
+};
+
 /**
  * Sentry settings used for plugin configuration.
  */
@@ -141,6 +167,10 @@ class SENTRY_API USentrySettings : public UObject
 		Meta = (DisplayName = "Enable verbose logging", ToolTip = "Flag indicating whether to enable verbose logging on desktop."))
 	bool Debug;
 
+	UPROPERTY(Config, EditAnywhere, Category = "Misc",
+	Meta = (DisplayName = "Enable for promoted builds only", ToolTip = "Flag indicating whether to enable for promoted builds only"))
+	bool EnableForPromotedBuildsOnly;
+
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
 		Meta = (DisplayName = "Enable for Build Configurations"))
 	FEnableBuildConfigurations EnableBuildConfigurations;
@@ -148,6 +178,10 @@ class SENTRY_API USentrySettings : public UObject
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
 		Meta = (DisplayName = "Enable for Build Target Types"))
 	FEnableBuildTargets EnableBuildTargets;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
+	Meta = (DisplayName = "Enable for Build Platform Types"))
+	FEnableBuildPlatforms EnableBuildPlatforms;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Misc",
 		Meta = (DisplayName = "Automatically add breadcrumbs"))

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -255,6 +255,13 @@ private:
 	/** Check whether the event capturing should be disabled for the current build configuration */
 	bool IsCurrentBuildTargetEnabled();
 
+	/** Check whether the event capturing should be disabled for the current build configuration */
+	bool IsCurrentPlatformEnabled();
+
+	/** Check whether the event capturing should be disabled for only promoted builds */
+	bool IsPromotedBuild();
+
+
 private:
 	TSharedPtr<ISentrySubsystem> SubsystemNativeImpl;
 


### PR DESCRIPTION
- Added ability to configure platforms the plugin is enabled on via config
- Added ability to only init if a promoted build type
- Enhanced logging 