### PR TITLE
Add user feedback capturing support for desktop

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -19,6 +19,7 @@
 #include "SentryBeforeSendHandler.h"
 #include "SentryTraceSampler.h"
 #include "SentryTransactionContext.h"
+#include "SentryUserFeedbackDesktop.h"
 
 #include "Infrastructure/SentryConvertorsDesktop.h"
 
@@ -283,7 +284,8 @@ USentryId* SentrySubsystemDesktop::CaptureEventWithScope(USentryEvent* event, co
 
 void SentrySubsystemDesktop::CaptureUserFeedback(USentryUserFeedback* userFeedback)
 {
-	UE_LOG(LogSentrySdk, Log, TEXT("CaptureUserFeedback method is not supported for the current platform."));
+	TSharedPtr<SentryUserFeedbackDesktop> userFeedbackDesktop = StaticCastSharedPtr<SentryUserFeedbackDesktop>(userFeedback->GetNativeImpl());
+	sentry_capture_user_feedback(userFeedbackDesktop->GetNativeObject());
 }
 
 void SentrySubsystemDesktop::SetUser(USentryUser* user)

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryUserFeedbackDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryUserFeedbackDesktop.cpp
@@ -1,0 +1,65 @@
+// Copyright (c) 2022 Sentry. All Rights Reserved.
+
+#include "SentryUserFeedbackDesktop.h"
+
+#include "SentryId.h"
+
+#include "Infrastructure/SentryConvertorsDesktop.h"
+
+#if USE_SENTRY_NATIVE
+
+SentryUserFeedbackDesktop::SentryUserFeedbackDesktop()
+{
+	UserFeedbackDesktop = sentry_value_new_object();
+}
+
+SentryUserFeedbackDesktop::SentryUserFeedbackDesktop(USentryId* eventId)
+{
+	UserFeedbackDesktop = sentry_value_new_object();
+	sentry_value_set_by_key(UserFeedbackDesktop, "event_id", sentry_value_new_string(TCHAR_TO_ANSI(*eventId->ToString())));
+}
+
+SentryUserFeedbackDesktop::~SentryUserFeedbackDesktop()
+{
+	// Put custom destructor logic here if needed
+}
+
+sentry_value_t SentryUserFeedbackDesktop::GetNativeObject()
+{
+	return UserFeedbackDesktop;
+}
+
+void SentryUserFeedbackDesktop::SetName(const FString& name)
+{
+	sentry_value_set_by_key(UserFeedbackDesktop, "name", sentry_value_new_string(TCHAR_TO_ANSI(*name)));
+}
+
+FString SentryUserFeedbackDesktop::GetName() const
+{
+	sentry_value_t username = sentry_value_get_by_key(UserFeedbackDesktop, "name");
+	return FString(sentry_value_as_string(username));
+}
+
+void SentryUserFeedbackDesktop::SetEmail(const FString& email)
+{
+	sentry_value_set_by_key(UserFeedbackDesktop, "email", sentry_value_new_string(TCHAR_TO_ANSI(*email)));
+}
+
+FString SentryUserFeedbackDesktop::GetEmail() const
+{
+	sentry_value_t email = sentry_value_get_by_key(UserFeedbackDesktop, "email");
+	return FString(sentry_value_as_string(email));
+}
+
+void SentryUserFeedbackDesktop::SetComment(const FString& comment)
+{
+	sentry_value_set_by_key(UserFeedbackDesktop, "comments", sentry_value_new_string(TCHAR_TO_ANSI(*comment)));
+}
+
+FString SentryUserFeedbackDesktop::GetComment() const
+{
+	sentry_value_t comment = sentry_value_get_by_key(UserFeedbackDesktop, "comments");
+	return FString(sentry_value_as_string(comment));
+}
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryUserFeedbackDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryUserFeedbackDesktop.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2022 Sentry. All Rights Reserved.
+
+#pragma once
+
+#include "Convenience/SentryInclude.h"
+
+#include "Interface/SentryUserFeedbackInterface.h"
+
+#if USE_SENTRY_NATIVE
+
+class USentryId;
+
+class SentryUserFeedbackDesktop : public ISentryUserFeedback
+{
+public:
+	SentryUserFeedbackDesktop();
+	SentryUserFeedbackDesktop(USentryId* eventId);
+	virtual ~SentryUserFeedbackDesktop() override;
+
+	sentry_value_t GetNativeObject();
+
+	virtual void SetName(const FString& name) override;
+	virtual FString GetName() const override;
+	virtual void SetEmail(const FString& email) override;
+	virtual FString GetEmail() const override;
+	virtual void SetComment(const FString& comment) override;
+	virtual FString GetComment() const override;
+
+private:
+	sentry_value_t UserFeedbackDesktop;
+};
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/SentryUserFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryUserFeedback.cpp
@@ -9,6 +9,8 @@
 #include "Android/SentryUserFeedbackAndroid.h"
 #elif PLATFORM_IOS || PLATFORM_MAC
 #include "Apple/SentryUserFeedbackApple.h"
+#elif PLATFORM_WINDOWS || PLATFORM_LINUX
+#include "Desktop/SentryUserFeedbackDesktop.h"
 #endif
 
 void USentryUserFeedback::Initialize(USentryId* EventId)
@@ -17,6 +19,8 @@ void USentryUserFeedback::Initialize(USentryId* EventId)
 	UserFeedbackNativeImpl = MakeShareable(new SentryUserFeedbackAndroid(EventId));
 #elif PLATFORM_IOS || PLATFORM_MAC
 	UserFeedbackNativeImpl = MakeShareable(new SentryUserFeedbackApple(EventId));
+#elif PLATFORM_WINDOWS || PLATFORM_LINUX
+	UserFeedbackNativeImpl = MakeShareable(new SentryUserFeedbackDesktop(EventId));
 #endif
 }
 

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -17,7 +17,7 @@ $modulesDir = Resolve-Path "$PSScriptRoot/../modules"
 $outDir = Resolve-Path "$PSScriptRoot/../plugin-dev/Source/ThirdParty"
 
 $macPlatfromDeps = @("mac", "ios", "android")
