### PR TITLE
Fix missing headers breaking non-unity builds in release 0.19.0.

### DIFF
--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -18,6 +18,8 @@
 #include "Framework/Notifications/NotificationManager.h"
 #include "Interfaces/IPluginManager.h"
 #include "Runtime/Launch/Resources/Version.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformFileManager.h"
 
 #include "Widgets/Text/SRichTextBlock.h"
 #include "Widgets/Text/STextBlock.h"


### PR DESCRIPTION
When upgrading from release 0.16.0 to 0.19.0, our Unreal project failed to build due to missing headers. Adding references to both `HAL/FileManager.h` and `HAL/PlatformFileManager.h` fixed the build.