### PR TITLE
Fix crash when re-initializing Sentry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixes
 
 - The SDK no longer intercepts assertions when using crash-reporter ([#586](https://github.com/getsentry/sentry-unreal/pull/586))
+- Fix crash when re-initializing Sentry ([#594](https://github.com/getsentry/sentry-unreal/pull/594))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -66,6 +66,18 @@ void USentrySubsystem::Deinitialize()
 
 void USentrySubsystem::Initialize()
 {
+	if (!SubsystemNativeImpl)
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry subsystem is invalid and can't be initialized."));
+		return;
+	}
+
+	if (SubsystemNativeImpl->IsEnabled())
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry is already initialized. It will be shut down automatically before re-init."));
+		Close();
+	}
+
 	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
 
 	if(Settings->Dsn.IsEmpty())
@@ -97,9 +109,6 @@ void USentrySubsystem::Initialize()
 		: USentryTraceSampler::StaticClass();
 
 	TraceSampler = NewObject<USentryTraceSampler>(this, TraceSamplerClass);
-
-	if (!SubsystemNativeImpl)
-		return;
 
 	SubsystemNativeImpl->InitWithSettings(Settings, BeforeSendHandler, TraceSampler);
 

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -327,4 +327,7 @@ private:
 	FDelegateHandle GameStateChangedDelegate;
 	FDelegateHandle UserActivityChangedDelegate;
 	FDelegateHandle GameSessionIDChangedDelegate;
+
+	FDelegateHandle OnAssertDelegate;
+	FDelegateHandle OnEnsureDelegate;
 };


### PR DESCRIPTION
This PR fixes the internal plugin crash when re-initializing `USentrySubsystem` without its explicit closing beforehand.

The crash was related to custom Sentry output devices that were not deregistered properly upon any subsequent initialization attempt.

Also, assertion/ensure delegates are now deregistered too whenever calling subsystem's `Close` method to avoid potential reporting of the same event multiple times if re-init occured.

Closes #592