### PR TITLE
Add conversion utility for log verbosity type based on Sentry message level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,11 @@
 
 ## Unreleased
 
-- Map sentry_level_t to ELogVerbosity::Type in PrintVerboseLog ([#536](https://github.com/getsentry/sentry-unreal/pull/536))
-
-
 ### Features
 
 - Add user feedback capturing support for desktop ([#521](https://github.com/getsentry/sentry-unreal/pull/521))
 - Add breadcrumbs automatically when printing to logs ([#522](https://github.com/getsentry/sentry-unreal/pull/522))
+- Add proper log verbosity type for internal `sentry-native` messages ([#536](https://github.com/getsentry/sentry-unreal/pull/536))
 
 ### Fixes
 
@@ -19,18 +17,12 @@
 - Bump CLI from v2.29.1 to v2.31.0 ([#512](https://github.com/getsentry/sentry-unreal/pull/512), [#515](https://github.com/getsentry/sentry-unreal/pull/515), [#517](https://github.com/getsentry/sentry-unreal/pull/517), [#524](https://github.com/getsentry/sentry-unreal/pull/524), [#525](https://github.com/getsentry/sentry-unreal/pull/525))
   - [changelog](https://github.com/getsentry/sentry-cli/blob/master/CHANGELOG.md#2310)
   - [diff](https://github.com/getsentry/sentry-cli/compare/2.29.1...2.31.0)
-- Bump Java SDK (Android) from v7.5.0 to v7.6.0 ([#513](https://github.com/getsentry/sentry-unreal/pull/513))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#760)
-  - [diff](https://github.com/getsentry/sentry-java/compare/7.5.0...7.6.0)
+- Bump Java SDK (Android) from v7.5.0 to v7.8.0 ([#513](https://github.com/getsentry/sentry-unreal/pull/513), [#534](https://github.com/getsentry/sentry-unreal/pull/534), [#535](https://github.com/getsentry/sentry-unreal/pull/535))
+  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#780)
+  - [diff](https://github.com/getsentry/sentry-java/compare/7.5.0...7.8.0)
 - Bump Native SDK from v0.7.0 to v0.7.2 ([#520](https://github.com/getsentry/sentry-unreal/pull/520), [#531](https://github.com/getsentry/sentry-unreal/pull/531))
   - [changelog](https://github.com/getsentry/sentry-native/blob/master/CHANGELOG.md#072)
   - [diff](https://github.com/getsentry/sentry-native/compare/0.7.0...0.7.2)
-- Bump Java SDK (Android) from v7.6.0 to v7.7.0 ([#534](https://github.com/getsentry/sentry-unreal/pull/534))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#770)
-  - [diff](https://github.com/getsentry/sentry-java/compare/7.6.0...7.7.0)
-- Bump Java SDK (Android) from v7.7.0 to v7.8.0 ([#535](https://github.com/getsentry/sentry-unreal/pull/535))
-  - [changelog](https://github.com/getsentry/sentry-java/blob/main/CHANGELOG.md#780)
-  - [diff](https://github.com/getsentry/sentry-java/compare/7.7.0...7.8.0)
 
 ## 0.16.0
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/Infrastructure/SentryConvertorsDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Infrastructure/SentryConvertorsDesktop.cpp
@@ -218,4 +218,32 @@ TArray<uint8> SentryConvertorsDesktop::SentryEnvelopeToByteArray(sentry_envelope
 	return envelopeData;
 }
 
+ELogVerbosity::Type SentryConvertorsDesktop::SentryLevelToLogVerbosity(sentry_level_t level)
+{
+	ELogVerbosity::Type LogVerbosity = ELogVerbosity::Error;
+
+	switch (level)
+	{
+	case SENTRY_LEVEL_DEBUG:
+		LogVerbosity = ELogVerbosity::Verbose;
+		break;
+	case SENTRY_LEVEL_INFO:
+		LogVerbosity = ELogVerbosity::Log;
+		break;
+	case SENTRY_LEVEL_WARNING:
+		LogVerbosity = ELogVerbosity::Warning;
+		break;
+	case SENTRY_LEVEL_ERROR:
+		LogVerbosity = ELogVerbosity::Error;
+		break;
+	case SENTRY_LEVEL_FATAL:
+		LogVerbosity = ELogVerbosity::Fatal;
+		break;
+	default:
+		UE_LOG(LogSentrySdk, Warning, TEXT("Unknown sentry level value used. Error will be returned."));
+	}
+
+	return LogVerbosity;
+}
+
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/Infrastructure/SentryConvertorsDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/Infrastructure/SentryConvertorsDesktop.h
@@ -32,6 +32,7 @@ public:
 	/** Other conversions */
 	static FString SentryLevelToString(ESentryLevel level);
 	static TArray<uint8> SentryEnvelopeToByteArray(sentry_envelope_t* envelope);
+	static ELogVerbosity::Type SentryLevelToLogVerbosity(sentry_level_t level);
 };
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -46,7 +46,13 @@ void PrintVerboseLog(sentry_level_t level, const char *message, va_list args, vo
 	char buffer[512];
 	vsnprintf(buffer, 512, message, args);
 
-	GLog->CategorizedLogf(LogSentrySdk.GetCategoryName(), SentryConvertorsDesktop::SentryLevelToLogVerbosity(level), TEXT("%s"), *FString(buffer));
+#if !NO_LOGGING
+	const FName SentryCategoryName(LogSentrySdk.GetCategoryName());
+#else
+	const FName SentryCategoryName(TEXT("LogSentrySdk"));
+#endif
+
+	GLog->CategorizedLogf(SentryCategoryName, SentryConvertorsDesktop::SentryLevelToLogVerbosity(level), TEXT("%s"), *FString(buffer));
 }
 
 sentry_value_t HandleBeforeSend(sentry_value_t event, void *hint, void *closure)

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -46,27 +46,7 @@ void PrintVerboseLog(sentry_level_t level, const char *message, va_list args, vo
 	char buffer[512];
 	vsnprintf(buffer, 512, message, args);
 
-	switch (level)
-	{
-	case SENTRY_LEVEL_DEBUG:
-		UE_LOG(LogSentrySdk, Verbose, TEXT("%s"), *FString(buffer));
-		break;
-	case SENTRY_LEVEL_INFO:
-		UE_LOG(LogSentrySdk, Log, TEXT("%s"), *FString(buffer));
-		break;
-	case SENTRY_LEVEL_WARNING:
-		UE_LOG(LogSentrySdk, Warning, TEXT("%s"), *FString(buffer));
-		break;
-	case SENTRY_LEVEL_ERROR:
-		UE_LOG(LogSentrySdk, Error, TEXT("%s"), *FString(buffer));
-		break;
-	case SENTRY_LEVEL_FATAL:
-		UE_LOG(LogSentrySdk, Fatal, TEXT("%s"), *FString(buffer));
-		break;
-	default:
-		UE_LOG(LogSentrySdk, Error, TEXT("Unknown sentry_level: %d"), level);
-		UE_LOG(LogSentrySdk, Error, TEXT("%s"), *FString(buffer));
-	}
+	GLog->CategorizedLogf(LogSentrySdk.GetCategoryName(), SentryConvertorsDesktop::SentryLevelToLogVerbosity(level), TEXT("%s"), *FString(buffer));
 }
 
 sentry_value_t HandleBeforeSend(sentry_value_t event, void *hint, void *closure)


### PR DESCRIPTION
This PR is a small clean-up for #536 

#skip-changelog