### PR TITLE
Add diagnostic level setting for symbol upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add diagnostic level setting for symbol upload ([#555](https://github.com/getsentry/sentry-unreal/pull/555))
+
 ## 0.17.1
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add diagnostic level setting for symbol upload ([#555](https://github.com/getsentry/sentry-unreal/pull/555))
+- Sentry-CLI now shares the diagnostic level set in the UE Editor settings ([#555](https://github.com/getsentry/sentry-unreal/pull/555))
 
 ## 0.17.1
 

--- a/plugin-dev/Scripts/upload-debug-symbols-win.bat
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.bat
@@ -47,6 +47,13 @@ if /i "%IncludeSourceFiles%"=="True" (
     set "CliArgs=--include-sources"
 )
 
+set CliLogLevel=
+
+call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings DiagnosticLevel CliLogLevel
+if "%CliLogLevel%"=="" (
+    set "CliLogLevel=info"
+)
+
 call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings EnableBuildPlatforms EnabledPlatforms
 if not "%EnabledPlatforms%"=="" (
   set PlatformToCheck=
@@ -99,7 +106,7 @@ echo Sentry: Upload started using PropertiesFile '%PropertiesFile%'
 set "SENTRY_PROPERTIES=%PropertiesFile%"
 echo %ProjectBinariesPath%
 echo %PluginBinariesPath%
-call "%CliExec%" upload-dif %CliArgs% --log-level info "%ProjectBinariesPath%" "%PluginBinariesPath%"
+call "%CliExec%" upload-dif %CliArgs% --log-level %CliLogLevel% "%ProjectBinariesPath%" "%PluginBinariesPath%"
 
 echo Sentry: Upload finished
 

--- a/plugin-dev/Scripts/upload-debug-symbols.sh
+++ b/plugin-dev/Scripts/upload-debug-symbols.sh
@@ -49,6 +49,12 @@ if [ -z $INCLUDE_SOURCES -a $UPLOAD_SYMBOLS == "True" ]; then
     CLI_ARGS+=(--include-sources)
 fi
 
+CLI_LOG_LEVEL=$(awk -F "=" '/DiagnosticLevel/ {print $2}' ${CONFIG_PATH}/DefaultEngine.ini)
+
+if [ -z $CLI_LOG_LEVEL ]; then
+    CLI_LOG_LEVEL="info"
+fi
+
 ENABLED_PLATFORMS=$(grep "EnableBuildPlatforms" ${CONFIG_PATH}/DefaultEngine.ini | sed -n 's/^EnableBuildPlatforms=//p' | sed -e 's/^(\(.*\))$/\1/')
 if [ ! -z $ENABLED_PLATFORMS ]; then
     PLATFORMS_ARRAY=$(echo "$ENABLED_PLATFORMS" | sed -e 's/,/ /g')
@@ -91,6 +97,6 @@ echo "Sentry: Upload started using PropertiesFile '$SENTRY_PROPERTIES'"
 
 chmod +x $SENTRY_CLI_EXEC
 
-$SENTRY_CLI_EXEC upload-dif $CLI_ARGS[@] $PROJECT_BINARIES_PATH $PLUGIN_BINARIES_PATH
+$SENTRY_CLI_EXEC upload-dif $CLI_ARGS[@] --log-level $CLI_LOG_LEVEL $PROJECT_BINARIES_PATH $PLUGIN_BINARIES_PATH
 
 echo "Sentry: Upload finished"

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -33,8 +33,9 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 	, TracesSampleRate(0.0f)
 	, TracesSampler(USentryTraceSampler::StaticClass())
 	, EnableForPromotedBuildsOnly(false)
-	, UploadSymbolsAutomatically(false)
+	, UploadSymbolsAutomatically(false)	
 	, IncludeSources(false)
+	, DiagnosticLevel(ESentryCliLogLevel::Info)
 	, CrashReporterUrl()
 	, bIsDirty(false)
 {
@@ -63,6 +64,7 @@ void USentrySettings::PostEditChangeProperty(FPropertyChangedEvent& PropertyChan
 		PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(USentrySettings, OrgName) ||
 		PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(USentrySettings, AuthToken) ||
 		PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(USentrySettings, IncludeSources) ||
+		PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(USentrySettings, DiagnosticLevel) ||
 		PropertyChangedEvent.Property->GetFName() == GET_MEMBER_NAME_CHECKED(USentrySettings, CrashReporterUrl))
 	{
 		return;

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -19,6 +19,16 @@ enum class ESentryTracesSamplingType : uint8
 	TracesSampler
 };
 
+UENUM(BlueprintType)
+enum class ESentryCliLogLevel : uint8
+{
+	Trace,
+	Debug,
+	Info,
+	Warn,
+	Error
+};
+
 USTRUCT(BlueprintType)
 struct FAutomaticBreadcrumbs
 {
@@ -332,6 +342,10 @@ class SENTRY_API USentrySettings : public UObject
 	UPROPERTY(Config, EditAnywhere, Category = "Debug Symbols",
 		Meta = (DisplayName = "Upload sources", ToolTip = "Flag indicating whether to automatically scan the debug files for references to source code files and upload them if any.", EditCondition = "UploadSymbolsAutomatically"))
 	bool IncludeSources;
+
+	UPROPERTY(Config, EditAnywhere, Category = "Debug Symbols",
+		Meta = (DisplayName = "Diagnostic Level", ToolTip = "Logs verbosity level during symbol uploading.", EditCondition = "UploadSymbolsAutomatically"))
+	ESentryCliLogLevel DiagnosticLevel;
 
 	UPROPERTY(Config, EditAnywhere, Category = "Crash Reporter",
 		Meta = (DisplayName = "Crash Reporter Endpoint", ToolTip = "Endpoint that Unreal Engine Crah Reporter should use in order to upload crash data to Sentry."))


### PR DESCRIPTION
This PR introduces a new plugin setting which allows to configure logs verbosity that Sentry CLI prints during symbol upload.

Closes #543