### PR TITLE
Fix threading issues capturing log messages as breadcrumbs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Sentry-CLI now shares the diagnostic level set in the UE Editor settings ([#555](https://github.com/getsentry/sentry-unreal/pull/555))
+- Fix threading issues capturing log messages as breadcrumbs ([#559](https://github.com/getsentry/sentry-unreal/pull/559))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
@@ -109,6 +109,19 @@ void SentrySubsystemAndroid::AddBreadcrumb(USentryBreadcrumb* breadcrumb)
 		breadcrumbAndroid->GetJObject());
 }
 
+void SentrySubsystemAndroid::AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FString>& Data, ESentryLevel Level)
+{
+	TSharedPtr<SentryBreadcrumbAndroid> breadcrumbAndroid = MakeShareable(new SentryBreadcrumbAndroid());
+	breadcrumbAndroid->SetMessage(Message);
+	breadcrumbAndroid->SetCategory(Category);
+	breadcrumbAndroid->SetType(Type);
+	breadcrumbAndroid->SetData(Data);
+	breadcrumbAndroid->SetLevel(Level);
+
+	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::Sentry, "addBreadcrumb", "(Lio/sentry/Breadcrumb;)V",
+		breadcrumbAndroid->GetJObject());
+}
+
 void SentrySubsystemAndroid::ClearBreadcrumbs()
 {
 	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::Sentry, "clearBreadcrumbs", "()V");

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.h
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.h
@@ -12,6 +12,7 @@ public:
 	virtual bool IsEnabled() override;
 	virtual ESentryCrashedLastRun IsCrashedLastRun() override;
 	virtual void AddBreadcrumb(USentryBreadcrumb* breadcrumb) override;
+	virtual void AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FString>& Data, ESentryLevel Level) override;
 	virtual void ClearBreadcrumbs() override;
 	virtual USentryId* CaptureMessage(const FString& message, ESentryLevel level) override;
 	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onConfigureScope, ESentryLevel level) override;

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
@@ -112,6 +112,18 @@ void SentrySubsystemApple::AddBreadcrumb(USentryBreadcrumb* breadcrumb)
 	[SENTRY_APPLE_CLASS(SentrySDK) addBreadcrumb:breadcrumbIOS->GetNativeObject()];
 }
 
+void SentrySubsystemApple::AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FString>& Data, ESentryLevel Level)
+{
+	TSharedPtr<SentryBreadcrumbApple> breadcrumbIOS = MakeShareable(new SentryBreadcrumbApple());
+	breadcrumbIOS->SetMessage(Message);
+	breadcrumbIOS->SetCategory(Category);
+	breadcrumbIOS->SetType(Type);
+	breadcrumbIOS->SetData(Data);
+	breadcrumbIOS->SetLevel(Level);
+
+	[SENTRY_APPLE_CLASS(SentrySDK) addBreadcrumb:breadcrumbIOS->GetNativeObject()];
+}
+
 void SentrySubsystemApple::ClearBreadcrumbs()
 {
 	[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.h
@@ -12,6 +12,7 @@ public:
 	virtual bool IsEnabled() override;
 	virtual ESentryCrashedLastRun IsCrashedLastRun() override;
 	virtual void AddBreadcrumb(USentryBreadcrumb* breadcrumb) override;
+	virtual void AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FString>& Data, ESentryLevel Level) override;
 	virtual void ClearBreadcrumbs() override;
 	virtual USentryId* CaptureMessage(const FString& message, ESentryLevel level) override;
 	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onConfigureScope, ESentryLevel level) override;

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
@@ -279,4 +279,9 @@ void SentryScopeDesktop::Apply(USentryEvent* event)
 	}
 }
 
+void SentryScopeDesktop::AddBreadcrumb(TSharedPtr<SentryBreadcrumbDesktop> breadcrumb)
+{
+	BreadcrumbsDesktop.Add(breadcrumb);
+}
+
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
@@ -17,12 +17,26 @@ SentryScopeDesktop::SentryScopeDesktop()
 {
 }
 
+SentryScopeDesktop::SentryScopeDesktop(const SentryScopeDesktop& Scope)
+{
+	Dist = Scope.Dist;
+	Environment = Scope.Environment;
+	FingerprintDesktop = Scope.FingerprintDesktop;
+	TagsDesktop = Scope.TagsDesktop;
+	ExtraDesktop = Scope.ExtraDesktop;
+	ContextsDesktop = Scope.ContextsDesktop;
+	BreadcrumbsDesktop = Scope.BreadcrumbsDesktop;
+	LevelDesktop = Scope.LevelDesktop;
+}
+
 SentryScopeDesktop::~SentryScopeDesktop()
 {
 }
 
 void SentryScopeDesktop::AddBreadcrumb(USentryBreadcrumb* breadcrumb)
 {
+	FScopeLock Lock(&CriticalSection);
+
 	BreadcrumbsDesktop.Add(StaticCastSharedPtr<SentryBreadcrumbDesktop>(breadcrumb->GetNativeImpl()));
 }
 
@@ -264,7 +278,7 @@ void SentryScopeDesktop::Apply(USentryEvent* event)
 				sentry_value_incref(nativeBreadcrumb);
 				sentry_value_append(eventBreadcrumbs, nativeBreadcrumb);
 			}
