### PR TITLE
Fix conditional debug symbols uploading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix issue with missing Sentry.framework in iOS app bundle UE 5.3 ([#390](https://github.com/getsentry/sentry-unreal/pull/390))
 - Fix dependencies loading for desktop ([#393](https://github.com/getsentry/sentry-unreal/pull/393))
 - Fix array/map Json string check to avoid unnecessary error messages in logs ([#394](https://github.com/getsentry/sentry-unreal/pull/394))
+- Fix conditional debug symbols uploading ([#399](https://github.com/getsentry/sentry-unreal/pull/399))
 
 ### Dependencies
 

--- a/plugin-dev/Scripts/upload-debug-symbols-win.bat
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.bat
@@ -5,8 +5,9 @@ setlocal enabledelayedexpansion
 set TargetPlatform=%1
 set TargetName=%2
 set TargetType=%3
-set ProjectPath=%4
-set PluginPath=%5
+set TargetConfig=%4
+set ProjectPath=%5
+set PluginPath=%6
 
 set ProjectBinariesPath=%ProjectPath:"=%\Binaries\%TargetPlatform%
 set PluginBinariesPath=%PluginPath:"=%\Source\ThirdParty\%TargetPlatform%
@@ -20,6 +21,7 @@ if "%TargetType%"=="Editor" (
 )
 
 if "%TargetPlatform%"=="Win64" (
+    set "TargetPlatform=Windows"
     set CliExec=%PluginPath%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
 ) else if "%TargetPlatform%"=="Linux" (
     set CliExec=%PluginPath%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
@@ -46,6 +48,36 @@ if /i "%IncludeSourceFiles%"=="True" (
     set "CliArgs=--include-sources"
 )
 
+call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings EnableBuildPlatforms EnabledPlatforms
+if not "%EnabledPlatforms%"=="" (
+  set PlatformToCheck="bEnable%TargetPlatform%=False"
+  call :FindString EnabledPlatforms PlatformToCheck IsPlatformDisabled
+  if "!IsPlatformDisabled!"=="true" (
+      echo "Sentry: Automatic symbols upload is disabled for build platform %TargetPlatform%. Skipping..."
+      exit
+  )
+)
+
+call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings EnableBuildTargets EnabledTargets
+if not "%EnabledTargets%"=="" (
+  set TargetToCheck="bEnable%TargetType%=False"
+  call :FindString EnabledTargets TargetToCheck IsTargetDisabled
+  if "!IsTargetDisabled!"=="true" (
+      echo "Sentry: Automatic symbols upload is disabled for build target type %TargetType%. Skipping..."
+      exit
+  )
+)
+
+call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings EnableBuildConfigurations EnabledConfigurations
+if not "%EnabledConfigurations%"=="" (
+  set ConfigToCheck="bEnable%TargetConfig%=False"
+  call :FindString EnabledConfigurations ConfigToCheck IsConfigDisabled
+  if "!IsConfigDisabled!"=="true" (
+      echo "Sentry: Automatic symbols upload is disabled for build configuration %TargetConfig%. Skipping..."
+      exit
+  )
+)
+
 set PropertiesFile=%ProjectPath:"=%\sentry.properties
 
 if not exist "%PropertiesFile%" (
@@ -69,6 +101,19 @@ echo Sentry: Upload finished
 
 endlocal
 exit
+
+:FindString <sourceStr> <findStr> <result>
+  setlocal  
+  for /f "delims=" %%A in ('echo %%%1%%') do set str1=%%A
+  for /f "delims=" %%A in ('echo %%%2%%') do set str2=%%A
+  echo.%str1%|findstr /C:"%str2%" >nul 2>&1
+  endlocal
+  if not errorlevel 1 (
+    set %~3=true
+  ) else (
+    set %~3=false
+  )  
+  goto :eof
 
 :ParseIniFile <filename> <section> <key> <result>
   set %~4=
@@ -98,3 +143,5 @@ exit
     )
   )
   endlocal
+  set insection=
+  goto :eof

--- a/plugin-dev/Scripts/upload-debug-symbols-win.bat
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.bat
@@ -21,7 +21,6 @@ if "%TargetType%"=="Editor" (
 )
 
 if "%TargetPlatform%"=="Win64" (
-    set "TargetPlatform=Windows"
     set CliExec=%PluginPath%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
 ) else if "%TargetPlatform%"=="Linux" (
     set CliExec=%PluginPath%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
@@ -50,7 +49,12 @@ if /i "%IncludeSourceFiles%"=="True" (
 
 call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings EnableBuildPlatforms EnabledPlatforms
 if not "%EnabledPlatforms%"=="" (
-  set PlatformToCheck="bEnable%TargetPlatform%=False"
+  set PlatformToCheck=
+  if "%TargetPlatform%"=="Win64" (
+    set "PlatformToCheck=bEnableWindows=False"
+  ) else (
+    set "PlatformToCheck=bEnable%TargetPlatform%=False"
+  )
   call :FindString EnabledPlatforms PlatformToCheck IsPlatformDisabled
   if "!IsPlatformDisabled!"=="true" (
       echo "Sentry: Automatic symbols upload is disabled for build platform %TargetPlatform%. Skipping..."

--- a/plugin-dev/Sentry.uplugin
+++ b/plugin-dev/Sentry.uplugin
@@ -31,10 +31,10 @@
 	"PostBuildSteps":
 	{
 		"Mac": [
-			"if [ -f \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" ]; then\n sh \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" $(TargetPlatform) $(TargetName) $(TargetType) \"$(ProjectDir)\" \"$(PluginDir)\"\nelse\n echo \"Sentry: Symbol upload script is missing. Skipping post build step.\"\nfi"
+			"if [ -f \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" ]; then\n sh \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" $(TargetPlatform) $(TargetName) $(TargetType) $(TargetConfiguration) \"$(ProjectDir)\" \"$(PluginDir)\"\nelse\n echo \"Sentry: Symbol upload script is missing. Skipping post build step.\"\nfi"
 		],
 		"Linux": [
-			"if [ -f \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" ]; then\n sh \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" $(TargetPlatform) $(TargetName) $(TargetType) \"$(ProjectDir)\" \"$(PluginDir)\"\nelse\n echo \"Sentry: Symbol upload script is missing. Skipping post build step.\"\nfi"
+			"if [ -f \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" ]; then\n sh \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" $(TargetPlatform) $(TargetName) $(TargetType) $(TargetConfiguration) \"$(ProjectDir)\" \"$(PluginDir)\"\nelse\n echo \"Sentry: Symbol upload script is missing. Skipping post build step.\"\nfi"
 		],
 		"Win64": [
 			"set SYM_UPLOAD_SCRIPT=\"$(PluginDir)/Scripts/upload-debug-symbols-win.bat\"",

--- a/plugin-dev/Sentry.uplugin
+++ b/plugin-dev/Sentry.uplugin
@@ -38,7 +38,7 @@
 		],
 		"Win64": [
 			"set SYM_UPLOAD_SCRIPT=\"$(PluginDir)/Scripts/upload-debug-symbols-win.bat\"",
-			"if exist \"%SYM_UPLOAD_SCRIPT%\" (call \"%SYM_UPLOAD_SCRIPT%\" $(TargetPlatform) $(TargetName) $(TargetType) \"$(ProjectDir)\" \"$(PluginDir)\") else (\necho Warning: Sentry: Symbol upload script is missing. Skipping post build step.\n)"
+			"if exist \"%SYM_UPLOAD_SCRIPT%\" (call \"%SYM_UPLOAD_SCRIPT%\" $(TargetPlatform) $(TargetName) $(TargetType) $(TargetConfiguration) \"$(ProjectDir)\" \"$(PluginDir)\") else (\necho Warning: Sentry: Symbol upload script is missing. Skipping post build step.\n)"
 		]
 	}
 }

--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -3,8 +3,26 @@
     <init>
         <log text="Sentry SDK Android UPL initialization"/>
 
-        <setBoolFromProperty result="bUploadSymbols" ini="Engine" section="/Script/Sentry.SentrySettings" property="UploadSymbolsAutomatically" default="false" />
+        <setBoolFromProperty result="bUploadSymbolsAutomatically" ini="Engine" section="/Script/Sentry.SentrySettings" property="UploadSymbolsAutomatically" default="false" />
         <setBoolFromProperty result="bIncludeSources" ini="Engine" section="/Script/Sentry.SentrySettings" property="IncludeSources" default="false" />
+
+        <setStringFromProperty result="enabledBuildPlatforms" ini="Engine" section="/Script/Sentry.SentrySettings" property="EnableBuildPlatforms" default=""/>
+        <setStringFromProperty result="enabledBuildConfigurations" ini="Engine" section="/Script/Sentry.SentrySettings" property="EnableBuildConfigurations" default=""/>
+        <setStringFromProperty result="enabledBuildTargetTypes" ini="Engine" section="/Script/Sentry.SentrySettings" property="EnableBuildTargets" default=""/>
+        
+        <setBoolContains result="bCurrentPlatformDisabled" source="$S(enabledBuildPlatforms)" find="bEnableAndroid=False"/>
+        <setBoolContains result="bCurrentConfigurationDisabled" source="$S(enabledBuildConfigurations)" find="bEnable$S(Configuration)=False"/>
+
+        <setBoolOr result="bSkipUpload" arg1="$B(bCurrentPlatformDisabled)" arg2="$B(bCurrentConfigurationDisabled)"/>
+
+        <if condition="bSkipUpload">
+            <true>
+                <setBool result="bUploadSymbols" value="false"/>
+            </true>
+            <false>
+                <setBool result="bUploadSymbols" value="$B(bUploadSymbolsAutomatically)"/>
+            </false>
+        </if>
     </init>
 
     <prebuildCopies>


### PR DESCRIPTION
This PR makes symbol-uploading scripts respect plugin settings which determine for what platforms/configurations/targets it's enabled.

Closes #395