### PR TITLE
Implement not dynamic delegate for ConfigureScope #511

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Android/Callbacks/SentryScopeCallbackAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Callbacks/SentryScopeCallbackAndroid.cpp
@@ -10,7 +10,7 @@ USentryScopeCallbackAndroid::USentryScopeCallbackAndroid()
 	}
 }
 
-void USentryScopeCallbackAndroid::BindDelegate(const FConfigureScopeDelegate& OnConfigure)
+void USentryScopeCallbackAndroid::BindDelegate(const FConfigureScopeNativeDelegate& OnConfigure)
 {
 	OnConfigureDelegate = OnConfigure;
 }

--- a/plugin-dev/Source/Sentry/Private/Android/Callbacks/SentryScopeCallbackAndroid.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Callbacks/SentryScopeCallbackAndroid.h
@@ -20,6 +20,5 @@ public:
 	void ExecuteDelegate(USentryScope* Scope);
 
 private:
-	UPROPERTY()
 	FConfigureScopeDelegate OnConfigureDelegate;
 };

--- a/plugin-dev/Source/Sentry/Private/Android/Callbacks/SentryScopeCallbackAndroid.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Callbacks/SentryScopeCallbackAndroid.h
@@ -16,9 +16,9 @@ class USentryScopeCallbackAndroid : public UObject
 public:
 	USentryScopeCallbackAndroid();
 
-	void BindDelegate(const FConfigureScopeDelegate& OnConfigure);
+	void BindDelegate(const FConfigureScopeNativeDelegate& OnConfigure);
 	void ExecuteDelegate(USentryScope* Scope);
 
 private:
-	FConfigureScopeDelegate OnConfigureDelegate;
+	FConfigureScopeNativeDelegate OnConfigureDelegate;
 };

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
@@ -122,7 +122,7 @@ USentryId* SentrySubsystemAndroid::CaptureMessage(const FString& message, ESentr
 	return SentryConvertorsAndroid::SentryIdToUnreal(*id);
 }
 
-USentryId* SentrySubsystemAndroid::CaptureMessageWithScope(const FString& message, const FConfigureScopeDelegate& onConfigureScope, ESentryLevel level)
+USentryId* SentrySubsystemAndroid::CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onConfigureScope, ESentryLevel level)
 {
 	USentryScopeCallbackAndroid* scopeCallback = NewObject<USentryScopeCallbackAndroid>();
 	scopeCallback->BindDelegate(onConfigureScope);
@@ -143,7 +143,7 @@ USentryId* SentrySubsystemAndroid::CaptureEvent(USentryEvent* event)
 	return SentryConvertorsAndroid::SentryIdToUnreal(*id);
 }
 
-USentryId* SentrySubsystemAndroid::CaptureEventWithScope(USentryEvent* event, const FConfigureScopeDelegate& onConfigureScope)
+USentryId* SentrySubsystemAndroid::CaptureEventWithScope(USentryEvent* event, const FConfigureScopeNativeDelegate& onConfigureScope)
 {
 	TSharedPtr<SentryEventAndroid> eventAndroid = StaticCastSharedPtr<SentryEventAndroid>(event->GetNativeImpl());
 
@@ -177,7 +177,7 @@ void SentrySubsystemAndroid::RemoveUser()
 	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::Sentry, "setUser", "(Lio/sentry/protocol/User;)V", nullptr);
 }
 
-void SentrySubsystemAndroid::ConfigureScope(const FConfigureScopeDelegate& onConfigureScope)
+void SentrySubsystemAndroid::ConfigureScope(const FConfigureScopeNativeDelegate& onConfigureScope)
 {
 	USentryScopeCallbackAndroid* scopeCallback = NewObject<USentryScopeCallbackAndroid>();
 	scopeCallback->BindDelegate(onConfigureScope);

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.h
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.h
@@ -14,13 +14,13 @@ public:
 	virtual void AddBreadcrumb(USentryBreadcrumb* breadcrumb) override;
 	virtual void ClearBreadcrumbs() override;
 	virtual USentryId* CaptureMessage(const FString& message, ESentryLevel level) override;
-	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeDelegate& onConfigureScope, ESentryLevel level) override;
+	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onConfigureScope, ESentryLevel level) override;
 	virtual USentryId* CaptureEvent(USentryEvent* event) override;
