### PR TITLE
Fix Sentry initialization on Amazon Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix Sentry initialization on Amazon Linux ([#657](https://github.com/getsentry/sentry-unreal/pull/657))
+
 ## 0.20.0
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -50,8 +50,6 @@ The SDK compiles with three latest engine versions.
 
 - Only crash events captured on Android contain the full callstack. Events that were captured manually won't have the native C++ part there.
 
-- On Linux `sudo apt-get install libc++-dev libcurl-dev` is required to install the `Crashpad` dependencies. This list may vary depending on your Linux distro. See the [Crashpad documentation](https://chromium.googlesource.com/crashpad/crashpad/+/refs/heads/main/doc/developing.md#prerequisites) for more details.
-
 - On Windows/Linux if crash event was captured during the garbage collection the `BeforeSendHandler` will not be invoked.
 
 ## Development

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -15,7 +15,7 @@ cmake --install "${sentryNativeRoot}/build" --prefix "${sentryNativeRoot}/instal
 # Build sentry-native using libstdc++
 cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER="clang++" -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++"
-cmake --build "${sentryNativeRoot}/build_crashpad_handler" --target crashpad_handler --parallel
+cmake --build "${sentryNativeRoot}/build_crashpad_handler" --target sentry --parallel
 cmake --install "${sentryNativeRoot}/build_crashpad_handler" --prefix "${sentryNativeRoot}/install_crashpad_handler"
 
 # Replace crashpad_handler binary 

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -6,19 +6,19 @@ export sentryArtifactsDestination=$2
 
 rm -rf "${sentryArtifactsDestination}/"*
 
-# Build sentry-native using libc++
+# Build sentry-native using clang and libc++ for static libs
 cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER="clang++" -D CMAKE_CXX_FLAGS="-stdlib=libc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libc++"
 cmake --build "${sentryNativeRoot}/build" --target sentry --parallel
 cmake --install "${sentryNativeRoot}/build" --prefix "${sentryNativeRoot}/install"
 
-# Build sentry-native using libstdc++
+# Build sentry-native using gcc for crashpad which's not depending on libc++
 cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build "${sentryNativeRoot}/build_crashpad_handler" --target sentry --parallel
 cmake --install "${sentryNativeRoot}/build_crashpad_handler" --prefix "${sentryNativeRoot}/install_crashpad_handler"
 
-# Replace crashpad_handler binary 
+# Replace crashpad_handler obtained after the first build with the matching binary from the second one
 cp "${sentryNativeRoot}/install_crashpad_handler/bin/crashpad_handler" "${sentryNativeRoot}/install/bin/crashpad_handler"
 
 mkdir "${sentryArtifactsDestination}/bin"

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -14,11 +14,11 @@ cmake --install "${sentryNativeRoot}/build" --prefix "${sentryNativeRoot}/instal
 
 # Build sentry-native using libstdc++
 cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
-    -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=gcc -D CMAKE_CXX_COMPILER="g++" -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++"
+    -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER="clang++" -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++"
 cmake --build "${sentryNativeRoot}/build_crashpad_handler" --target crashpad_handler --parallel
 cmake --install "${sentryNativeRoot}/build_crashpad_handler" --prefix "${sentryNativeRoot}/install_crashpad_handler"
 
-# Replace crashpad_handler binary
+# Replace crashpad_handler binary 
 cp "${sentryNativeRoot}/install_crashpad_handler/bin/crashpad_handler" "${sentryNativeRoot}/install/bin/crashpad_handler"
 
 mkdir "${sentryArtifactsDestination}/bin"

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -14,7 +14,7 @@ cmake --install "${sentryNativeRoot}/build" --prefix "${sentryNativeRoot}/instal
 
 # Build sentry-native using libstdc++
 cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
-    -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER="clang++" -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++"
+    -D CMAKE_BUILD_TYPE=RelWithDebInfo
 cmake --build "${sentryNativeRoot}/build_crashpad_handler" --target sentry --parallel
 cmake --install "${sentryNativeRoot}/build_crashpad_handler" --prefix "${sentryNativeRoot}/install_crashpad_handler"
 

--- a/scripts/build-linux.sh
+++ b/scripts/build-linux.sh
@@ -6,10 +6,20 @@ export sentryArtifactsDestination=$2
 
 rm -rf "${sentryArtifactsDestination}/"*
 
+# Build sentry-native using libc++
 cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang -D CMAKE_CXX_COMPILER="clang++" -D CMAKE_CXX_FLAGS="-stdlib=libc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libc++"
 cmake --build "${sentryNativeRoot}/build" --target sentry --parallel
 cmake --install "${sentryNativeRoot}/build" --prefix "${sentryNativeRoot}/install"
+
+# Build sentry-native using libstdc++
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
+    -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=gcc -D CMAKE_CXX_COMPILER="g++" -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++"
+cmake --build "${sentryNativeRoot}/build_crashpad_handler" --target crashpad_handler --parallel
+cmake --install "${sentryNativeRoot}/build_crashpad_handler" --prefix "${sentryNativeRoot}/install_crashpad_handler"
+
+# Replace crashpad_handler binary
+cp "${sentryNativeRoot}/install_crashpad_handler/bin/crashpad_handler" "${sentryNativeRoot}/install/bin/crashpad_handler"
 
 mkdir "${sentryArtifactsDestination}/bin"
 mkdir "${sentryArtifactsDestination}/include"


### PR DESCRIPTION
Currently `sentry-native` is built using `clang` and `libc++` to make the corresponding static libs included in `sentry-unreal` plugin compatible with UE. This introduces additional overhead for using Sentry on Linux since `libc++` as one of the `Crashpad` dependencies has to be installed separately and for some distros this package is not available (i.e. AL 2/2023).

This PR suggests to build `sentry-native` in CI twice: once to obtain static libs using the current configuration and once to get the `Crashpad` executable not dependent on `libc++` using `gcc` which then replaces binary obtained during the first build.

Related #431 

Closes #635 