### PR TITLE
Remove warning about missing WER module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Remove warning about missing WER module ([#584](https://github.com/getsentry/sentry-unreal/pull/584))
+
 ### Dependencies
 
 - Bump Cocoa SDK (iOS) from v8.29.0 to v8.29.1 ([#580](https://github.com/getsentry/sentry-unreal/pull/580))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,6 @@
 
 ## Unreleased
 
-### Fixes
-
-- Remove warning about missing WER module ([#584](https://github.com/getsentry/sentry-unreal/pull/584))
-
 ### Dependencies
 
 - Bump Cocoa SDK (iOS) from v8.29.0 to v8.29.1 ([#580](https://github.com/getsentry/sentry-unreal/pull/580))

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -47,13 +47,23 @@ void PrintVerboseLog(sentry_level_t level, const char *message, va_list args, vo
 	char buffer[512];
 	vsnprintf(buffer, 512, message, args);
 
+	FString MessageBuf = FString(buffer);
+
+	// The WER (Windows Error Reporting) module (crashpad_wer.dll) can't be distributed along with other Sentry binaries
+	// within the plugin package due to some UE Marketplace restrictions. Its absence doesn't affect crash capturing
+	// and the corresponding warning can be disregarded
+	if(MessageBuf.Equals(TEXT("crashpad WER handler module not found")))
+	{
+		return;
+	}
+
 #if !NO_LOGGING
 	const FName SentryCategoryName(LogSentrySdk.GetCategoryName());
 #else
 	const FName SentryCategoryName(TEXT("LogSentrySdk"));
 #endif
 
-	GLog->CategorizedLogf(SentryCategoryName, SentryConvertorsDesktop::SentryLevelToLogVerbosity(level), TEXT("%s"), *FString(buffer));
+	GLog->CategorizedLogf(SentryCategoryName, SentryConvertorsDesktop::SentryLevelToLogVerbosity(level), TEXT("%s"), *MessageBuf);
 }
 
 sentry_value_t HandleBeforeSend(sentry_value_t event, void *hint, void *closure)


### PR DESCRIPTION
This PR filters out the "crashpad WER handler module not found" warning which is printed during the `sentry-native` initialization.

The WER (Windows Error Reporting) module (crashpad_wer.dll) can't be distributed along with other Sentry binaries within the plugin package due to some UE Marketplace restrictions. Its absence doesn't affect crash capturing and the corresponding warning can be disregarded safely.

Closes #583