-	virtual USentryId* CaptureEventWithScope(USentryEvent* event, const FConfigureScopeDelegate& onConfigureScope) override;
+	virtual USentryId* CaptureEventWithScope(USentryEvent* event, const FConfigureScopeNativeDelegate& onConfigureScope) override;
 	virtual void CaptureUserFeedback(USentryUserFeedback* userFeedback) override;
 	virtual void SetUser(USentryUser* user) override;
 	virtual void RemoveUser() override;
-	virtual void ConfigureScope(const FConfigureScopeDelegate& onConfigureScope) override;
+	virtual void ConfigureScope(const FConfigureScopeNativeDelegate& onConfigureScope) override;
 	virtual void SetContext(const FString& key, const TMap<FString, FString>& values) override;
 	virtual void SetTag(const FString& key, const FString& value) override;
 	virtual void RemoveTag(const FString& key) override;

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
@@ -128,7 +128,7 @@ USentryId* SentrySubsystemApple::CaptureMessage(const FString& message, ESentryL
 	return SentryConvertorsApple::SentryIdToUnreal(id);
 }
 
-USentryId* SentrySubsystemApple::CaptureMessageWithScope(const FString& message, const FConfigureScopeDelegate& onConfigureScope, ESentryLevel level)
+USentryId* SentrySubsystemApple::CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onConfigureScope, ESentryLevel level)
 {
 	SentryId* id = [SENTRY_APPLE_CLASS(SentrySDK) captureMessage:message.GetNSString() withScopeBlock:^(SentryScope* scope){
 		[scope setLevel:SentryConvertorsApple::SentryLevelToNative(level)];
@@ -146,7 +146,7 @@ USentryId* SentrySubsystemApple::CaptureEvent(USentryEvent* event)
 	return SentryConvertorsApple::SentryIdToUnreal(id);
 }
 
-USentryId* SentrySubsystemApple::CaptureEventWithScope(USentryEvent* event, const FConfigureScopeDelegate& onConfigureScope)
+USentryId* SentrySubsystemApple::CaptureEventWithScope(USentryEvent* event, const FConfigureScopeNativeDelegate& onConfigureScope)
 {
 	TSharedPtr<SentryEventApple> eventIOS = StaticCastSharedPtr<SentryEventApple>(event->GetNativeImpl());
 
@@ -176,7 +176,7 @@ void SentrySubsystemApple::RemoveUser()
 	[SENTRY_APPLE_CLASS(SentrySDK) setUser:nil];
 }
 
-void SentrySubsystemApple::ConfigureScope(const FConfigureScopeDelegate& onConfigureScope)
+void SentrySubsystemApple::ConfigureScope(const FConfigureScopeNativeDelegate& onConfigureScope)
 {
 	[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
 		onConfigureScope.ExecuteIfBound(SentryConvertorsApple::SentryScopeToUnreal(scope));

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.h
@@ -14,13 +14,13 @@ public:
 	virtual void AddBreadcrumb(USentryBreadcrumb* breadcrumb) override;
 	virtual void ClearBreadcrumbs() override;
 	virtual USentryId* CaptureMessage(const FString& message, ESentryLevel level) override;
-	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeDelegate& onConfigureScope, ESentryLevel level) override;
+	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onConfigureScope, ESentryLevel level) override;
 	virtual USentryId* CaptureEvent(USentryEvent* event) override;
-	virtual USentryId* CaptureEventWithScope(USentryEvent* event, const FConfigureScopeDelegate& onConfigureScope) override;
+	virtual USentryId* CaptureEventWithScope(USentryEvent* event, const FConfigureScopeNativeDelegate& onConfigureScope) override;
 	virtual void CaptureUserFeedback(USentryUserFeedback* userFeedback) override;
 	virtual void SetUser(USentryUser* user) override;
 	virtual void RemoveUser() override;
-	virtual void ConfigureScope(const FConfigureScopeDelegate& onConfigureScope) override;
+	virtual void ConfigureScope(const FConfigureScopeNativeDelegate& onConfigureScope) override;
 	virtual void SetContext(const FString& key, const TMap<FString, FString>& values) override;
 	virtual void SetTag(const FString& key, const FString& value) override;
 	virtual void RemoveTag(const FString& key) override;

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -231,7 +231,7 @@ USentryId* SentrySubsystemDesktop::CaptureMessage(const FString& message, ESentr
 	return SentryConvertorsDesktop::SentryIdToUnreal(id);
 }
 
-USentryId* SentrySubsystemDesktop::CaptureMessageWithScope(const FString& message, const FConfigureScopeDelegate& onScopeConfigure, ESentryLevel level)
+USentryId* SentrySubsystemDesktop::CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onScopeConfigure, ESentryLevel level)
 {
 	FScopeLock Lock(&CriticalSection);
 
@@ -264,7 +264,7 @@ USentryId* SentrySubsystemDesktop::CaptureEvent(USentryEvent* event)
 	return SentryConvertorsDesktop::SentryIdToUnreal(id);
 }
 
-USentryId* SentrySubsystemDesktop::CaptureEventWithScope(USentryEvent* event, const FConfigureScopeDelegate& onScopeConfigure)
+USentryId* SentrySubsystemDesktop::CaptureEventWithScope(USentryEvent* event, const FConfigureScopeNativeDelegate& onScopeConfigure)
 {
 	FScopeLock Lock(&CriticalSection);
 
@@ -303,7 +303,7 @@ void SentrySubsystemDesktop::RemoveUser()
 	crashReporter->RemoveUser();
 }
 
-void SentrySubsystemDesktop::ConfigureScope(const FConfigureScopeDelegate& onConfigureScope)
+void SentrySubsystemDesktop::ConfigureScope(const FConfigureScopeNativeDelegate& onConfigureScope)
 {
 	USentryScope* Scope = NewObject<USentryScope>();
 	Scope->InitWithNativeImpl(GetCurrentScope());

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
@@ -23,13 +23,13 @@ public:
 	virtual void AddBreadcrumb(USentryBreadcrumb* breadcrumb) override;
 	virtual void ClearBreadcrumbs() override;
 	virtual USentryId* CaptureMessage(const FString& message, ESentryLevel level) override;
-	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeDelegate& onScopeConfigure, ESentryLevel level) override;
+	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onScopeConfigure, ESentryLevel level) override;
 	virtual USentryId* CaptureEvent(USentryEvent* event) override;
