### PR TITLE
Fix casing in include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 ### Fixes
 
 - Fix Linux intermediates paths in `FilterPlugin.ini` ([#468](https://github.com/getsentry/sentry-unreal/pull/468))
+- Fix casing for include of HAL/PlatformFileManager for Linux compilation ([#468](https://github.com/getsentry/sentry-unreal/pull/499))
 
 ### Dependencies
 

--- a/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
@@ -6,7 +6,7 @@
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
 #include "Interfaces/IPluginManager.h"
-#include "HAL/PlatformFileManager.h"
+#include "HAL/PlatformFilemanager.h"
 #include "GenericPlatform/GenericPlatformFile.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"

--- a/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
@@ -6,7 +6,11 @@
 #include "Interfaces/IHttpRequest.h"
 #include "Interfaces/IHttpResponse.h"
 #include "Interfaces/IPluginManager.h"
+#if ENGINE_MAJOR_VERSION >= 5
+#include "HAL/PlatformFileManager.h"
+#else
 #include "HAL/PlatformFilemanager.h"
+#endif
 #include "GenericPlatform/GenericPlatformFile.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"


### PR DESCRIPTION
For some reason this particular file has inconsistent casing with the rest of the files in the UE4 codebase and Linux is obviously case sensitive, so this causes build failures.

I've updated the include to match the casing of the actual file from UE4