### PR TITLE
Fix crash capturing issue on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix issue with overwriting `__sentry` attribute in crash context object ([#401](https://github.com/getsentry/sentry-unreal/pull/401))
+- Fix crash capturing issue on Linux ([#410](https://github.com/getsentry/sentry-unreal/pull/410))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Unreleased
 
 - Fix issue with overwriting `__sentry` attribute in crash context object ([#401](https://github.com/getsentry/sentry-unreal/pull/401))
-- Fix crash capturing issue on Linux ([#410](https://github.com/getsentry/sentry-unreal/pull/410))
+- Fix stack corruption during crash capturing within `on_crash` hook handler on Linux ([#410](https://github.com/getsentry/sentry-unreal/pull/410))
 
 ### Dependencies
 
@@ -98,7 +98,7 @@
 ### Fixes
 
 - Fix automatic game log attachment (Android) ([#309](https://github.com/getsentry/sentry-unreal/pull/309))
-  
+
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.cpp
@@ -13,7 +13,7 @@ FSentryCrashContext::FSentryCrashContext(TSharedPtr<FSharedCrashContext> Context
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 	: CrashContext(Context)
 #else
-	: FGenericCrashContext(Context.CrashType, Context.ErrorMessage)
+	: FGenericCrashContext(Context->CrashType, Context->ErrorMessage)
 	, CrashContext(Context)
 #endif
 {

--- a/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/CrashReporter/SentryCrashContext.h
@@ -17,7 +17,7 @@ struct FSentryCrashContext
 struct FSentryCrashContext : public FGenericCrashContext
 #endif
 {
-	FSentryCrashContext(const FSharedCrashContext& Context);
+	FSentryCrashContext(TSharedPtr<FSharedCrashContext> Context);
 
 public:
 	static FSentryCrashContext Get();
@@ -27,7 +27,7 @@ public:
 	FString GetGameData(const FString& Key);
 
 private:
-	FSharedCrashContext CrashContext;
+	TSharedPtr<FSharedCrashContext> CrashContext;
 };
 
 #endif

--- a/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp
+++ b/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp
@@ -2,19 +2,12 @@
 
 void USentryPlaygroundUtils::Crash()
 {
-	UE_LOG(LogTemp, Log, TEXT("USentryPlaygroundUtils::Crash() utility function called!"));
-
-	// Supressing warnings for when using warnings as errors on the target. 
-	#pragma warning(suppress: 6011)	
-	char *ptr = 0;
-	#pragma warning(suppress: 6011)
+	volatile char *ptr = 0;
 	*ptr += 1;
 }
 
 void USentryPlaygroundUtils::Assert()
 {
-	UE_LOG(LogTemp, Log, TEXT("USentryPlaygroundUtils::Assert() utility function called!"));
-
 	char *ptr = nullptr;
 	check(ptr != nullptr);
 }

--- a/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp
+++ b/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp
@@ -2,6 +2,8 @@
 
 void USentryPlaygroundUtils::Crash()
 {
+	UE_LOG(LogTemp, Log, TEXT("USentryPlaygroundUtils::Crash() utility function called!"));
+
 	// Supressing warnings for when using warnings as errors on the target. 
 	#pragma warning(suppress: 6011)	
 	char *ptr = 0;
@@ -11,6 +13,8 @@ void USentryPlaygroundUtils::Crash()
 
 void USentryPlaygroundUtils::Assert()
 {
+	UE_LOG(LogTemp, Log, TEXT("USentryPlaygroundUtils::Assert() utility function called!"));
+
 	char *ptr = nullptr;
 	check(ptr != nullptr);
 }


### PR DESCRIPTION
This PR addresses the issue with crash reports not being uploaded to Sentry when `on_crash` hook is set during the `sentry-native` initialization on Linux. Whenever a crash occurs new instance of `FSharedCrashContext` struct is allocated on the signal's handler stack which might lead to its overflow and further corruption. Moving the crash context allocation to the heap instead resolves the problem and handler is able to process the captured event properly.