### PR TITLE
Add non-ASCII characters support for user messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add non-ASCII characters support for user messages ([#624](https://github.com/getsentry/sentry-unreal/pull/624))
+
 ### Fixes
 
 - Fix intermittent errors during plugin initialization on macOS/iOS ([#618](https://github.com/getsentry/sentry-unreal/pull/618))

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryBreadcrumbDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryBreadcrumbDesktop.cpp
@@ -28,7 +28,7 @@ sentry_value_t SentryBreadcrumbDesktop::GetNativeObject()
 
 void SentryBreadcrumbDesktop::SetMessage(const FString& message)
 {
-	sentry_value_set_by_key(BreadcrumbDesktop, "message", sentry_value_new_string(TCHAR_TO_ANSI(*message)));
+	sentry_value_set_by_key(BreadcrumbDesktop, "message", sentry_value_new_string(TCHAR_TO_UTF8(*message)));
 }
 
 FString SentryBreadcrumbDesktop::GetMessage() const

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryEventDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryEventDesktop.cpp
@@ -31,7 +31,7 @@ sentry_value_t SentryEventDesktop::GetNativeObject()
 void SentryEventDesktop::SetMessage(const FString& message)
 {
 	sentry_value_t messageСontainer = sentry_value_new_object();
-	sentry_value_set_by_key(messageСontainer, "formatted", sentry_value_new_string(TCHAR_TO_ANSI(*message)));
+	sentry_value_set_by_key(messageСontainer, "formatted", sentry_value_new_string(TCHAR_TO_UTF8(*message)));
 	sentry_value_set_by_key(EventDesktop, "message", messageСontainer);
 }
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -193,13 +193,13 @@ void SentrySubsystemDesktop::InitWithSettings(const USentrySettings* settings, U
 		sentry_options_set_handler_pathw(options, *HandlerPath);
 	}
 #elif PLATFORM_LINUX
-	sentry_options_set_handler_path(options, TCHAR_TO_ANSI(*GetHandlerPath()));
+	sentry_options_set_handler_path(options, TCHAR_TO_UTF8(*GetHandlerPath()));
 #endif
 
 #if PLATFORM_WINDOWS
 	sentry_options_set_database_pathw(options, *GetDatabasePath());
 #elif PLATFORM_LINUX
-	sentry_options_set_database_path(options, TCHAR_TO_ANSI(*GetDatabasePath()));
+	sentry_options_set_database_path(options, TCHAR_TO_UTF8(*GetDatabasePath()));
 #endif
 
 	sentry_options_set_release(options, TCHAR_TO_ANSI(settings->OverrideReleaseName

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -301,7 +301,7 @@ void SentrySubsystemDesktop::ClearBreadcrumbs()
 
 USentryId* SentrySubsystemDesktop::CaptureMessage(const FString& message, ESentryLevel level)
 {
-	sentry_value_t sentryEvent = sentry_value_new_message_event(SentryConvertorsDesktop::SentryLevelToNative(level), nullptr, TCHAR_TO_ANSI(*message));
+	sentry_value_t sentryEvent = sentry_value_new_message_event(SentryConvertorsDesktop::SentryLevelToNative(level), nullptr, TCHAR_TO_UTF8(*message));
 
 	if(isStackTraceEnabled)
 	{

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryUserFeedbackDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryUserFeedbackDesktop.cpp
@@ -31,7 +31,7 @@ sentry_value_t SentryUserFeedbackDesktop::GetNativeObject()
 
 void SentryUserFeedbackDesktop::SetName(const FString& name)
 {
-	sentry_value_set_by_key(UserFeedbackDesktop, "name", sentry_value_new_string(TCHAR_TO_ANSI(*name)));
+	sentry_value_set_by_key(UserFeedbackDesktop, "name", sentry_value_new_string(TCHAR_TO_UTF8(*name)));
 }
 
 FString SentryUserFeedbackDesktop::GetName() const
@@ -53,7 +53,7 @@ FString SentryUserFeedbackDesktop::GetEmail() const
 
 void SentryUserFeedbackDesktop::SetComment(const FString& comment)
 {
-	sentry_value_set_by_key(UserFeedbackDesktop, "comments", sentry_value_new_string(TCHAR_TO_ANSI(*comment)));
+	sentry_value_set_by_key(UserFeedbackDesktop, "comments", sentry_value_new_string(TCHAR_TO_UTF8(*comment)));
 }
 
 FString SentryUserFeedbackDesktop::GetComment() const


### PR DESCRIPTION
This PR adds non-ASCII characters support in custom messages that users might provide for entities like events, breadcrumbs or user feedback.

Closes #621 