### PR TITLE
ci: add packaging/testing for UE 5.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,7 +117,7 @@ jobs:
       fail-fast: false
       matrix:
         # Note: these versions must match scripts/packaging/engine-versions.txt
-        unreal: ['5.1', '5.2']
+        unreal: ['5.1', '5.2', '5.3']
         app: ['sample']
 
     steps:


### PR DESCRIPTION
Since the Docker image for UE 5.3 is now available CI should package/test plugin against this engine version as well.

#skip-changelog