### PR TITLE
Fix errors caused by Cpp20 adoption in UE 5.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+###
+
+- Fix errors caused by Cpp20 adoption in UE 5.3 ([#377](https://github.com/getsentry/sentry-unreal/pull/377))
+
 ### Dependencies
 
 - Bump Cocoa SDK (iOS) from v8.10.0 to v8.11.0 ([#367](https://github.com/getsentry/sentry-unreal/pull/367))

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -359,7 +359,7 @@ void USentrySubsystem::ConfigureBreadcrumbs()
 
 	if(Settings->AutomaticBreadcrumbs.bOnMapLoadingStarted)
 	{
-		PreLoadMapDelegate = FCoreUObjectDelegates::PreLoadMap.AddLambda([=](const FString& MapName)
+		PreLoadMapDelegate = FCoreUObjectDelegates::PreLoadMap.AddLambda([this](const FString& MapName)
 		{
 			AddBreadcrumbWithParams(TEXT("PreLoadMap"), TEXT("Unreal"), TEXT("Default"),
 				{{TEXT("Map"), MapName}}, ESentryLevel::Info);
@@ -368,7 +368,7 @@ void USentrySubsystem::ConfigureBreadcrumbs()
 
 	if(Settings->AutomaticBreadcrumbs.bOnMapLoaded)
 	{
-		PostLoadMapDelegate = FCoreUObjectDelegates::PostLoadMapWithWorld.AddLambda([=](UWorld* World)
+		PostLoadMapDelegate = FCoreUObjectDelegates::PostLoadMapWithWorld.AddLambda([this](UWorld* World)
 		{
 			if (World)
 			{

--- a/plugin-dev/Source/SentryEditor/Private/SentryCliDownloader.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentryCliDownloader.cpp
@@ -23,7 +23,7 @@ void FSentryCliDownloader::Download(const TFunction<void(bool)>& OnCompleted)
 {
 	SentryCliDownloadRequest = FHttpModule::Get().CreateRequest();
 
-	SentryCliDownloadRequest->OnProcessRequestComplete().BindLambda([=](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess)
+	SentryCliDownloadRequest->OnProcessRequestComplete().BindLambda([this, OnCompleted](FHttpRequestPtr Request, FHttpResponsePtr Response, bool bSuccess)
 	{
 		if (!bSuccess || !Response.IsValid())
 		{

--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -165,7 +165,7 @@ void FSentrySettingsCustomization::DrawDebugSymbolsNotice(IDetailLayoutBuilder& 
 					.HAlign(HAlign_Center)
 					.VAlign(VAlign_Center)
 					.ContentPadding(FMargin(8, 2))
-					.OnClicked_Lambda([=]() -> FReply
+					.OnClicked_Lambda([this, CrashReporterUrlHandle]() -> FReply
 					{
 						FString CrcEndpoint;
 						CrashReporterUrlHandle->GetValue(CrcEndpoint);
@@ -183,7 +183,7 @@ void FSentrySettingsCustomization::DrawDebugSymbolsNotice(IDetailLayoutBuilder& 
 					.HAlign(HAlign_Center)
 					.VAlign(VAlign_Center)
 					.ContentPadding(FMargin(8, 2))
-					.OnClicked_Lambda([=]() -> FReply
+					.OnClicked_Lambda([this]() -> FReply
 					{
 						UpdateCrcConfig(DefaultCrcEndpoint);
 						return FReply::Handled();
@@ -244,7 +244,7 @@ TSharedRef<SWidget> FSentrySettingsCustomization::MakeSentryCliStatusRow(FName I
 			.VAlign(VAlign_Center)
 			[
 				SNew(SButton)
-				.OnClicked_Lambda([=]() -> FReply
+				.OnClicked_Lambda([this]() -> FReply
 				{
 					if(CliDownloader.IsValid() && CliDownloader->GetStatus() != ESentryCliStatus::Downloading)
 					{


### PR DESCRIPTION
In UE 5.3 C++ standard has changed from Cpp17 to Cpp20 which causes build errors if `this` is captured implicitly in lambda expressions. This PR fixes the issue by passing variables to lambdas explicitly instead of using `[=]` capture clause.