### PR TITLE
Fix event level on Win/Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Fix issue with overwriting `__sentry` attribute in crash context object ([#401](https://github.com/getsentry/sentry-unreal/pull/401))
+- Fix event level being always overwritten by the current scope's level on Win/Linux ([#412](https://github.com/getsentry/sentry-unreal/pull/412))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
@@ -172,10 +172,12 @@ void SentryScopeDesktop::Apply(USentryEvent* event)
 
 	sentry_value_t nativeEvent = eventDesktop->GetNativeObject();
 
-	FString levelStr = SentryConvertorsDesktop::SentryLevelToString(LevelDesktop).ToLower();
-	if (!levelStr.IsEmpty())
+	sentry_value_t eventLevel = sentry_value_get_by_key(nativeEvent, "level");
+
+	FString scopeLevelStr = SentryConvertorsDesktop::SentryLevelToString(LevelDesktop).ToLower();
+	if (!scopeLevelStr.IsEmpty() && sentry_value_is_null(eventLevel))
 	{
-		sentry_value_set_by_key(nativeEvent, "level", sentry_value_new_string(TCHAR_TO_ANSI(*levelStr)));
+		sentry_value_set_by_key(nativeEvent, "level", sentry_value_new_string(TCHAR_TO_ANSI(*scopeLevelStr)));
 	}
 
 	if(!Dist.IsEmpty())

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -26,11 +26,6 @@ USentryEvent::USentryEvent()
 	}
 }
 
-USentryEvent* USentryEvent::CreateEmptyEvent()
-{
-	return NewObject<USentryEvent>();
-}
-
 USentryEvent* USentryEvent::CreateEventWithMessageAndLevel(const FString& Message, ESentryLevel Level)
 {
 	USentryEvent* Event = NewObject<USentryEvent>();

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -36,7 +36,9 @@ USentryEvent* USentryEvent::CreateEventWithMessageAndLevel(const FString& Messag
 	USentryEvent* Event = NewObject<USentryEvent>();
 
 	if(!Message.IsEmpty())
+	{
 		Event->SetMessage(Message);
+	}
 
 	Event->SetLevel(Level);
 

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -26,6 +26,23 @@ USentryEvent::USentryEvent()
 	}
 }
 
+USentryEvent* USentryEvent::CreateEmptyEvent()
+{
+	return NewObject<USentryEvent>();
+}
+
+USentryEvent* USentryEvent::CreateEventWithMessageAndLevel(const FString& Message, ESentryLevel Level)
+{
+	USentryEvent* Event = NewObject<USentryEvent>();
+
+	if(!Message.IsEmpty())
+		Event->SetMessage(Message);
+
+	Event->SetLevel(Level);
+
+	return Event;
+}
+
 void USentryEvent::SetMessage(const FString& Message)
 {
 	if (!EventNativeImpl)

--- a/plugin-dev/Source/Sentry/Public/SentryEvent.h
+++ b/plugin-dev/Source/Sentry/Public/SentryEvent.h
@@ -19,10 +19,6 @@ class SENTRY_API USentryEvent : public UObject
 public:
 	USentryEvent();
 
-	/** Creates the empty event. */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	static USentryEvent* CreateEmptyEvent();
-
 	/**
 	 * Creates the event with specified message and level.
 	 *

--- a/plugin-dev/Source/Sentry/Public/SentryEvent.h
+++ b/plugin-dev/Source/Sentry/Public/SentryEvent.h
@@ -19,6 +19,19 @@ class SENTRY_API USentryEvent : public UObject
 public:
 	USentryEvent();
 
+	/** Creates the empty event. */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	static USentryEvent* CreateEmptyEvent();
+
+	/**
+	 * Creates the event with specified message and level.
+	 *
+	 * @param Message Message to sent.
+	 * @param Level Level of the event.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	static USentryEvent* CreateEventWithMessageAndLevel(const FString& Message, ESentryLevel Level);
+
 	/** Sets message of the event. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
 	void SetMessage(const FString& Message);

--- a/plugin-dev/Source/Sentry/Public/SentryLibrary.h
+++ b/plugin-dev/Source/Sentry/Public/SentryLibrary.h
@@ -30,7 +30,8 @@ public:
 	 * @param Message Message to sent.
 	 * @param Level Level of the event.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	UFUNCTION(BlueprintCallable, Category = "Sentry",
+		Meta = (DeprecatedFunction, DeprecationMessage="Function has been deprecated. Use SentryEvent CreateEventWithMessageAndLevel instead"))
 	static USentryEvent* CreateSentryEvent(const FString& Message, ESentryLevel Level);
 
 	/**
@@ -42,7 +43,7 @@ public:
 	 * @param IpAddress IP address of the user.
 	 * @param Data Additional arbitrary fields related to the user.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Sentry", meta = (AutoCreateRefTerm = "Data"))
+	UFUNCTION(BlueprintCallable, Category = "Sentry", Meta = (AutoCreateRefTerm = "Data"))
 	static USentryUser* CreateSentryUser(const FString& Email, const FString& Id, const FString& Username, const FString& IpAddress,
 		const TMap<FString, FString>& Data);
 
@@ -66,7 +67,7 @@ public:
 	 * @param Data Data associated with the breadcrumb.
 	 * @param Level Level of the breadcrumb.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Sentry", meta = (AutoCreateRefTerm = "Data"))
+	UFUNCTION(BlueprintCallable, Category = "Sentry", Meta = (AutoCreateRefTerm = "Data"))
 	static USentryBreadcrumb* CreateSentryBreadcrumb(const FString& Message, const FString& Type, const FString& Category,
 		const TMap<FString, FString>& Data, ESentryLevel Level = ESentryLevel::Info);
 


### PR DESCRIPTION
This PR addresses the issue with events' level always being overwritten by a current scope's level (`Debug` by default) on Win/Linux. Now scope's level is applied only to the events that don't have this property set, otherwise events' level remains unchanged.

Also, the convenience function for creating event objects was mo moved to the `USentryEvent` class + function allowing to create an empty event (without a pre-set level) was added.

Closes #409 