### PR TITLE
Map sentry_level_t to ELogVerbosity::Type in PrintVerboseLog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- Map sentry_level_t to ELogVerbosity::Type in PrintVerboseLog ([#536](https://github.com/getsentry/sentry-unreal/pull/536))
+
+
 ### Features
 
 - Add user feedback capturing support for desktop ([#521](https://github.com/getsentry/sentry-unreal/pull/521))

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -46,7 +46,27 @@ void PrintVerboseLog(sentry_level_t level, const char *message, va_list args, vo
 	char buffer[512];
 	vsnprintf(buffer, 512, message, args);
 
-	UE_LOG(LogSentrySdk, Log, TEXT("%s"), *FString(buffer));
+	switch (level)
+	{
+	case SENTRY_LEVEL_DEBUG:
+		UE_LOG(LogSentrySdk, Verbose, TEXT("%s"), *FString(buffer));
+		break;
+	case SENTRY_LEVEL_INFO:
+		UE_LOG(LogSentrySdk, Log, TEXT("%s"), *FString(buffer));
+		break;
+	case SENTRY_LEVEL_WARNING:
+		UE_LOG(LogSentrySdk, Warning, TEXT("%s"), *FString(buffer));
+		break;
+	case SENTRY_LEVEL_ERROR:
+		UE_LOG(LogSentrySdk, Error, TEXT("%s"), *FString(buffer));
+		break;
+	case SENTRY_LEVEL_FATAL:
+		UE_LOG(LogSentrySdk, Fatal, TEXT("%s"), *FString(buffer));
+		break;
+	default:
+		UE_LOG(LogSentrySdk, Error, TEXT("Unknown sentry_level: %d"), level);
+		UE_LOG(LogSentrySdk, Error, TEXT("%s"), *FString(buffer));
+	}
 }
 
 sentry_value_t HandleBeforeSend(sentry_value_t event, void *hint, void *closure)


### PR DESCRIPTION
Sentry's logging writes verbose SDK information to the default log level. I'd like to suggest mapping the sentry_level_t parameter to ELogVerbosity::Type.

Three potential things to raise here:
-  The fallback behaviour logs to the Error Category, alongside a message for an unknown sentry_level. 
- SENTRY_LEVEL_FATAL logs will shut down the app. In my testing, I've never seen a SENTRY_LEVEL_FATAL log message so I don't know what the right thing to do here is. I've mapped 1:1 to Unreal's categories, but I think logging to Error with a wrapper message might be a good idea.
- It might be worth having a Static Log Category for SDK messages specifically, something like:

`DEFINE_LOG_CATEGORY_STATIC(LogSentryNativeSdk, Display, All);` and then using that _just_ for these messages.