### PR TITLE
Add ability to check if sentry should be initialised to prevent unnecessary warnings

### DIFF
--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -270,7 +270,7 @@ public:
 
 	bool IsSupportedForCurrentSettings()
 	{
-		return IsCurrentBuildConfigurationEnabled() && IsCurrentBuildTargetEnabled() && IsCurrentPlatformEnabled();
+		return IsCurrentBuildConfigurationEnabled() && IsCurrentBuildTargetEnabled() && IsCurrentPlatformEnabled() && EnableForPromotedBuildsOnly();
 	}
 private:
 	/** Adds default context data for all events captured by Sentry SDK. */

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -268,6 +268,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
 	USentryTransaction* StartTransactionWithContextAndOptions(USentryTransactionContext* Context, const TMap<FString, FString>& Options);
 
+	bool IsSupportedForCurrentSettings()
+	{
+		return IsCurrentBuildConfigurationEnabled() && IsCurrentBuildTargetEnabled() && IsCurrentPlatformEnabled();
+	}
 private:
 	/** Adds default context data for all events captured by Sentry SDK. */
 	void AddDefaultContext();


### PR DESCRIPTION
This was a change made by someone internally that's probs useful for others. 

We use it when setting up Sentry via Code instead than using the automatic logic. 