### PR TITLE
Fix problem with parsing existing parameter after missing parameter

### DIFF
--- a/plugin-dev/Scripts/upload-debug-symbols-win.bat
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.bat
@@ -141,7 +141,10 @@ exit
           set insection=1
         ) else (
           endlocal
-          if defined insection goto :eof
+          if defined insection (
+            set insection=
+            goto :eof
+          )
         )
       )
     )


### PR DESCRIPTION
This fixes situation when all the parameters in ```[/Script/Sentry.SentrySettings]``` which follows non existing parameter in batch file are going to be skipped. 

In the example below EnableBuildTargets won't be parsed, because there is no EnableBuildPlatforms parameter set.
```
[/Script/Sentry.SentrySettings]
Debug=True
AutomaticBreadcrumbs=(bOnMapLoadingStarted=True,bOnMapLoaded=True,bOnGameStateClassChanged=True,bOnGameSessionIDChanged=True,bOnUserActivityStringChanged=True)
UploadSymbolsAutomatically=True
InitAutomatically=True
Release="main-1987"
PropertiesFilePath=Config/sentry.properties
EnableAutoCrashCapturing=False
BeforeSendHandler=/Script/CoreUObject.Class'/Script/Project.ProjectSentryBeforeSendHandler'
EnableAutoLogAttachment=True
IncludeSources=True
EnableBuildTargets=(bEnableClient=True,bEnableGame=True,bEnableEditor=False,bEnableServer=False,bEnableProgram=True)
Dsn="https://something@crash-reports.something/3"
```