### PR TITLE
Add trace propagation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add setting that allows switching between the project and user directories for the internal Sentry database location on Windows/Linux ([#616](https://github.com/getsentry/sentry-unreal/pull/616))
 - Add non-ASCII characters support for user messages ([#624](https://github.com/getsentry/sentry-unreal/pull/624))
-- Add trace propagation ([#631](https://github.com/getsentry/sentry-unreal/pull/631))
+- Added API to allow users to trace their distributed system and connect in-game with backend errors ([#631](https://github.com/getsentry/sentry-unreal/pull/631))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - Add setting that allows switching between the project and user directories for the internal Sentry database location on Windows/Linux ([#616](https://github.com/getsentry/sentry-unreal/pull/616))
 - Add non-ASCII characters support for user messages ([#624](https://github.com/getsentry/sentry-unreal/pull/624))
-- Added API to allow users to trace their distributed system and connect in-game with backend errors ([#631](https://github.com/getsentry/sentry-unreal/pull/631))
+- Add API to allow users to trace their distributed system and connect in-game with backend errors ([#631](https://github.com/getsentry/sentry-unreal/pull/631))
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add setting that allows switching between the project and user directories for the internal Sentry database location on Windows/Linux ([#616](https://github.com/getsentry/sentry-unreal/pull/616))
 - Add non-ASCII characters support for user messages ([#624](https://github.com/getsentry/sentry-unreal/pull/624))
+- Add trace propagation ([#631](https://github.com/getsentry/sentry-unreal/pull/631))
 
 ### Fixes
 

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/SentryJavaClasses.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/SentryJavaClasses.cpp
@@ -21,6 +21,7 @@ const FSentryJavaClass SentryJavaClasses::SamplingContext		= FSentryJavaClass { 
 const FSentryJavaClass SentryJavaClasses::CustomSamplingContext	= FSentryJavaClass { "io/sentry/CustomSamplingContext", ESentryJavaClassType::External };
 const FSentryJavaClass SentryJavaClasses::TransactionContext	= FSentryJavaClass { "io/sentry/TransactionContext", ESentryJavaClassType::External };
 const FSentryJavaClass SentryJavaClasses::TransactionOptions	= FSentryJavaClass { "io/sentry/TransactionOptions", ESentryJavaClassType::External };
+const FSentryJavaClass SentryJavaClasses::SentryTraceHeader		= FSentryJavaClass { "io/sentry/SentryTraceHeader", ESentryJavaClassType::External };
 
 // System Java classes definitions
 const FSentryJavaClass SentryJavaClasses::ArrayList				= FSentryJavaClass { "java/util/ArrayList", ESentryJavaClassType::System };

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/SentryJavaClasses.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/SentryJavaClasses.h
@@ -25,6 +25,7 @@ struct SentryJavaClasses
 	const static FSentryJavaClass CustomSamplingContext;
 	const static FSentryJavaClass TransactionContext;
 	const static FSentryJavaClass TransactionOptions;
+	const static FSentryJavaClass SentryTraceHeader;
 
 	// System Java classes
 	const static FSentryJavaClass ArrayList;

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySpanAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySpanAndroid.cpp
@@ -17,6 +17,7 @@ void SentrySpanAndroid::SetupClassMethods()
 	IsFinishedMethod = GetMethod("isFinished", "()Z");
 	SetTagMethod = GetMethod("setTag", "(Ljava/lang/String;Ljava/lang/String;)V");
 	SetDataMethod = GetMethod("setData", "(Ljava/lang/String;Ljava/lang/Object;)V");
+	ToSentryTraceMethod = GetMethod("toSentryTrace", "()Lio/sentry/SentryTraceHeader;");
 }
 
 void SentrySpanAndroid::Finish()
@@ -47,4 +48,13 @@ void SentrySpanAndroid::SetData(const FString& key, const TMap<FString, FString>
 void SentrySpanAndroid::RemoveData(const FString& key)
 {
 	SetData(key, TMap<FString, FString>());
+}
+
+void SentrySpanAndroid::GetTrace(FString& name, FString& value)
+{
+	FSentryJavaObjectWrapper NativeTraceHeader(SentryJavaClasses::SentryTraceHeader, *CallObjectMethod<jobject>(ToSentryTraceMethod));
+	FSentryJavaMethod GetValueMethod = NativeTraceHeader.GetMethod("getValue", "()Ljava/lang/String;");
+
+	name = TEXT("sentry-trace");
+	value = NativeTraceHeader.CallMethod<FString>(GetValueMethod);
 }

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySpanAndroid.h
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySpanAndroid.h
@@ -19,11 +19,12 @@ public:
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetData(const FString& key, const TMap<FString, FString>& values) override;
 	virtual void RemoveData(const FString& key) override;
-
+	virtual void GetTrace(FString& name, FString& value) override;
 
 private:
 	FSentryJavaMethod FinishMethod;
 	FSentryJavaMethod IsFinishedMethod;
 	FSentryJavaMethod SetTagMethod;
 	FSentryJavaMethod SetDataMethod;
+	FSentryJavaMethod ToSentryTraceMethod;
 };

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
@@ -292,3 +292,11 @@ USentryTransaction* SentrySubsystemAndroid::StartTransactionWithContextAndOption
 
 	return SentryConvertorsAndroid::SentryTransactionToUnreal(*transaction);
 }
+
+USentryTransactionContext* SentrySubsystemAndroid::ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders)
+{
+	auto transactionContext = FSentryJavaObjectWrapper::CallStaticObjectMethod<jobject>(SentryJavaClasses::Sentry, "continueTrace", "(Ljava/lang/String;Ljava/util/List;)Lio/sentry/TransactionContext;",
+		*FSentryJavaObjectWrapper::GetJString(sentryTrace), SentryConvertorsAndroid::StringArrayToNative(baggageHeaders)->GetJObject());
+
+	return SentryConvertorsAndroid::SentryTransactionContextToUnreal(*transactionContext);
+}

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.h
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.h
@@ -34,4 +34,5 @@ public:
 	virtual USentryTransaction* StartTransaction(const FString& name, const FString& operation) override;
 	virtual USentryTransaction* StartTransactionWithContext(USentryTransactionContext* context) override;
 	virtual USentryTransaction* StartTransactionWithContextAndOptions(USentryTransactionContext* context, const TMap<FString, FString>& options) override;
+	virtual USentryTransactionContext* ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders) override;
 };

--- a/plugin-dev/Source/Sentry/Private/Android/SentryTransactionAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/SentryTransactionAndroid.cpp
@@ -19,6 +19,7 @@ void SentryTransactionAndroid::SetupClassMethods()
 	SetNameMethod = GetMethod("setName", "(Ljava/lang/String;)V");
 	SetTagMethod = GetMethod("setTag", "(Ljava/lang/String;Ljava/lang/String;)V");
 	SetDataMethod = GetMethod("setData", "(Ljava/lang/String;Ljava/lang/Object;)V");
+	ToSentryTraceMethod = GetMethod("toSentryTrace", "()Lio/sentry/SentryTraceHeader;");
 }
 
 USentrySpan* SentryTransactionAndroid::StartChild(const FString& operation, const FString& desctiption)
@@ -60,4 +61,13 @@ void SentryTransactionAndroid::SetData(const FString& key, const TMap<FString, F
 void SentryTransactionAndroid::RemoveData(const FString& key)
 {
 	SetData(key, TMap<FString, FString>());
+}
+
+void SentryTransactionAndroid::GetTrace(FString& name, FString& value)
+{
+	FSentryJavaObjectWrapper NativeTraceHeader(SentryJavaClasses::SentryTraceHeader, *CallObjectMethod<jobject>(ToSentryTraceMethod));
+	FSentryJavaMethod GetValueMethod = NativeTraceHeader.GetMethod("getValue", "()Ljava/lang/String;");
+
+	name = TEXT("sentry-trace");
+	value = NativeTraceHeader.CallMethod<FString>(GetValueMethod);
 }

--- a/plugin-dev/Source/Sentry/Private/Android/SentryTransactionAndroid.h
+++ b/plugin-dev/Source/Sentry/Private/Android/SentryTransactionAndroid.h
@@ -21,6 +21,7 @@ public:
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetData(const FString& key, const TMap<FString, FString>& values) override;
 	virtual void RemoveData(const FString& key) override;
+	virtual void GetTrace(FString& name, FString& value) override;
 
 private:
 	FSentryJavaMethod StartChildMethod;
@@ -29,4 +30,5 @@ private:
 	FSentryJavaMethod SetNameMethod;
 	FSentryJavaMethod SetTagMethod;
 	FSentryJavaMethod SetDataMethod;
+	FSentryJavaMethod ToSentryTraceMethod;
 };

--- a/plugin-dev/Source/Sentry/Private/Apple/SentryIdApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentryIdApple.cpp
@@ -7,7 +7,12 @@
 
 SentryIdApple::SentryIdApple()
 {
+	// `SentryId` definition was moved to Swift so its name that can be recognized by UE should be taken from "Sentry-Swift.h" to successfully load class on Mac
+#if PLATFORM_MAC
+	IdApple = [[SENTRY_APPLE_CLASS(_TtC6Sentry8SentryId) alloc] init];
+#elif PLATFORM_IOS
 	IdApple = [[SENTRY_APPLE_CLASS(SentryId) alloc] init];
+#endif
 }
 
 SentryIdApple::SentryIdApple(SentryId* id)

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySpanApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySpanApple.cpp
@@ -56,5 +56,8 @@ void SentrySpanApple::RemoveData(const FString& key)
 
 void SentrySpanApple::GetTrace(FString& name, FString& value)
 {
-	UE_LOG(LogSentrySdk, Log, TEXT("Manual trace propagation not supported for Apple."));
+	SentryTraceHeader* traceHeader = [SpanApple toTraceHeader];
+
+	name = TEXT("sentry-trace");
+	value = FString([traceHeader value]);
 }

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySpanApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySpanApple.cpp
@@ -2,6 +2,8 @@
 
 #include "SentrySpanApple.h"
 
+#include "SentryDefines.h"
+
 #include "Infrastructure/SentryConvertorsApple.h"
 
 #include "Convenience/SentryInclude.h"
@@ -50,4 +52,9 @@ void SentrySpanApple::SetData(const FString& key, const TMap<FString, FString>& 
 void SentrySpanApple::RemoveData(const FString& key)
 {
 	[SpanApple removeDataForKey:key.GetNSString()];
+}
+
+void SentrySpanApple::GetTrace(FString& name, FString& value)
+{
+	UE_LOG(LogSentrySdk, Log, TEXT("Manual trace propagation not supported for Apple."));
 }

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySpanApple.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySpanApple.h
@@ -20,7 +20,7 @@ public:
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetData(const FString& key, const TMap<FString, FString>& values) override;
 	virtual void RemoveData(const FString& key) override;
-
+	virtual void GetTrace(FString& name, FString& value) override;
 
 private:
 	id<SentrySpan> SpanApple;

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
@@ -79,7 +79,6 @@ void SentrySubsystemApple::InitWithSettings(const USentrySettings* settings, USe
 				[options addInAppExclude:it->GetNSString()];
 			}
 			options.enableAppHangTracking = settings->EnableAppNotRespondingTracking;
-			options.enableTracing = settings->EnableTracing;
 			if(settings->EnableTracing && settings->SamplingType == ESentryTracesSamplingType::UniformSampleRate)
 			{
 				options.tracesSampleRate = [NSNumber numberWithFloat:settings->TracesSampleRate];

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
@@ -319,9 +319,17 @@ USentryTransactionContext* SentrySubsystemApple::ContinueTrace(const FString& se
 	{
 		sampleDecision = traceParts[2].Equals(TEXT("1")) ? kSentrySampleDecisionYes : kSentrySampleDecisionNo;
 	}
-	
+
+	// `SentryId` definition was moved to Swift so its name that can be recognized by UE should be taken from "Sentry-Swift.h" to successfully load class on Mac
+
+#if PLATFORM_MAC
+	SentryId* traceId = [[SENTRY_APPLE_CLASS(_TtC6Sentry8SentryId) alloc] initWithUUIDString:traceParts[0].GetNSString()];
+#elif PLATFORM_IOS
+	SentryId* traceId = [[SENTRY_APPLE_CLASS(SentryId) alloc] initWithUUIDString:traceParts[0].GetNSString()];
+#endif
+
 	SentryTransactionContext* transactionContext = [[SENTRY_APPLE_CLASS(SentryTransactionContext) alloc] initWithName:@"<unlabeled transaction>" operation:@"default"
-		traceId:[[SENTRY_APPLE_CLASS(SentryId) alloc] initWithUUIDString:traceParts[0].GetNSString()]
+		traceId:traceId
 		spanId:[[SENTRY_APPLE_CLASS(SentrySpanId) alloc] init]
 		parentSpanId:[[SENTRY_APPLE_CLASS(SentrySpanId) alloc] initWithValue:traceParts[1].GetNSString()]
 		parentSampled:sampleDecision];

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
@@ -333,5 +333,7 @@ USentryTransactionContext* SentrySubsystemApple::ContinueTrace(const FString& se
 		parentSpanId:[[SENTRY_APPLE_CLASS(SentrySpanId) alloc] initWithValue:traceParts[1].GetNSString()]
 		parentSampled:sampleDecision];
 
+	// currently `sentry-cocoa` doesn't have API for `SentryTransactionContext` to set `baggageHeaders`
+
 	return SentryConvertorsApple::SentryTransactionContextToUnreal(transactionContext);
 }

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.cpp
@@ -303,3 +303,9 @@ USentryTransaction* SentrySubsystemApple::StartTransactionWithContextAndOptions(
 
 	return SentryConvertorsApple::SentryTransactionToUnreal(transaction);
 }
+
+USentryTransactionContext* SentrySubsystemApple::ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders)
+{
+	UE_LOG(LogSentrySdk, Log, TEXT("Manual trace propagation not supported for Apple."));
+	return nullptr;
+}

--- a/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentrySubsystemApple.h
@@ -34,4 +34,5 @@ public:
 	virtual USentryTransaction* StartTransaction(const FString& name, const FString& operation) override;
 	virtual USentryTransaction* StartTransactionWithContext(USentryTransactionContext* context) override;
 	virtual USentryTransaction* StartTransactionWithContextAndOptions(USentryTransactionContext* context, const TMap<FString, FString>& options) override;
+	virtual USentryTransactionContext* ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders) override;
 };

--- a/plugin-dev/Source/Sentry/Private/Apple/SentryTransactionApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentryTransactionApple.cpp
@@ -68,5 +68,8 @@ void SentryTransactionApple::RemoveData(const FString& key)
 
 void SentryTransactionApple::GetTrace(FString& name, FString& value)
 {
-	UE_LOG(LogSentrySdk, Log, TEXT("Manual trace propagation not supported for Apple."));
+	SentryTraceHeader* traceHeader = [TransactionApple toTraceHeader];
+
+	name = TEXT("sentry-trace");
+	value = FString([traceHeader value]);
 }

--- a/plugin-dev/Source/Sentry/Private/Apple/SentryTransactionApple.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentryTransactionApple.cpp
@@ -65,3 +65,8 @@ void SentryTransactionApple::RemoveData(const FString& key)
 {
 	[TransactionApple removeDataForKey:key.GetNSString()];
 }
+
+void SentryTransactionApple::GetTrace(FString& name, FString& value)
+{
+	UE_LOG(LogSentrySdk, Log, TEXT("Manual trace propagation not supported for Apple."));
+}

--- a/plugin-dev/Source/Sentry/Private/Apple/SentryTransactionApple.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/SentryTransactionApple.h
@@ -22,6 +22,7 @@ public:
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetData(const FString& key, const TMap<FString, FString>& values) override;
 	virtual void RemoveData(const FString& key) override;
+	virtual void GetTrace(FString& name, FString& value) override;
 
 private:
 	id<SentrySpan> TransactionApple;

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySpanDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySpanDesktop.cpp
@@ -6,6 +6,12 @@
 
 #if USE_SENTRY_NATIVE
 
+void CopySpanTracingHeader(const char *key, const char *value, void *userdata)
+{
+	sentry_value_t *header = static_cast<sentry_value_t*>(userdata);
+	sentry_value_set_by_key(*header, key, sentry_value_new_string(value));
+}
+
 SentrySpanDesktop::SentrySpanDesktop(sentry_span_t* span)
 	: SpanDesktop(span)
 	, isFinished(false)
@@ -60,6 +66,18 @@ void SentrySpanDesktop::RemoveData(const FString& key)
 	FScopeLock Lock(&CriticalSection);
 
 	sentry_span_remove_data(SpanDesktop, TCHAR_TO_ANSI(*key));
+}
+
+void SentrySpanDesktop::GetTrace(FString& name, FString& value)
+{
+	sentry_value_t tracingHeader = sentry_value_new_object();
+
+	sentry_span_iter_headers(SpanDesktop, CopySpanTracingHeader, &tracingHeader);
+
+	name = TEXT("sentry-trace");
+	value = FString(sentry_value_as_string(sentry_value_get_by_key(tracingHeader, "sentry-trace")));
+
+	sentry_value_decref(tracingHeader);
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySpanDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySpanDesktop.h
@@ -24,6 +24,7 @@ public:
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetData(const FString& key, const TMap<FString, FString>& values) override;
 	virtual void RemoveData(const FString& key) override;
+	virtual void GetTrace(FString& name, FString& value) override;
 
 private:
 	sentry_span_t* SpanDesktop;

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.cpp
@@ -497,6 +497,21 @@ USentryTransaction* SentrySubsystemDesktop::StartTransactionWithContextAndOption
 	return StartTransactionWithContext(context);
 }
 
+USentryTransactionContext* SentrySubsystemDesktop::ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders)
+{
+	sentry_transaction_context_t* nativeTransactionContext = sentry_transaction_context_new("<unlabeled transaction>", "default");
+	sentry_transaction_context_update_from_header(nativeTransactionContext, "sentry-trace", TCHAR_TO_ANSI(*sentryTrace));
+
+	// currently `sentry-native` doesn't have API for `sentry_transaction_context_t` to set `baggageHeaders`
+
+	TSharedPtr<SentryTransactionContextDesktop> transactionContextDesktop = MakeShareable(new SentryTransactionContextDesktop(nativeTransactionContext));
+
+	USentryTransactionContext* TransactionContext = NewObject<USentryTransactionContext>();
+	TransactionContext->InitWithNativeImpl(transactionContextDesktop);
+
+	return TransactionContext;
+}
+
 USentryBeforeSendHandler* SentrySubsystemDesktop::GetBeforeSendHandler()
 {
 	return beforeSend;

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentrySubsystemDesktop.h
@@ -43,6 +43,7 @@ public:
 	virtual USentryTransaction* StartTransaction(const FString& name, const FString& operation) override;
 	virtual USentryTransaction* StartTransactionWithContext(USentryTransactionContext* context) override;
 	virtual USentryTransaction* StartTransactionWithContextAndOptions(USentryTransactionContext* context, const TMap<FString, FString>& options) override;
+	virtual USentryTransactionContext* ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders) override;
 
 	USentryBeforeSendHandler* GetBeforeSendHandler();
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryTransactionDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryTransactionDesktop.h
@@ -26,6 +26,7 @@ public:
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetData(const FString& key, const TMap<FString, FString>& values) override;
 	virtual void RemoveData(const FString& key) override;
+	virtual void GetTrace(FString& name, FString& value) override;
 
 private:
 	sentry_transaction_t* TransactionDesktop;

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySpanInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySpanInterface.h
@@ -15,4 +15,5 @@ public:
 	virtual void RemoveTag(const FString& key) = 0;
 	virtual void SetData(const FString& key, const TMap<FString, FString>& values) = 0;
 	virtual void RemoveData(const FString& key) = 0;
+	virtual void GetTrace(FString& name, FString& value) = 0;
 };

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
@@ -50,4 +50,5 @@ public:
 	virtual USentryTransaction* StartTransaction(const FString& name, const FString& operation) = 0;
 	virtual USentryTransaction* StartTransactionWithContext(USentryTransactionContext* context) = 0;
 	virtual USentryTransaction* StartTransactionWithContextAndOptions(USentryTransactionContext* context, const TMap<FString, FString>& options) = 0;
+	virtual USentryTransactionContext* ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders) = 0;
 };

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryTransactionInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryTransactionInterface.h
@@ -19,4 +19,5 @@ public:
 	virtual void RemoveTag(const FString& key) = 0;
 	virtual void SetData(const FString& key, const TMap<FString, FString>& values) = 0;
 	virtual void RemoveData(const FString& key) = 0;
+	virtual void GetTrace(FString& name, FString& value) = 0;
 };

--- a/plugin-dev/Source/Sentry/Private/SentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySpan.cpp
@@ -64,6 +64,14 @@ void USentrySpan::RemoveData(const FString& key)
 	SentrySpanNativeImpl->RemoveData(key);
 }
 
+void USentrySpan::GetTrace(FString& name, FString& value)
+{
+	if (!SentrySpanNativeImpl || SentrySpanNativeImpl->IsFinished())
+		return;
+
+	SentrySpanNativeImpl->GetTrace(name, value);
+}
+
 void USentrySpan::InitWithNativeImpl(TSharedPtr<ISentrySpan> spanImpl)
 {
 	SentrySpanNativeImpl = spanImpl;

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -392,6 +392,14 @@ USentryTransaction* USentrySubsystem::StartTransactionWithContextAndOptions(USen
 	return SubsystemNativeImpl->StartTransactionWithContextAndOptions(Context, Options);
 }
 
+USentryTransactionContext* USentrySubsystem::ContinueTrace(const FString& SentryTrace, const TArray<FString>& BaggageHeaders)
+{
+	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
+		return nullptr;
+
+	return SubsystemNativeImpl->ContinueTrace(SentryTrace, BaggageHeaders);
+}
+
 bool USentrySubsystem::IsSupportedForCurrentSettings()
 {
 	if(!IsCurrentBuildConfigurationEnabled() || !IsCurrentBuildTargetEnabled() || !IsCurrentPlatformEnabled())

--- a/plugin-dev/Source/Sentry/Private/SentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryTransaction.cpp
@@ -81,6 +81,14 @@ void USentryTransaction::RemoveData(const FString& key)
 	SentryTransactionNativeImpl->RemoveData(key);
 }
 
+void USentryTransaction::GetTrace(FString& name, FString& value)
+{
+	if (!SentryTransactionNativeImpl || SentryTransactionNativeImpl->IsFinished())
+		return;
+
+	SentryTransactionNativeImpl->GetTrace(name, value);
+}
+
 void USentryTransaction::InitWithNativeImpl(TSharedPtr<ISentryTransaction> transactionImpl)
 {
 	SentryTransactionNativeImpl = transactionImpl;

--- a/plugin-dev/Source/Sentry/Public/SentrySpan.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySpan.h
@@ -43,6 +43,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
 	void RemoveData(const FString& key);
 
+	/** Gets trace information that could be sent as a `sentry-trace` header */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	void GetTrace(FString& name, FString& value);
+
 	void InitWithNativeImpl(TSharedPtr<ISentrySpan> spanImpl);
 	TSharedPtr<ISentrySpan> GetNativeImpl();
 

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -269,6 +269,16 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
 	USentryTransaction* StartTransactionWithContextAndOptions(USentryTransactionContext* Context, const TMap<FString, FString>& Options);
 
+	/**
+	 * Creates a transaction context to propagate distributed tracing metadata from upstream
+	 * services and continue a trace based on corresponding HTTP header values.
+	 *
+	 * @param SentryTrace Incoming request 'sentry-trace' header
+	 * @param BaggageHeaders Incoming request 'baggage' headers
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Sentry", meta = (AutoCreateRefTerm = "BaggageHeaders"))
+	USentryTransactionContext* ContinueTrace(const FString& SentryTrace, const TArray<FString>& BaggageHeaders);
+
 	/** Checks if Sentry event capturing is supported for current settings. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
 	bool IsSupportedForCurrentSettings();

--- a/plugin-dev/Source/Sentry/Public/SentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Public/SentryTransaction.h
@@ -52,6 +52,10 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
 	void RemoveData(const FString& key);
 
+	/** Gets trace information that could be sent as a `sentry-trace` header */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	void GetTrace(FString& name, FString& value);
+
 	void InitWithNativeImpl(TSharedPtr<ISentryTransaction> transactionImpl);
 	TSharedPtr<ISentryTransaction> GetNativeImpl();
 


### PR DESCRIPTION
This PR adds missing APIs required for the distributed tracing feature. Basically, now it's possible to create a new `TransactionContext` based on a given [trace header](https://develop.sentry.dev/sdk/telemetry/traces/#header-sentry-trace) and query existing span/transaction trace info for its further propagation.

Closes #627 