### PR TITLE
Add breakpad support for Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Add extra crash context for native integration ([#342](https://github.com/getsentry/sentry-unreal/pull/342))
 - Add missing plugin settings ([#335](https://github.com/getsentry/sentry-unreal/pull/335))
 - Update event context categories for desktop ([#356](https://github.com/getsentry/sentry-unreal/pull/356))
-- Add breakpad support for Windows/Linux ([#363](https://github.com/getsentry/sentry-unreal/pull/363))
+- Add breakpad support for Windows ([#363](https://github.com/getsentry/sentry-unreal/pull/363))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Add extra crash context for native integration ([#342](https://github.com/getsentry/sentry-unreal/pull/342))
 - Add missing plugin settings ([#335](https://github.com/getsentry/sentry-unreal/pull/335))
 - Update event context categories for desktop ([#356](https://github.com/getsentry/sentry-unreal/pull/356))
+- Add breakpad support for Windows/Linux ([#363](https://github.com/getsentry/sentry-unreal/pull/363))
 
 ### Fixes
 

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -119,7 +119,6 @@ public class Sentry : ModuleRules
 			PublicRuntimeLibraryPaths.Add(PlatformBinariesPath);
 
 			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "bin", "libsentry.so"));
-
 			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "libbreakpad_client.a"));
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -115,11 +115,12 @@ public class Sentry : ModuleRules
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private", "Desktop"));
 
 			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "libsentry.so"), Path.Combine(PlatformThirdPartyPath, "bin", "libsentry.so"));
-			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "breakpad"), Path.Combine(PlatformThirdPartyPath, "bin", "breakpad"));
 
 			PublicRuntimeLibraryPaths.Add(PlatformBinariesPath);
 
 			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "bin", "libsentry.so"));
+
+			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "libbreakpad_client.a"));
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
 		}

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -115,11 +115,11 @@ public class Sentry : ModuleRules
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private", "Desktop"));
 
 			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "libsentry.so"), Path.Combine(PlatformThirdPartyPath, "bin", "libsentry.so"));
+			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "crashpad_handler"), Path.Combine(PlatformThirdPartyPath, "bin", "crashpad_handler"));
 
 			PublicRuntimeLibraryPaths.Add(PlatformBinariesPath);
 
 			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "bin", "libsentry.so"));
-			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "libbreakpad_client.a"));
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
 		}

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -99,12 +99,12 @@ public class Sentry : ModuleRules
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private", "Desktop"));
 
 			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "sentry.dll"), Path.Combine(PlatformThirdPartyPath, "bin", "sentry.dll"));
-			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "crashpad_handler.exe"), Path.Combine(PlatformThirdPartyPath, "bin", "crashpad_handler.exe"));
 			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "sentry.pdb"), Path.Combine(PlatformThirdPartyPath, "bin", "sentry.pdb"));
 
 			PublicDelayLoadDLLs.Add("sentry.dll");
 
 			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "sentry.lib"));
+			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "breakpad_client.lib"));
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
 		}
@@ -115,7 +115,7 @@ public class Sentry : ModuleRules
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private", "Desktop"));
 
 			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "libsentry.so"), Path.Combine(PlatformThirdPartyPath, "bin", "libsentry.so"));
-			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "crashpad_handler"), Path.Combine(PlatformThirdPartyPath, "bin", "crashpad_handler"));
+			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "breakpad"), Path.Combine(PlatformThirdPartyPath, "bin", "breakpad"));
 
 			PublicRuntimeLibraryPaths.Add(PlatformBinariesPath);
 

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -106,9 +106,8 @@ function buildSentryNative()
 {
     Push-Location -Path "$modulesDir/sentry-native"
 
-    cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal
+    cmake -B "build" -D SENTRY_BACKEND=breakpad -D SENTRY_SDK_NAME=sentry.native.unreal
     cmake --build "build" --target sentry --config RelWithDebInfo --parallel
-    cmake --build "build" --target crashpad_handler --config Release --parallel
 
     Pop-Location
 
@@ -130,7 +129,7 @@ function buildSentryNative()
     Copy-Item "$modulesDir/sentry-native/build/RelWithDebInfo/sentry.lib" -Destination "$nativeOutDirLibs/sentry.lib"
     Copy-Item "$modulesDir/sentry-native/build/RelWithDebInfo/sentry.dll" -Destination "$nativeOutDirBinaries/sentry.dll"
     Copy-Item "$modulesDir/sentry-native/build/RelWithDebInfo/sentry.pdb" -Destination "$nativeOutDirBinaries/sentry.pdb"
-    Copy-Item "$modulesDir/sentry-native/build/crashpad_build/handler/Release/crashpad_handler.exe" -Destination "$nativeOutDirBinaries/crashpad_handler.exe"
+    Copy-Item "$modulesDir/sentry-native/build/external/RelWithDebInfo/breakpad_client.lib" -Destination "$nativeOutDirLibs/breakpad_client.lib"
     Copy-Item "$modulesDir/sentry-native/include/sentry.h" -Destination "$nativeOutDirIncludes/sentry.h"
 }
 

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -11,10 +11,11 @@ cmake --build "${sentryNativeRoot}/build" --target sentry --parallel
 
 mkdir "${sentryArtifactsDestination}/bin"
 mkdir "${sentryArtifactsDestination}/include"
