### PR TITLE
Fix compatibility issue with Android File Server plugin during debug symbols upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 ### Fixes
 
 - Add path strings escaping for debug symbol upload script ([#561](https://github.com/getsentry/sentry-unreal/pull/561))
-- Fix compatibility issue with Android File Server plugin during debug symbols upload ([#568](https://github.com/getsentry/sentry-unreal/pull/568))
+- The SDK now uploads debug symbols properly with the `Android File Server` plugin enabled in UE 5.0 and newer ([#568](https://github.com/getsentry/sentry-unreal/pull/568))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - Add path strings escaping for debug symbol upload script ([#561](https://github.com/getsentry/sentry-unreal/pull/561))
+- Fix compatibility issue with Android File Server plugin during debug symbols upload ([#568](https://github.com/getsentry/sentry-unreal/pull/568))
 
 ### Dependencies
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,6 @@ The SDK compiles with three latest engine versions.
 <Tag Files="#RuntimeDependencies" Filter="sentry.dll;crashpad_handler.exe" With="#BinariesToArchive$(EditorPlatform)"/>
  ```
 
-- In order to fix errors during the Android debug symbols upload in UE 5.0 or newer (Windows) the default `Android File Server` plugin has to be disabled first.
-
 - In UE 5.2 or newer game log attached to crashes captured with `sentry-native` integration instead of [crash reporter](https://docs.sentry.io/platforms/unreal/setup-crashreport/) could be truncated. This is caused by current `crashpad` behavior which sends crashes to Sentry right away while UE is still about to write some bits of information to the log file.
 
 - Only crash events captured on Android contain the full callstack. Events that were captured manually won't have the native C++ part there.

--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -33,6 +33,7 @@
         <if condition="bUploadSymbols">
             <true>
                 <copyFile src="$S(ProjectDir)/sentry.properties" dst="$S(BuildDir)/gradle/sentry.properties" />
+                <copyFile src="$S(ProjectDir)/sentry.properties" dst="$S(BuildDir)/gradle/AFSProject/app/sentry.properties" />
             </true>
         </if>
     </prebuildCopies>


### PR DESCRIPTION
This PR adds `sentry.properties` file copying to implicitly generated AFS project directory when packaging a game for Android which allows Sentry gradle plugin to handle debug symbols upload properly.