### PR TITLE
Fix batch script 'exit' usage which breaks command chaining (&&).

### DIFF
--- a/plugin-dev/Scripts/upload-debug-symbols-win.bat
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.bat
@@ -17,7 +17,7 @@ echo Sentry: Start debug symbols upload
 
 if "%TargetType%"=="Editor" (
     echo Sentry: Automatic symbols upload is not required for Editor target. Skipping...
-    exit
+    exit /B 0
 )
 
 if "%TargetPlatform%"=="Win64" (
@@ -26,17 +26,17 @@ if "%TargetPlatform%"=="Win64" (
     set CliExec=%PluginPath:"=%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
 ) else if "%TargetPlatform%"=="Android" (
     echo Warning: Sentry: Debug symbols upload for Android is handled by Sentry's gradle plugin if enabled
-    exit
+    exit /B 0
 ) else (
     echo Warning: Sentry: Unexpected platform %TargetPlatform%. Skipping...
-    exit
+    exit /B 0
 )
 
 call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings UploadSymbolsAutomatically UploadSymbols
 
 if /i "%UploadSymbols%" NEQ "True" (
     echo Sentry: Automatic symbols upload is disabled in plugin settings. Skipping...
-    exit
+    exit /B 0
 )
 
 call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings IncludeSources IncludeSourceFiles
@@ -65,7 +65,7 @@ if not "%EnabledPlatforms%"=="" (
   call :FindString EnabledPlatforms PlatformToCheck IsPlatformDisabled
   if "!IsPlatformDisabled!"=="true" (
       echo "Sentry: Automatic symbols upload is disabled for build platform %TargetPlatform%. Skipping..."
-      exit
+      exit /B 0
   )
 )
 
@@ -75,7 +75,7 @@ if not "%EnabledTargets%"=="" (
   call :FindString EnabledTargets TargetToCheck IsTargetDisabled
   if "!IsTargetDisabled!"=="true" (
       echo "Sentry: Automatic symbols upload is disabled for build target type %TargetType%. Skipping..."
-      exit
+      exit /B 0
   )
 )
 
@@ -85,7 +85,7 @@ if not "%EnabledConfigurations%"=="" (
   call :FindString EnabledConfigurations ConfigToCheck IsConfigDisabled
   if "!IsConfigDisabled!"=="true" (
       echo "Sentry: Automatic symbols upload is disabled for build configuration %TargetConfig%. Skipping..."
-      exit
+      exit /B 0
   )
 )
 
@@ -93,12 +93,12 @@ set PropertiesFile=%ProjectPath:"=%\sentry.properties
 
 if not exist "%PropertiesFile%" (
     echo Warning: Sentry: Properties file is missing: '%PropertiesFile%'
-    exit
+    exit /B 0
 )
 
 if not exist "%CliExec%" (
     echo Warning: Sentry: Sentry CLI is not configured in plugin settings. Skipping...
-    exit
+    exit /B 0
 )
 
 echo Sentry: Upload started using PropertiesFile '%PropertiesFile%'
@@ -111,10 +111,10 @@ call "%CliExec%" upload-dif %CliArgs% --log-level %CliLogLevel% "%ProjectBinarie
 echo Sentry: Upload finished
 
 endlocal
-exit
+exit /B 0
 
 :FindString <sourceStr> <findStr> <result>
-  setlocal  
+  setlocal
   for /f "delims=" %%A in ('echo %%%1%%') do set str1=%%A
   for /f "delims=" %%A in ('echo %%%2%%') do set str2=%%A
   echo.%str1%|findstr /C:"%str2%" >nul 2>&1
@@ -123,7 +123,7 @@ exit
     set %~3=true
   ) else (
     set %~3=false
-  )  
+  )
   goto :eof
 
 :ParseIniFile <filename> <section> <key> <result>


### PR DESCRIPTION
Refrain from using `exit` in Windows Batch scripts since this breaks behaviour in Unreal Engine that uses command chaining (`&&`) for `PostBuildStep` action commands ([`UEBuildTarget.cs:2864`](https://github.com/EpicGames/UnrealEngine/blob/release/Engine/Source/Programs/UnrealBuildTool/Configuration/UEBuildTarget.cs#L2864)). This means that the associated `.run` sentinel files aren't output, breaking minimal rebuild checks.

> Note 2: Command [EXIT](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/exit_2) without parameter /B results always in exiting entire command process independent on calling hierarchy and independent on how the Windows command processor was started – with parameter /K to keep cmd.exe running as used when opening a command prompt window or with /C to close after command processing finished as used on double clicking a batch file. Therefore exit without /B should be used wisely in a batch file (best: never).[^1]

[^1]: https://stackoverflow.com/a/37518000