-	virtual USentryId* CaptureEventWithScope(USentryEvent* event, const FConfigureScopeDelegate& onScopeConfigure) override;
+	virtual USentryId* CaptureEventWithScope(USentryEvent* event, const FConfigureScopeNativeDelegate& onScopeConfigure) override;
 	virtual void CaptureUserFeedback(USentryUserFeedback* userFeedback) override;
 	virtual void SetUser(USentryUser* user) override;
 	virtual void RemoveUser() override;
-	virtual void ConfigureScope(const FConfigureScopeDelegate& onConfigureScope) override;
+	virtual void ConfigureScope(const FConfigureScopeNativeDelegate& onConfigureScope) override;
 	virtual void SetContext(const FString& key, const TMap<FString, FString>& values) override;
 	virtual void SetTag(const FString& key, const FString& value) override;
 	virtual void RemoveTag(const FString& key) override;

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
@@ -30,13 +30,13 @@ public:
 	virtual void AddBreadcrumb(USentryBreadcrumb* breadcrumb) = 0;
 	virtual void ClearBreadcrumbs() = 0;
 	virtual USentryId* CaptureMessage(const FString& message, ESentryLevel level) = 0;
-	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeDelegate& onConfigureScope, ESentryLevel level) = 0;
+	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onConfigureScope, ESentryLevel level) = 0;
 	virtual USentryId* CaptureEvent(USentryEvent* event) = 0;
-	virtual USentryId* CaptureEventWithScope(USentryEvent* event, const FConfigureScopeDelegate& onConfigureScope) = 0;
+	virtual USentryId* CaptureEventWithScope(USentryEvent* event, const FConfigureScopeNativeDelegate& onConfigureScope) = 0;
 	virtual void CaptureUserFeedback(USentryUserFeedback* userFeedback) = 0;
 	virtual void SetUser(USentryUser* user) = 0;
 	virtual void RemoveUser() = 0;
-	virtual void ConfigureScope(const FConfigureScopeDelegate& onConfigureScope) = 0;
+	virtual void ConfigureScope(const FConfigureScopeNativeDelegate& onConfigureScope) = 0;
 	virtual void SetContext(const FString& key, const TMap<FString, FString>& values) = 0;
 	virtual void SetTag(const FString& key, const FString& value) = 0;
 	virtual void RemoveTag(const FString& key) = 0;

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -200,14 +200,14 @@ USentryId* USentrySubsystem::CaptureMessage(const FString& Message, ESentryLevel
 	return SubsystemNativeImpl->CaptureMessage(Message, Level);
 }
 
