### PR TITLE
Fix event's message get/set methods for desktop

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryEventDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryEventDesktop.cpp
@@ -29,12 +29,15 @@ sentry_value_t SentryEventDesktop::GetNativeObject()
 
 void SentryEventDesktop::SetMessage(const FString& message)
 {
-	sentry_value_set_by_key(EventDesktop, "message", sentry_value_new_string(TCHAR_TO_ANSI(*message)));
+	sentry_value_t messageСontainer = sentry_value_new_object();
+	sentry_value_set_by_key(messageСontainer, "formatted", sentry_value_new_string(TCHAR_TO_ANSI(*message)));
+	sentry_value_set_by_key(EventDesktop, "message", messageСontainer);
 }
 
 FString SentryEventDesktop::GetMessage() const
 {
-	sentry_value_t message = sentry_value_get_by_key(EventDesktop, "message");
+	sentry_value_t messageСontainer = sentry_value_get_by_key(EventDesktop, "message");
+	sentry_value_t message = sentry_value_get_by_key(messageСontainer, "formatted");
 	return FString(sentry_value_as_string(message));
 }
 


### PR DESCRIPTION
This PR fixes an issue where the `beforeSend` handler returned an empty message string for events created with `sentry_value_new_message_event`. It ensures that the actual message string is included in the `formatted` child node of the `message` object for these events.

Closes #504 