### PR TITLE
Fix build errors in UE 4.27 due to missing `FOutputDevice` method

### DIFF
--- a/plugin-dev/Source/Sentry/Private/SentryOutputDevice.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryOutputDevice.cpp
@@ -69,7 +69,9 @@ bool FSentryOutputDevice::CanBeUsedOnMultipleThreads() const
 	return true;
 }
 
+#if ENGINE_MAJOR_VERSION >= 5
 bool FSentryOutputDevice::CanBeUsedOnPanicThread() const
 {
 	return true;
 }
+#endif

--- a/plugin-dev/Source/Sentry/Public/SentryOutputDevice.h
+++ b/plugin-dev/Source/Sentry/Public/SentryOutputDevice.h
@@ -11,5 +11,8 @@ public:
 
 	virtual bool CanBeUsedOnAnyThread() const override;
 	virtual bool CanBeUsedOnMultipleThreads() const override;
+
+#if ENGINE_MAJOR_VERSION >= 5
 	virtual bool CanBeUsedOnPanicThread() const override;
+#endif
 };


### PR DESCRIPTION
This PR fixes build errors in UE 4.27 that were introduced in scope of #522 

#skip-changelog