-USentryId* USentrySubsystem::CaptureMessageWithScope(const FString& Message, const FConfigureScopeDynDelegate& OnConfigureScope, ESentryLevel Level)
+USentryId* USentrySubsystem::CaptureMessageWithScope(const FString& Message, const FConfigureScopeDelegate& OnConfigureScope, ESentryLevel Level)
 {
     return CaptureMessageWithScope(Message,
-        FConfigureScopeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()),
+        FConfigureScopeNativeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()),
         Level);
 }
 
-USentryId* USentrySubsystem::CaptureMessageWithScope(const FString& Message, const FConfigureScopeDelegate& OnConfigureScope, ESentryLevel Level)
+USentryId* USentrySubsystem::CaptureMessageWithScope(const FString& Message, const FConfigureScopeNativeDelegate& OnConfigureScope, ESentryLevel Level)
 {
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 		return nullptr;
@@ -223,13 +223,13 @@ USentryId* USentrySubsystem::CaptureEvent(USentryEvent* Event)
 	return SubsystemNativeImpl->CaptureEvent(Event);
 }
 
-USentryId* USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDynDelegate& OnConfigureScope)
+USentryId* USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDelegate& OnConfigureScope)
 {
     return CaptureEventWithScope(Event,
-        FConfigureScopeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()));
+        FConfigureScopeNativeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()));
 }
 
-USentryId* USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDelegate& OnConfigureScope)
+USentryId* USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeNativeDelegate& OnConfigureScope)
 {
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 		return nullptr;
@@ -272,12 +272,12 @@ void USentrySubsystem::RemoveUser()
 	SubsystemNativeImpl->RemoveUser();
 }
 
-void USentrySubsystem::ConfigureScope(const FConfigureScopeDynDelegate& OnConfigureScope)
+void USentrySubsystem::ConfigureScope(const FConfigureScopeDelegate& OnConfigureScope)
 {
-    ConfigureScope(FConfigureScopeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()));
+    ConfigureScope(FConfigureScopeNativeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()));
 }
 
-void USentrySubsystem::ConfigureScope(const FConfigureScopeDelegate& OnConfigureScope)
+void USentrySubsystem::ConfigureScope(const FConfigureScopeNativeDelegate& OnConfigureScope)
 {
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 		return;

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -186,12 +186,19 @@ USentryId* USentrySubsystem::CaptureMessage(const FString& Message, ESentryLevel
 	return SubsystemNativeImpl->CaptureMessage(Message, Level);
 }
 
+USentryId* USentrySubsystem::CaptureMessageWithScope(const FString& Message, const FConfigureScopeDynDelegate& OnConfigureScope, ESentryLevel Level)
+{
+    return CaptureMessageWithScope(Message,
+        FConfigureScopeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()),
+        Level);
+}
+
 USentryId* USentrySubsystem::CaptureMessageWithScope(const FString& Message, const FConfigureScopeDelegate& OnConfigureScope, ESentryLevel Level)
 {
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 		return nullptr;
 
-	return SubsystemNativeImpl->CaptureMessageWithScope(Message, OnConfigureScope, Level);
+    return SubsystemNativeImpl->CaptureMessageWithScope(Message, OnConfigureScope, Level);
 }
 
 USentryId* USentrySubsystem::CaptureEvent(USentryEvent* Event)
@@ -202,12 +209,18 @@ USentryId* USentrySubsystem::CaptureEvent(USentryEvent* Event)
 	return SubsystemNativeImpl->CaptureEvent(Event);
 }
 
+USentryId* USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDynDelegate& OnConfigureScope)
+{
+    return CaptureEventWithScope(Event,
+        FConfigureScopeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()));
+}
+
 USentryId* USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDelegate& OnConfigureScope)
 {
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 		return nullptr;
 
-	return SubsystemNativeImpl->CaptureEventWithScope(Event, OnConfigureScope);
+    return SubsystemNativeImpl->CaptureEventWithScope(Event, OnConfigureScope);
 }
 
 void USentrySubsystem::CaptureUserFeedback(USentryUserFeedback* UserFeedback)
@@ -245,12 +258,17 @@ void USentrySubsystem::RemoveUser()
 	SubsystemNativeImpl->RemoveUser();
 }
 
