### PR TITLE
Allow override of UploadSymbolsAutomatically value from an environment variable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add setting that allows switching between the project and user directories for the internal Sentry database location on Windows/Linux ([#616](https://github.com/getsentry/sentry-unreal/pull/616))
 - Add non-ASCII characters support for user messages ([#624](https://github.com/getsentry/sentry-unreal/pull/624))
+- Allow overriding `UploadSymbolsAutomatically` via environment variable `SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY` ([#636](https://github.com/getsentry/sentry-unreal/pull/636))
 
 ### Fixes
 

--- a/plugin-dev/Scripts/upload-debug-symbols-win.bat
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.bat
@@ -32,10 +32,16 @@ if "%TargetPlatform%"=="Win64" (
     exit /B 0
 )
 
-call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings UploadSymbolsAutomatically UploadSymbols
+if /i "%SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY%" NEQ "" (
+  set UploadSymbols=%SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY%
+  echo Sentry: Automatic symbols upload is overridden as '%SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY%' from environment variable SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY
+) else (
+  call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings UploadSymbolsAutomatically UploadSymbols
+  echo Sentry: Automatic symbols upload is '%UploadSymbols%' from plugin settings
+)
 
 if /i "%UploadSymbols%" NEQ "True" (
-    echo Sentry: Automatic symbols upload is disabled in plugin settings. Skipping...
+    echo Sentry: Automatic symbols upload is disabled. Skipping...
     exit /B 0
 )
 

--- a/plugin-dev/Scripts/upload-debug-symbols-win.bat
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.bat
@@ -32,12 +32,12 @@ if "%TargetPlatform%"=="Win64" (
     exit /B 0
 )
 
+call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings UploadSymbolsAutomatically UploadSymbols
+echo Sentry: Automatic symbols upload is '%UploadSymbols%' from plugin settings
+
 if /i "%SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY%" NEQ "" (
   set UploadSymbols=%SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY%
   echo Sentry: Automatic symbols upload is overridden as '%SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY%' from environment variable SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY
-) else (
-  call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings UploadSymbolsAutomatically UploadSymbols
-  echo Sentry: Automatic symbols upload is '%UploadSymbols%' from plugin settings
 )
 
 if /i "%UploadSymbols%" NEQ "True" (

--- a/plugin-dev/Scripts/upload-debug-symbols.sh
+++ b/plugin-dev/Scripts/upload-debug-symbols.sh
@@ -31,6 +31,12 @@ else
 fi
 
 UPLOAD_SYMBOLS=$(awk -F "=" '/UploadSymbolsAutomatically/ {print $2}' "${CONFIG_PATH}/DefaultEngine.ini")
+echo "Sentry: Automatic symbols upload is '$UPLOAD_SYMBOLS' from plugin settings"
+
+if [ ! -z $SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY ]; then
+    UPLOAD_SYMBOLS=$SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY
+    echo "Sentry: Automatic symbols upload is overridden as '$SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY' from environment variable SENTRY_UPLOAD_SYMBOLS_AUTOMATICALLY"
+fi
 
 if [ -z $UPLOAD_SYMBOLS ]; then
     echo "Sentry: Automatic symbols upload is disabled in plugin settings. Skipping..."


### PR DESCRIPTION
The use-case for this is that we want to upload symbols in some CI builds, but not when developers build and cook locally, so currently we have to edit the config file DefaultConfig.ini as part of the CI process. This is cumbersome, as it has some awkward interactions with Perforce and e.g. TeamCity that make the state of the files on CI agents hard to reason about without adding a preamble script to every job that enforces the correct value, even ones that shouldn't need to touch this config file. It interacts especially poorly when a developer has edited DefaultConfig.ini in their Perforce changelist, and introduces risk when other jobs reusing the same workspace make commits back to Perforce.

Allowing an environment variable to be supplied instead will allow conditional enabling / disabling of symbol upload without having to edit files, making it much easier to implement without having to worry about the state of files on disk, so is much preferable.

I've tested this with Unreal Engine 5.4, and the environment variable is passed through from the call to UnrealAutomationTool through to invoking the post-build script.