### PR TITLE
Fix assertions being captured with native integration when using crash reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix assertions being captured with native integration when using crash reporter ([#586](https://github.com/getsentry/sentry-unreal/pull/586))
+
 ### Dependencies
 
 - Bump Cocoa SDK (iOS) from v8.29.0 to v8.29.1 ([#580](https://github.com/getsentry/sentry-unreal/pull/580))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix assertions being captured with native integration when using crash reporter ([#586](https://github.com/getsentry/sentry-unreal/pull/586))
+- The SDK no longer intercepts assertions when using crash-reporter ([#586](https://github.com/getsentry/sentry-unreal/pull/586))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -120,7 +120,18 @@ void USentrySubsystem::Initialize()
 	ConfigureBreadcrumbs();
 
 	ConfigureOutputDevice();
+
+#if PLATFORM_WINDOWS
+	if (FEngineVersion::Current().GetMajor() == 5 && FEngineVersion::Current().GetMinor() >= 2)
+	{
+		if (Settings->EnableAutoCrashCapturing)
+		{
+			ConfigureOutputDeviceError();
+		}
+	}
+#else
 	ConfigureOutputDeviceError();
+#endif
 
 	FCoreDelegates::OnHandleSystemEnsure.AddLambda([this]()
 	{


### PR DESCRIPTION
This PR adds an extra check allowing us to determine whether the SDK should install its custom assertions capturing hook which could interfere with crash reporter.

Related to #537