+void USentrySubsystem::ConfigureScope(const FConfigureScopeDynDelegate& OnConfigureScope)
+{
+    ConfigureScope(FConfigureScopeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()));
+}
+
 void USentrySubsystem::ConfigureScope(const FConfigureScopeDelegate& OnConfigureScope)
 {
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 		return;
 
-	SubsystemNativeImpl->ConfigureScope(OnConfigureScope);
+    SubsystemNativeImpl->ConfigureScope(OnConfigureScope);
 }
 
 void USentrySubsystem::SetContext(const FString& Key, const TMap<FString, FString>& Values)

--- a/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
@@ -38,7 +38,7 @@ void SentrySubsystemSpec::Define()
 
 		It("should always return non-null Event ID if scoped version used", [this]()
 		{
-			const FConfigureScopeDelegate testDelegate;
+			const FConfigureScopeNativeDelegate testDelegate;
 			const USentryId* eventId = SentrySubsystem->CaptureMessageWithScope(FString(TEXT("Automation: Sentry test message with scope")), testDelegate, ESentryLevel::Debug);
 			TestNotNull("Event ID is non-null", eventId);
 		});
@@ -60,7 +60,7 @@ void SentrySubsystemSpec::Define()
 			USentryEvent* testEvent = NewObject<USentryEvent>();
 			testEvent->SetMessage(TEXT("Automation: Sentry test event message"));
 
-			const FConfigureScopeDelegate testDelegate;
+			const FConfigureScopeNativeDelegate testDelegate;
 
 			const USentryId* eventId = SentrySubsystem->CaptureEventWithScope(testEvent, testDelegate);
 			TestNotNull("Event ID is non-null", eventId);

--- a/plugin-dev/Source/Sentry/Public/SentryScope.h
+++ b/plugin-dev/Source/Sentry/Public/SentryScope.h
@@ -128,5 +128,5 @@ private:
 	TSharedPtr<ISentryScope> ScopeNativeImpl;
 };
 
-DECLARE_DELEGATE_OneParam(FConfigureScopeDelegate, USentryScope*);
-DECLARE_DYNAMIC_DELEGATE_OneParam(FConfigureScopeDynDelegate, USentryScope*, Scope);
+DECLARE_DELEGATE_OneParam(FConfigureScopeNativeDelegate, USentryScope*);
+DECLARE_DYNAMIC_DELEGATE_OneParam(FConfigureScopeDelegate, USentryScope*, Scope);

--- a/plugin-dev/Source/Sentry/Public/SentryScope.h
+++ b/plugin-dev/Source/Sentry/Public/SentryScope.h
@@ -128,4 +128,5 @@ private:
 	TSharedPtr<ISentryScope> ScopeNativeImpl;
 };
 
-DECLARE_DYNAMIC_DELEGATE_OneParam(FConfigureScopeDelegate, USentryScope*, Scope);
+DECLARE_DELEGATE_OneParam(FConfigureScopeDelegate, USentryScope*);
+DECLARE_DYNAMIC_DELEGATE_OneParam(FConfigureScopeDynDelegate, USentryScope*, Scope);

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -119,18 +119,19 @@ public:
 	 *
 	 * @note: Not supported for Windows/Linux.
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Sentry", meta = (AutoCreateRefTerm = "OnCofigureScope"))
-	USentryId* CaptureMessageWithScope(const FString& Message, const FConfigureScopeDelegate& OnConfigureScope, ESentryLevel Level = ESentryLevel::Info);
+    UFUNCTION(BlueprintCallable, Category = "Sentry", meta = (AutoCreateRefTerm = "OnConfigureScope"))
+    USentryId* CaptureMessageWithScope(const FString& Message, const FConfigureScopeDynDelegate& OnConfigureScope, ESentryLevel Level = ESentryLevel::Info);
+    USentryId* CaptureMessageWithScope(const FString& Message, const FConfigureScopeDelegate& OnConfigureScope, ESentryLevel Level = ESentryLevel::Info);
 
-	/**
-	 * Captures a manually created event and sends it to Sentry.
-	 *
-	 * @param Event The event to send to Sentry.
-	 */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentryId* CaptureEvent(USentryEvent* Event);
+    /**
+     * Captures a manually created event and sends it to Sentry.
+     *
+     * @param Event The event to send to Sentry.
+     */
+    UFUNCTION(BlueprintCallable, Category = "Sentry")
+    USentryId* CaptureEvent(USentryEvent* Event);
 
