### PR TITLE
Fix CI build errors for UE 5.4 by adding missing include

### DIFF
--- a/plugin-dev/Source/Sentry/Public/SentryOutputDeviceError.h
+++ b/plugin-dev/Source/Sentry/Public/SentryOutputDeviceError.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "Misc/OutputDeviceError.h"
+#include "Delegates/Delegate.h"
 
 class FSentryOutputDeviceError : public FOutputDeviceError
 {


### PR DESCRIPTION
#skip-changelog