### PR TITLE
Fix issue with invalidating breadcrumbs during event capturing on Win/Linux 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix issue with invalidating breadcrumbs during event capturing on Win/Linux ([#445](https://github.com/getsentry/sentry-unreal/pull/445))
+
 ### Dependencies
 
 - Bump Java SDK (Android) from v6.33.0 to v6.33.1 ([#435](https://github.com/getsentry/sentry-unreal/pull/435))

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
@@ -260,16 +260,20 @@ void SentryScopeDesktop::Apply(USentryEvent* event)
 
 			for (const auto& Breadcrumb : BreadcrumbsDesktop)
 			{
-				sentry_value_append(eventBreadcrumbs, Breadcrumb->GetNativeObject());
+				sentry_value_t nativeBreadcrumb = Breadcrumb->GetNativeObject();
+				sentry_value_incref(nativeBreadcrumb);
+				sentry_value_append(eventBreadcrumbs, nativeBreadcrumb);
 			}
-
+	
 			sentry_value_set_by_key(nativeEvent, "breadcrumbs", eventBreadcrumbs);
 		}
 		else
 		{
 			for (const auto& Breadcrumb : BreadcrumbsDesktop)
 			{
-				sentry_value_append(eventBreadcrumbs, Breadcrumb->GetNativeObject());
+				sentry_value_t nativeBreadcrumb = Breadcrumb->GetNativeObject();
+				sentry_value_incref(nativeBreadcrumb);
+				sentry_value_append(eventBreadcrumbs, nativeBreadcrumb);
 			}
 		}
 	}


### PR DESCRIPTION
Scope was transferring ownership of existing breadcrumbs to captured events which led to their pre-mature invalidation and random crashes later.

Closes #418 