-	/**
+    /**
 	 * Captures a manually created event and sends it to Sentry.
 	 *
 	 * @param Event The event to send to Sentry.
@@ -139,19 +140,20 @@ public:
 	 * @note: Not supported for Windows/Linux.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentryId* CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDelegate& OnConfigureScope);
+    USentryId* CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDynDelegate& OnConfigureScope);
+    USentryId* CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDelegate& OnConfigureScope);
 
-	/**
-	 * Captures a user feedback.
-	 *
-	 * @param UserFeedback The user feedback to send to Sentry.
-	 *
-	 * @note: Not supported for Windows/Linux.
-	 */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void CaptureUserFeedback(USentryUserFeedback* UserFeedback);
+    /**
+     * Captures a user feedback.
+     *
+     * @param UserFeedback The user feedback to send to Sentry.
+     *
+     * @note: Not supported for Windows/Linux.
+     */
+    UFUNCTION(BlueprintCallable, Category = "Sentry")
+    void CaptureUserFeedback(USentryUserFeedback* UserFeedback);
 
-	/**
+    /**
 	 * Captures a user feedback.
 	 *
 	 * @param EventId The event Id.
@@ -185,16 +187,17 @@ public:
 	 * @note: Not supported for Windows/Linux.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry", meta = (AutoCreateRefTerm = "OnCofigureScope"))
-	void ConfigureScope(const FConfigureScopeDelegate& OnConfigureScope);
+    void ConfigureScope(const FConfigureScopeDynDelegate& OnConfigureScope);
+    void ConfigureScope(const FConfigureScopeDelegate& OnConfigureScope);
 
-	/**
-	 * Sets context values which will be used for enriching events. 
-	 *
-	 * @param Key Context key.
-	 * @param Values Context values.
-	 */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void SetContext(const FString& Key, const TMap<FString, FString>& Values);
+    /**
+     * Sets context values which will be used for enriching events.
+     *
+     * @param Key Context key.
+     * @param Values Context values.
+     */
+    UFUNCTION(BlueprintCallable, Category = "Sentry")
+    void SetContext(const FString& Key, const TMap<FString, FString>& Values);
 
 	/**
 	 * Sets global tag - key/value string pair which will be attached to every event.

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -121,8 +121,8 @@ public:
 	 * @note: Not supported for Windows/Linux.
 	 */
     UFUNCTION(BlueprintCallable, Category = "Sentry", meta = (AutoCreateRefTerm = "OnConfigureScope"))
-    USentryId* CaptureMessageWithScope(const FString& Message, const FConfigureScopeDynDelegate& OnConfigureScope, ESentryLevel Level = ESentryLevel::Info);
     USentryId* CaptureMessageWithScope(const FString& Message, const FConfigureScopeDelegate& OnConfigureScope, ESentryLevel Level = ESentryLevel::Info);
+    USentryId* CaptureMessageWithScope(const FString& Message, const FConfigureScopeNativeDelegate& OnConfigureScope, ESentryLevel Level = ESentryLevel::Info);
 
     /**
      * Captures a manually created event and sends it to Sentry.
@@ -141,8 +141,8 @@ public:
 	 * @note: Not supported for Windows/Linux.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-    USentryId* CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDynDelegate& OnConfigureScope);
     USentryId* CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDelegate& OnConfigureScope);
+    USentryId* CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeNativeDelegate& OnConfigureScope);
 
     /**
      * Captures a user feedback.
@@ -188,8 +188,8 @@ public:
 	 * @note: Not supported for Windows/Linux.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry", meta = (AutoCreateRefTerm = "OnCofigureScope"))
-    void ConfigureScope(const FConfigureScopeDynDelegate& OnConfigureScope);
     void ConfigureScope(const FConfigureScopeDelegate& OnConfigureScope);
+    void ConfigureScope(const FConfigureScopeNativeDelegate& OnConfigureScope);
 
     /**
      * Sets context values which will be used for enriching events.


### PR DESCRIPTION
Here is my PR for implementing the use of DECLARE_DELEGATE_OneParam for ConfigureScope #511

Converting FConfigureScopeDelegate to a non dynamic delegate might cause issues on migration of code for existing cpp users as now the cpp version of the implementation would be `FConfigureScopeDynDelegate` (but maybe could be good to make aware for people to replace their existing cpp code to use `FConfigureScopeDelegate`