### PR TITLE
Fix build errors due to missing includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Missing includes errors should no longer pass over CI checks ([#606](https://github.com/getsentry/sentry-unreal/pull/606))
+
 ## 0.19.0
 
 ### Breaking Changes

--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -16,6 +16,8 @@
 #include "Misc/ConfigCacheIni.h"
 #include "PropertyHandle.h"
 #include "Framework/Notifications/NotificationManager.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformFileManager.h"
 #include "Interfaces/IPluginManager.h"
 #include "Runtime/Launch/Resources/Version.h"
 

--- a/sample/Source/SentryPlaygroundEditor.Target.cs
+++ b/sample/Source/SentryPlaygroundEditor.Target.cs
@@ -10,6 +10,10 @@ public class SentryPlaygroundEditorTarget : TargetRules
 		Type = TargetType.Editor;
 		DefaultBuildSettings = BuildSettingsVersion.Latest;
 
+		// Disable Unity build and PCH files to catch missing include errors in CI
+		bUseUnityBuild = false;
+		bUsePCHFiles = false;
+
 #if UE_5_1_OR_LATER
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 #endif


### PR DESCRIPTION
This PR adds missing includes that were causing build errors and disable Unity build and PCH filses usage for sample's editor target to detect these issues in CI automatically.

Related to #604 