-	
+
 			sentry_value_set_by_key(nativeEvent, "breadcrumbs", eventBreadcrumbs);
 		}
 		else
@@ -281,6 +295,8 @@ void SentryScopeDesktop::Apply(USentryEvent* event)
 
 void SentryScopeDesktop::AddBreadcrumb(TSharedPtr<SentryBreadcrumbDesktop> breadcrumb)
 {
+	FScopeLock Lock(&CriticalSection);
+
 	BreadcrumbsDesktop.Add(breadcrumb);
 }
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.h
@@ -45,6 +45,7 @@ public:
 	virtual void Clear() override;
 
 	void Apply(USentryEvent* event);
+	void AddBreadcrumb(TSharedPtr<SentryBreadcrumbDesktop> breadcrumb);
 
 private:
 	FString Dist;

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "HAL/CriticalSection.h"
+
 #include "Interface/SentryScopeInterface.h"
 
 #if USE_SENTRY_NATIVE
@@ -16,6 +18,7 @@ class SentryScopeDesktop : public ISentryScope
 {
 public:
 	SentryScopeDesktop();
+	SentryScopeDesktop(const SentryScopeDesktop& Scope);
 	virtual ~SentryScopeDesktop() override;
 
 	virtual void AddBreadcrumb(USentryBreadcrumb* breadcrumb) override;
@@ -61,6 +64,8 @@ private:
 	TArray<TSharedPtr<SentryBreadcrumbDesktop>> BreadcrumbsDesktop;
 
 	ESentryLevel LevelDesktop;
+
+	FCriticalSection CriticalSection;
 };
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -219,6 +219,18 @@ void SentrySubsystemDesktop::AddBreadcrumb(USentryBreadcrumb* breadcrumb)
 	GetCurrentScope()->AddBreadcrumb(breadcrumb);
 }
 
+void SentrySubsystemDesktop::AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FString>& Data, ESentryLevel Level)
+{
+	TSharedPtr<SentryBreadcrumbDesktop> breadcrumbDesktop = MakeShareable(new SentryBreadcrumbDesktop());
+	breadcrumbDesktop->SetMessage(Message);
+	breadcrumbDesktop->SetCategory(Category);
+	breadcrumbDesktop->SetType(Type);
+	breadcrumbDesktop->SetData(Data);
+	breadcrumbDesktop->SetLevel(Level);
+
+	GetCurrentScope()->AddBreadcrumb(breadcrumbDesktop);
+}
+
 void SentrySubsystemDesktop::ClearBreadcrumbs()
 {
 	GetCurrentScope()->ClearBreadcrumbs();

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
@@ -21,6 +21,7 @@ public:
 	virtual bool IsEnabled() override;
 	virtual ESentryCrashedLastRun IsCrashedLastRun() override;
 	virtual void AddBreadcrumb(USentryBreadcrumb* breadcrumb) override;
+	virtual void AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FString>& Data, ESentryLevel Level) override;
 	virtual void ClearBreadcrumbs() override;
 	virtual USentryId* CaptureMessage(const FString& message, ESentryLevel level) override;
 	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onScopeConfigure, ESentryLevel level) override;

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
@@ -28,6 +28,7 @@ public:
 	virtual bool IsEnabled() = 0;
 	virtual ESentryCrashedLastRun IsCrashedLastRun() = 0;
 	virtual void AddBreadcrumb(USentryBreadcrumb* breadcrumb) = 0;
+	virtual void AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FString>& Data, ESentryLevel Level) = 0;
 	virtual void ClearBreadcrumbs() = 0;
 	virtual USentryId* CaptureMessage(const FString& message, ESentryLevel level) = 0;
 	virtual USentryId* CaptureMessageWithScope(const FString& message, const FConfigureScopeNativeDelegate& onConfigureScope, ESentryLevel level) = 0;

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -174,14 +174,10 @@ void USentrySubsystem::AddBreadcrumb(USentryBreadcrumb* Breadcrumb)
 
 void USentrySubsystem::AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FString>& Data, ESentryLevel Level)
 {
-	USentryBreadcrumb* Breadcrumb = NewObject<USentryBreadcrumb>();
-	Breadcrumb->SetMessage(Message);
-	Breadcrumb->SetCategory(Category);
-	Breadcrumb->SetType(Type);
-	Breadcrumb->SetData(Data);
-	Breadcrumb->SetLevel(Level);
+	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
+		return;
 
-	AddBreadcrumb(Breadcrumb);
+	SubsystemNativeImpl->AddBreadcrumbWithParams(Message, Category, Type, Data, Level);
 }
 
 void USentrySubsystem::ClearBreadcrumbs()


### PR DESCRIPTION
This PR addresses an [issue](https://github.com/getsentry/sentry-unreal/issues/514#issuecomment-2077663102) which was discovered during the discussion around #514 

Since log messages, asserts, ensures, etc. can come from different threads adding breadcrumbs automatically on such events can lead to undefined results due to the following reasons:
- New breadcrumb `UObject` instance is created during garbage collection
- Concurrent access to internal `SentryScopeDesktop` breadcrumbs storage

In order to resolve this breadcrumbs can now be captured without instancing any extra objects and some threading considerations were added.