### PR TITLE
Fix build errors introduced after adding a check if event capturing is supported for current plugin settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add user feedback capturing support for desktop ([#521](https://github.com/getsentry/sentry-unreal/pull/521))
 - Add breadcrumbs automatically when printing to logs ([#522](https://github.com/getsentry/sentry-unreal/pull/522))
 - Add proper log verbosity type for internal `sentry-native` messages ([#536](https://github.com/getsentry/sentry-unreal/pull/536))
+- Add ability to check if sentry should be initialised to prevent unnecessary warnings ([#544](https://github.com/getsentry/sentry-unreal/pull/544))
 
 ### Fixes
 

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -79,7 +79,7 @@ void USentrySubsystem::Initialize()
 		return;
 	}
 
-	if(Settings->EnableForPromotedBuildsOnly && !FApp::GetEngineIsPromotedBuild())
+	if(IsPromotedBuildsOnlyEnabled() && !FApp::GetEngineIsPromotedBuild())
 	{
 		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization skipped since event capturing is disabled for the non-promoted builds in plugin settings."));
 		return;
@@ -357,6 +357,21 @@ USentryTransaction* USentrySubsystem::StartTransactionWithContextAndOptions(USen
 	return SubsystemNativeImpl->StartTransactionWithContextAndOptions(Context, Options);
 }
 
+bool USentrySubsystem::IsSupportedForCurrentSettings()
+{
+	if(!IsCurrentBuildConfigurationEnabled() || !IsCurrentBuildTargetEnabled() || !IsCurrentPlatformEnabled())
+	{
+		return false;
+	}
+
+	if(IsPromotedBuildsOnlyEnabled() && !FApp::GetEngineIsPromotedBuild())
+	{
+		return false;
+	}
+
+	return true;
+}
+
 void USentrySubsystem::AddDefaultContext()
 {
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
@@ -591,4 +606,11 @@ bool USentrySubsystem::IsCurrentPlatformEnabled()
 #endif
 
 	return IsBuildPlatformEnabled;
+}
+
+bool USentrySubsystem::IsPromotedBuildsOnlyEnabled()
+{
+	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
+
+	return Settings->EnableForPromotedBuildsOnly;
 }

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -268,10 +268,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
 	USentryTransaction* StartTransactionWithContextAndOptions(USentryTransactionContext* Context, const TMap<FString, FString>& Options);
 
-	bool IsSupportedForCurrentSettings()
-	{
-		return IsCurrentBuildConfigurationEnabled() && IsCurrentBuildTargetEnabled() && IsCurrentPlatformEnabled() && EnableForPromotedBuildsOnly();
-	}
+	/** Checks if Sentry event capturing is supported for current settings. */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	bool IsSupportedForCurrentSettings();
+
 private:
 	/** Adds default context data for all events captured by Sentry SDK. */
 	void AddDefaultContext();
@@ -291,14 +291,17 @@ private:
 	/** Unsubscribe from game events that are used for automatic breadcrumbs. */
 	void DisableAutomaticBreadcrumbs();
 
-	/** Check whether the event capturing should be disabled for the current build configuration */
+	/** Check whether the event capturing should be enabled for the current build configuration */
 	bool IsCurrentBuildConfigurationEnabled();
 
-	/** Check whether the event capturing should be disabled for the current build configuration */
+	/** Check whether the event capturing should be enabled for the current build target */
 	bool IsCurrentBuildTargetEnabled();
 
-	/** Check whether the event capturing should be disabled for the current build configuration */
+	/** Check whether the event capturing should be enabled for the current platform */
 	bool IsCurrentPlatformEnabled();
+
+	/** Check whether the event capturing should be enabled for promoted builds only */
+	bool IsPromotedBuildsOnlyEnabled();
 
 private:
 	TSharedPtr<ISentrySubsystem> SubsystemNativeImpl;


### PR DESCRIPTION
This PR fixes minor build errors introduced in #544

#skip-changelog