+mkdir "${sentryArtifactsDestination}/lib"
 
 strip -s "${sentryNativeRoot}/build/libsentry.so" -w -K sentry_[^_]* -o "${sentryArtifactsDestination}/bin/libsentry.so"
 cp "${sentryNativeRoot}/build/libsentry.so" "${sentryArtifactsDestination}/bin/libsentry.dbg.so"
-strip -x "${sentryNativeRoot}/build/breakpad/handler/breakpad" -o "${sentryArtifactsDestination}/bin/breakpad"
+cp "${sentryNativeRoot}/build/libbreakpad_client.a" "${sentryArtifactsDestination}/lib/libbreakpad_client.a"
 cp "${sentryNativeRoot}/include/sentry.h" "${sentryArtifactsDestination}/include/sentry.h"
 
 pushd ${sentryArtifactsDestination}/bin

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -6,7 +6,7 @@ export sentryArtifactsDestination=$2
 
 rm -rf "${sentryArtifactsDestination}/"*
 
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D CMAKE_BUILD_TYPE=RelWithDebInfo
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=breakpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D CMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build "${sentryNativeRoot}/build" --target sentry --parallel
 
 mkdir "${sentryArtifactsDestination}/bin"
@@ -14,7 +14,7 @@ mkdir "${sentryArtifactsDestination}/include"
 
 strip -s "${sentryNativeRoot}/build/libsentry.so" -w -K sentry_[^_]* -o "${sentryArtifactsDestination}/bin/libsentry.so"
 cp "${sentryNativeRoot}/build/libsentry.so" "${sentryArtifactsDestination}/bin/libsentry.dbg.so"
-strip -x "${sentryNativeRoot}/build/crashpad_build/handler/crashpad_handler" -o "${sentryArtifactsDestination}/bin/crashpad_handler"
+strip -x "${sentryNativeRoot}/build/breakpad/handler/breakpad" -o "${sentryArtifactsDestination}/bin/breakpad"
 cp "${sentryNativeRoot}/include/sentry.h" "${sentryArtifactsDestination}/include/sentry.h"
 
 pushd ${sentryArtifactsDestination}/bin

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -6,7 +6,7 @@ export sentryArtifactsDestination=$2
 
 rm -rf "${sentryArtifactsDestination}/"*
 
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=breakpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D CMAKE_BUILD_TYPE=RelWithDebInfo
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D CMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build "${sentryNativeRoot}/build" --target sentry --parallel
 
 mkdir "${sentryArtifactsDestination}/bin"
@@ -15,7 +15,7 @@ mkdir "${sentryArtifactsDestination}/lib"
 
 strip -s "${sentryNativeRoot}/build/libsentry.so" -w -K sentry_[^_]* -o "${sentryArtifactsDestination}/bin/libsentry.so"
 cp "${sentryNativeRoot}/build/libsentry.so" "${sentryArtifactsDestination}/bin/libsentry.dbg.so"
-cp "${sentryNativeRoot}/build/external/libbreakpad_client.a" "${sentryArtifactsDestination}/lib/libbreakpad_client.a"
+strip -x "${sentryNativeRoot}/build/crashpad_build/handler/crashpad_handler" -o "${sentryArtifactsDestination}/bin/crashpad_handler"
 cp "${sentryNativeRoot}/include/sentry.h" "${sentryArtifactsDestination}/include/sentry.h"
 
 pushd ${sentryArtifactsDestination}/bin

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -15,7 +15,7 @@ mkdir "${sentryArtifactsDestination}/lib"
 
 strip -s "${sentryNativeRoot}/build/libsentry.so" -w -K sentry_[^_]* -o "${sentryArtifactsDestination}/bin/libsentry.so"
 cp "${sentryNativeRoot}/build/libsentry.so" "${sentryArtifactsDestination}/bin/libsentry.dbg.so"
-cp "${sentryNativeRoot}/build/libbreakpad_client.a" "${sentryArtifactsDestination}/lib/libbreakpad_client.a"
+cp "${sentryNativeRoot}/build/external/libbreakpad_client.a" "${sentryArtifactsDestination}/lib/libbreakpad_client.a"
 cp "${sentryNativeRoot}/include/sentry.h" "${sentryArtifactsDestination}/include/sentry.h"
 
 pushd ${sentryArtifactsDestination}/bin

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -11,7 +11,6 @@ cmake --build "${sentryNativeRoot}/build" --target sentry --parallel
 
 mkdir "${sentryArtifactsDestination}/bin"
 mkdir "${sentryArtifactsDestination}/include"
