### PR TITLE
Fix issue with overwriting `__sentry` attribute in crash context object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fix issue with overwriting `__sentry` attribute in crash context object ([#401](https://github.com/getsentry/sentry-unreal/pull/401))
+
 ## 0.11.0
 
 ### Fixes
@@ -12,15 +16,12 @@
 
 ### Dependencies
 
-- Bump Cocoa SDK (iOS) from v8.11.0 to v8.12.0 ([#386](https://github.com/getsentry/sentry-unreal/pull/386))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8120)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.11.0...8.12.0)
+- Bump Cocoa SDK (iOS) from v8.11.0 to v8.13.0 ([#386](https://github.com/getsentry/sentry-unreal/pull/386), [#392](https://github.com/getsentry/sentry-unreal/pull/392))
+  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8130)
+  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.11.0...8.13.0)
 - Bump CLI from v2.20.7 to v2.21.2 ([#389](https://github.com/getsentry/sentry-unreal/pull/389), [#391](https://github.com/getsentry/sentry-unreal/pull/391), [#400](https://github.com/getsentry/sentry-unreal/pull/400))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2212)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.20.7...2.21.2)
-- Bump Cocoa SDK (iOS) from v8.12.0 to v8.13.0 ([#392](https://github.com/getsentry/sentry-unreal/pull/392))
-  - [changelog](https://github.com/getsentry/sentry-cocoa/blob/main/CHANGELOG.md#8130)
-  - [diff](https://github.com/getsentry/sentry-cocoa/compare/8.12.0...8.13.0)
 - Bump Java SDK (Android) from v6.29.0 to v6.30.0 ([#396](https://github.com/getsentry/sentry-unreal/pull/396))
   - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#6300)
   - [diff](https://github.com/getsentry/sentry-java/compare/6.29.0...6.30.0)

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
@@ -9,15 +9,18 @@
 
 #if USE_SENTRY_NATIVE
 
+FSentryCrashContext::FSentryCrashContext(const FSharedCrashContext& Context)
+	: FGenericCrashContext(Context.CrashType, Context.ErrorMessage)
+	, CrashContext(Context)
+{
+}
+
 FSentryCrashContext FSentryCrashContext::Get()
 {
 	FSharedCrashContext SharedCrashContext;
-	FGenericCrashContext::CopySharedCrashContext(SharedCrashContext);
+	CopySharedCrashContext(SharedCrashContext);
 
-	FSentryCrashContext SentryCrashContext;
-	SentryCrashContext.CrashContext = SharedCrashContext;
-
-	return SentryCrashContext;
+	return FSentryCrashContext(SharedCrashContext);
 }
 
 void FSentryCrashContext::Apply(TSharedPtr<SentryScopeDesktop> Scope)
@@ -55,12 +58,15 @@ void FSentryCrashContext::Apply(TSharedPtr<SentryScopeDesktop> Scope)
 
 FString FSentryCrashContext::GetGameData(const FString& Key)
 {
+	const FString* GameDataItem = nullptr;
+
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
-	const FString* GameDataItem = FGenericCrashContext::GetGameData().Find(Key);
-	return GameDataItem != nullptr ? *GameDataItem : FString();
+	GameDataItem = FGenericCrashContext::GetGameData().Find(Key);
 #else
-	return CrashContext.GetGameData(Key);
+	GameDataItem = FGenericCrashContext::GetGameData(Key);
 #endif
+
+	return GameDataItem != nullptr ? *GameDataItem : FString();
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
@@ -9,11 +9,6 @@
 
 #if USE_SENTRY_NATIVE
 
-FSentryCrashContext::FSentryCrashContext()
-	: CrashContext()
-{
-}
-
 FSentryCrashContext FSentryCrashContext::Get()
 {
 	FSharedCrashContext SharedCrashContext;

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
@@ -22,7 +22,7 @@ FSentryCrashContext::FSentryCrashContext(const FSharedCrashContext& Context)
 FSentryCrashContext FSentryCrashContext::Get()
 {
 	FSharedCrashContext SharedCrashContext;
-	CopySharedCrashContext(SharedCrashContext);
+	FGenericCrashContext::CopySharedCrashContext(SharedCrashContext);
 
 	return FSentryCrashContext(SharedCrashContext);
 }

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
@@ -10,8 +10,12 @@
 #if USE_SENTRY_NATIVE
 
 FSentryCrashContext::FSentryCrashContext(const FSharedCrashContext& Context)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
+	: CrashContext(Context)
+#else
 	: FGenericCrashContext(Context.CrashType, Context.ErrorMessage)
 	, CrashContext(Context)
+#endif
 {
 }
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.h
@@ -17,6 +17,8 @@ struct FSentryCrashContext
 struct FSentryCrashContext : public FGenericCrashContext
 #endif
 {
+	FSentryCrashContext(const FSharedCrashContext& Context);
+
 public:
 	static FSentryCrashContext Get();
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.h
@@ -12,13 +12,11 @@
 class SentryScopeDesktop;
 
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
-class FSentryCrashContext
+struct FSentryCrashContext
 #else
-class FSentryCrashContext : public FGenericCrashContext
+struct FSentryCrashContext : public FGenericCrashContext
 #endif
 {
-	FSentryCrashContext();
-
 public:
 	static FSentryCrashContext Get();
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.h
@@ -1,19 +1,30 @@
-﻿#pragma once
+﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+
+#pragma once
 
 #include "CoreMinimal.h"
 
+#include "Runtime/Launch/Resources/Version.h"
 #include "GenericPlatform/GenericPlatformCrashContext.h"
 
 #if USE_SENTRY_NATIVE
 
 class SentryScopeDesktop;
 
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 class FSentryCrashContext
+#else
+class FSentryCrashContext : public FGenericCrashContext
+#endif
 {
+	FSentryCrashContext();
+
 public:
-	FSentryCrashContext(const FSharedCrashContext& Context);
+	static FSentryCrashContext Get();
 
 	void Apply(TSharedPtr<SentryScopeDesktop> Scope);
+
+	FString GetGameData(const FString& Key);
 
 private:
 	FSharedCrashContext CrashContext;

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashReporter.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashReporter.cpp
@@ -21,7 +21,7 @@ SentryCrashReporter::SentryCrashReporter()
 	if(!sentryData.IsEmpty())
 	{
 		const TSharedRef<TJsonReader<>> jsonReader = TJsonReaderFactory<>::Create(*sentryData);
-		if (FJsonSerializer::Deserialize(jsonReader, crashReporterConfig) && crashReporterConfig.IsValid())
+		if (!FJsonSerializer::Deserialize(jsonReader, crashReporterConfig) && crashReporterConfig.IsValid())
 		{
 			UE_LOG(LogSentrySdk, Log, TEXT("Faield to deserialize `__sentry` data stored in crash context object: %s"), *FString(sentryData));
 		}

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashReporter.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashReporter.cpp
@@ -80,8 +80,19 @@ void SentryCrashReporter::SetContext(const FString& key, const TMap<FString, FSt
 		valuesConfig->SetStringField(it.Key(), it.Value());
 	}
 
-	TSharedPtr<FJsonObject> contextConfig = MakeShareable(new FJsonObject);
-	contextConfig->SetObjectField(key, valuesConfig);
+	TSharedPtr<FJsonObject> contextConfig;
+
+	if(crashReporterConfig->HasField(TEXT("contexts")))
+	{
+		contextConfig = crashReporterConfig->GetObjectField(TEXT("contexts"));
+		contextConfig->SetObjectField(key, valuesConfig);
+	}
+	else
+	{
+		contextConfig = MakeShareable(new FJsonObject);
+		contextConfig->SetObjectField(key, valuesConfig);
+		crashReporterConfig->SetObjectField(TEXT("contexts"), contextConfig);
+	}
 
 	crashReporterConfig->SetObjectField(TEXT("contexts"), contextConfig);
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashReporter.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashReporter.cpp
@@ -1,8 +1,11 @@
 // Copyright (c) 2022 Sentry. All Rights Reserved.
 
 #include "SentryCrashReporter.h"
+#include "SentryCrashContext.h"
 
 #include "SentryUser.h"
+#include "SentryDefines.h"
+
 #include "Dom/JsonObject.h"
 #include "Serialization/JsonSerializer.h"
 
@@ -13,6 +16,16 @@
 SentryCrashReporter::SentryCrashReporter()
 {
 	crashReporterConfig = MakeShareable(new FJsonObject);
+
+	const FString sentryData = FSentryCrashContext::Get().GetGameData(TEXT("__sentry"));
+	if(!sentryData.IsEmpty())
+	{
+		const TSharedRef<TJsonReader<>> jsonReader = TJsonReaderFactory<>::Create(*sentryData);
+		if (FJsonSerializer::Deserialize(jsonReader, crashReporterConfig) && crashReporterConfig.IsValid())
+		{
+			UE_LOG(LogSentrySdk, Log, TEXT("Faield to deserialize `__sentry` data stored in crash context object: %s"), *FString(sentryData));
+		}
+	}
 }
 
 void SentryCrashReporter::SetRelease(const FString& release)

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -57,10 +57,7 @@ sentry_value_t HandleBeforeCrash(const sentry_ucontext_t *uctx, sentry_value_t e
 {
 	SentrySubsystemDesktop* SentrySubsystem = static_cast<SentrySubsystemDesktop*>(closure);
 
-	FSharedCrashContext SharedCrashContext;
-	FGenericCrashContext::CopySharedCrashContext(SharedCrashContext);
-
-	FSentryCrashContext SentryCrashContext = FSentryCrashContext(SharedCrashContext);
+	FSentryCrashContext SentryCrashContext = FSentryCrashContext::Get();
 	SentryCrashContext.Apply(SentrySubsystem->GetCurrentScope());
 
 	return HandleBeforeSend(event, nullptr, closure);

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -57,8 +57,7 @@ sentry_value_t HandleBeforeCrash(const sentry_ucontext_t *uctx, sentry_value_t e
 {
 	SentrySubsystemDesktop* SentrySubsystem = static_cast<SentrySubsystemDesktop*>(closure);
 
-	FSentryCrashContext SentryCrashContext = FSentryCrashContext::Get();
-	SentryCrashContext.Apply(SentrySubsystem->GetCurrentScope());
+	FSentryCrashContext::Get().Apply(SentrySubsystem->GetCurrentScope());
 
 	return HandleBeforeSend(event, nullptr, closure);
 }


### PR DESCRIPTION
Closes #379 