### PR TITLE
Fix iOS build errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix invalid breadcrumbs level for Win/Linux ([#426](https://github.com/getsentry/sentry-unreal/pull/426))
+- Fix iOS build errors ([#429](https://github.com/getsentry/sentry-unreal/pull/429))
 
 ## 0.12.1
 

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -74,6 +74,7 @@ public class Sentry : ModuleRules
 			AdditionalPropertiesForReceipt.Add("IOSPlugin", Path.Combine(PluginPath, "Sentry_IOS_UPL.xml"));
 
 			PublicDefinitions.Add("COCOAPODS=0");
+			PublicDefinitions.Add("SENTRY_NO_UIKIT=1");
 		}
 
 		// Additional routine for Android


### PR DESCRIPTION
This addresses build errors that arised presumably after merging #417  (UIKit linking)