-mkdir "${sentryArtifactsDestination}/lib"
 
 strip -s "${sentryNativeRoot}/build/libsentry.so" -w -K sentry_[^_]* -o "${sentryArtifactsDestination}/bin/libsentry.so"
 cp "${sentryNativeRoot}/build/libsentry.so" "${sentryArtifactsDestination}/bin/libsentry.dbg.so"

--- a/scripts/build-win64.sh
+++ b/scripts/build-win64.sh
@@ -6,9 +6,8 @@ export sentryArtifactsDestination=$2
 
 rm -rf "${sentryArtifactsDestination}/"*
 
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=breakpad -D SENTRY_SDK_NAME=sentry.native.unreal
 cmake --build "${sentryNativeRoot}/build" --target sentry --config RelWithDebInfo --parallel
-cmake --build "${sentryNativeRoot}/build" --target crashpad_handler --config Release --parallel
 
 mkdir "${sentryArtifactsDestination}/bin"
 mkdir "${sentryArtifactsDestination}/include"
@@ -17,5 +16,5 @@ mkdir "${sentryArtifactsDestination}/lib"
 cp ${sentryNativeRoot}/build/RelWithDebInfo/sentry.lib ${sentryArtifactsDestination}/lib/sentry.lib
 cp ${sentryNativeRoot}/build/RelWithDebInfo/sentry.dll ${sentryArtifactsDestination}/bin/sentry.dll
 cp ${sentryNativeRoot}/build/RelWithDebInfo/sentry.pdb ${sentryArtifactsDestination}/bin/sentry.pdb
-cp ${sentryNativeRoot}/build/crashpad_build/handler/Release/crashpad_handler.exe ${sentryArtifactsDestination}/bin/crashpad_handler.exe
+cp ${sentryNativeRoot}/build/external/RelWithDebInfo/breakpad_client.lib ${sentryArtifactsDestination}/lib/breakpad_client.lib
 cp ${sentryNativeRoot}/include/sentry.h ${sentryArtifactsDestination}/include/sentry.h

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -245,12 +245,11 @@ Source/ThirdParty/IOS/Sentry.framework/PrivateHeaders/SentryTraceContext.h
 Source/ThirdParty/IOS/Sentry.framework/Sentry
 Source/ThirdParty/Linux/
 Source/ThirdParty/Linux/bin/
+Source/ThirdParty/Linux/bin/crashpad_handler
 Source/ThirdParty/Linux/bin/libsentry.dbg.so
 Source/ThirdParty/Linux/bin/libsentry.so
 Source/ThirdParty/Linux/include/
 Source/ThirdParty/Linux/include/sentry.h
-Source/ThirdParty/Linux/lib/
-Source/ThirdParty/Linux/lib/libbreakpad_client.a
 Source/ThirdParty/Mac/
 Source/ThirdParty/Mac/bin/
 Source/ThirdParty/Mac/bin/sentry.dylib

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -245,11 +245,12 @@ Source/ThirdParty/IOS/Sentry.framework/PrivateHeaders/SentryTraceContext.h
 Source/ThirdParty/IOS/Sentry.framework/Sentry
 Source/ThirdParty/Linux/
 Source/ThirdParty/Linux/bin/
-Source/ThirdParty/Linux/bin/crashpad_handler
 Source/ThirdParty/Linux/bin/libsentry.dbg.so
 Source/ThirdParty/Linux/bin/libsentry.so
 Source/ThirdParty/Linux/include/
 Source/ThirdParty/Linux/include/sentry.h
+Source/ThirdParty/Linux/lib/
+Source/ThirdParty/Linux/lib/libbreakpad_client.a
 Source/ThirdParty/Mac/
 Source/ThirdParty/Mac/bin/
 Source/ThirdParty/Mac/bin/sentry.dylib
@@ -319,10 +320,10 @@ Source/ThirdParty/Mac/include/Headers/SentryUser.h
 Source/ThirdParty/Mac/include/Headers/SentryUserFeedback.h
 Source/ThirdParty/Win64/
 Source/ThirdParty/Win64/bin/
-Source/ThirdParty/Win64/bin/crashpad_handler.exe
 Source/ThirdParty/Win64/bin/sentry.dll
 Source/ThirdParty/Win64/bin/sentry.pdb
 Source/ThirdParty/Win64/include/
 Source/ThirdParty/Win64/include/sentry.h
 Source/ThirdParty/Win64/lib/
+Source/ThirdParty/Win64/lib/breakpad_client.lib
 Source/ThirdParty/Win64/lib/sentry.lib


### PR DESCRIPTION
This PR switches `sentry-native` backend from `crashpad` to `breakpad`. It allows Sentry to comply with the [UE Marketplace publishing rules (2.6.2.e)](https://www.unrealengine.com/en-US/marketplace-guidelines#262e) which restrict the distribution of certain file types.

`breakpad` is an in-proc crash handler represented by a separate library unlike the `crashpad` which is essentially a separate app. The key difference it introduces for the crash-capturing flow is that game has to be re-launched in order to send captured crash to Sentry.