-$winPlatfromDeps = @("win", "android")
+$winPlatfromDeps = @("win")
 
 function buildSentryCocoaIos()
 {
@@ -106,12 +106,14 @@ function buildSentryNative()
 {
     Push-Location -Path "$modulesDir/sentry-native"
 
-    cmake -B "build" -D SENTRY_BACKEND=breakpad -D SENTRY_SDK_NAME=sentry.native.unreal
+    cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF
     cmake --build "build" --target sentry --config RelWithDebInfo --parallel
+    cmake --build "build" --target crashpad_handler --config RelWithDebInfo --parallel
+    cmake --install "build" --prefix "install" --config RelWithDebInfo
 
     Pop-Location
 
-    $nativeOutDir = "$outDir/Win64"
+    $nativeOutDir = "$outDir/Win64/Crashpad"
     $nativeOutDirLibs = "$nativeOutDir/lib"
     $nativeOutDirBinaries = "$nativeOutDir/bin"
     $nativeOutDirIncludes = "$nativeOutDir/include"
@@ -126,11 +128,9 @@ function buildSentryNative()
     New-Item $nativeOutDirBinaries -ItemType Directory > $null
     New-Item $nativeOutDirIncludes -ItemType Directory > $null
 
-    Copy-Item "$modulesDir/sentry-native/build/RelWithDebInfo/sentry.lib" -Destination "$nativeOutDirLibs/sentry.lib"
-    Copy-Item "$modulesDir/sentry-native/build/RelWithDebInfo/sentry.dll" -Destination "$nativeOutDirBinaries/sentry.dll"
-    Copy-Item "$modulesDir/sentry-native/build/RelWithDebInfo/sentry.pdb" -Destination "$nativeOutDirBinaries/sentry.pdb"
-    Copy-Item "$modulesDir/sentry-native/build/external/RelWithDebInfo/breakpad_client.lib" -Destination "$nativeOutDirLibs/breakpad_client.lib"
-    Copy-Item "$modulesDir/sentry-native/include/sentry.h" -Destination "$nativeOutDirIncludes/sentry.h"
+    Get-ChildItem -Path "$modulesDir/sentry-native/install/lib" -Filter "*.lib" -Recurse | Copy-Item -Destination $nativeOutDirLibs
+    Copy-Item "$modulesDir/sentry-native/install/bin/crashpad_handler.exe" -Destination $nativeOutDirBinaries
+    Copy-Item "$modulesDir/sentry-native/install/include/sentry.h" -Destination $nativeOutDirIncludes
 }
 
 function buildPlatformDependency([string] $platform)

--- a/scripts/packaging/package-github.snapshot
+++ b/scripts/packaging/package-github.snapshot
@@ -118,6 +118,8 @@ Source/Sentry/Private/Desktop/SentryTransactionDesktop.cpp
 Source/Sentry/Private/Desktop/SentryTransactionDesktop.h
 Source/Sentry/Private/Desktop/SentryUserDesktop.cpp
 Source/Sentry/Private/Desktop/SentryUserDesktop.h
+Source/Sentry/Private/Desktop/SentryUserFeedbackDesktop.cpp
+Source/Sentry/Private/Desktop/SentryUserFeedbackDesktop.h
 Source/Sentry/Private/Desktop/Transport/
 Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.cpp
 Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.h

--- a/scripts/packaging/package-marketplace.snapshot
+++ b/scripts/packaging/package-marketplace.snapshot
@@ -116,6 +116,8 @@ Source/Sentry/Private/Desktop/SentryTransactionDesktop.cpp
 Source/Sentry/Private/Desktop/SentryTransactionDesktop.h
 Source/Sentry/Private/Desktop/SentryUserDesktop.cpp
 Source/Sentry/Private/Desktop/SentryUserDesktop.h
+Source/Sentry/Private/Desktop/SentryUserFeedbackDesktop.cpp
+Source/Sentry/Private/Desktop/SentryUserFeedbackDesktop.h
 Source/Sentry/Private/Desktop/Transport/
 Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.cpp
 Source/Sentry/Private/Desktop/Transport/SentryDsnUrl.h


### PR DESCRIPTION
Introduction of the [corresponding API]((https://github.com/getsentry/sentry-native/pull/966)) to `sentry-native` enabled adding this feature to UE plugin so there is no need to use [user feedback endpoint](https://docs.sentry.io/product/user-feedback/) anymore.