### PR TITLE
Fix build errors on Mac when using UE Marketplace plugin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix issue with invalidating breadcrumbs during event capturing on Win/Linux ([#445](https://github.com/getsentry/sentry-unreal/pull/445))
+- Fix build errors on Mac when using UE Marketplace plugin version ([#451](https://github.com/getsentry/sentry-unreal/pull/451))
 
 ### Dependencies
 

--- a/plugin-dev/Sentry.uplugin
+++ b/plugin-dev/Sentry.uplugin
@@ -31,6 +31,7 @@
 	"PostBuildSteps":
 	{
 		"Mac": [
+			"if [ $(TargetPlatform) = \"Mac\" ] && [ ! -f \"$(PluginDir)/Binaries/Mac/sentry.dylib\" ]; then\n cp \"$(PluginDir)/Source/ThirdParty/Mac/bin/sentry.dylib\" \"$(PluginDir)/Binaries/Mac/sentry.dylib\"\nfi",
 			"if [ -f \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" ]; then\n sh \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" $(TargetPlatform) $(TargetName) $(TargetType) $(TargetConfiguration) \"$(ProjectDir)\" \"$(PluginDir)\"\nelse\n echo \"Sentry: Symbol upload script is missing. Skipping post build step.\"\nfi"
 		],
 		"Linux": [


### PR DESCRIPTION
This PR adds `sentry.dylib` copying to the `Binaries` directory as a post-build step when packaging the game for Mac using the UE Marketplace plugin version.

Closes #446 