### PR TITLE
Fix build errors in UE 4.27

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix build errors in UE 4.27 ([#660](https://github.com/getsentry/sentry-unreal/pull/660))
+
 ### Dependencies
 
 - Bump Cocoa SDK (iOS) from v8.37.0 to v8.38.0 ([#659](https://github.com/getsentry/sentry-unreal/pull/659))

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.cpp
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.cpp
@@ -11,6 +11,7 @@
 #include "Misc/FileHelper.h"
 #include "Engine/GameViewportClient.h"
 #include "Framework/Application/SlateApplication.h"
+#include "Runtime/Launch/Resources/Version.h"
 
 bool SentryScreenshotUtils::CaptureScreenshot(const FString& ScreenshotSavePath)
 {
@@ -47,10 +48,16 @@ bool SentryScreenshotUtils::CaptureScreenshot(const FString& ScreenshotSavePath)
 		return false;
 	}
 
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 	GetHighResScreenshotConfig().MergeMaskIntoAlpha(Bitmap, FIntRect());
-
 	TArray64<uint8> CompressedBitmap;
 	FImageUtils::PNGCompressImageArray(ViewportSize.X, ViewportSize.Y, Bitmap, CompressedBitmap);
+#else
+	GetHighResScreenshotConfig().MergeMaskIntoAlpha(Bitmap);
+	TArray<uint8> CompressedBitmap;
+	FImageUtils::CompressImageArray(ViewportSize.X, ViewportSize.Y, Bitmap, CompressedBitmap);
+#endif
+
 	FFileHelper::SaveArrayToFile(CompressedBitmap, *ScreenshotSavePath);
 
 	UE_LOG(LogSentrySdk, Log, TEXT("Screenshot saved to: %s"), *ScreenshotSavePath);

--- a/plugin-dev/Source/Sentry/Public/SentryOutputDeviceError.h
+++ b/plugin-dev/Source/Sentry/Public/SentryOutputDeviceError.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Runtime/Launch/Resources/Version.h"
 #include "Misc/OutputDeviceError.h"
 #include "Delegates/Delegate.h"
 
@@ -15,7 +16,11 @@ public:
 
 	FOutputDeviceError* GetParentDevice();
 
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 	TMulticastDelegate<void(const FString&), FDefaultTSDelegateUserPolicy> OnAssert;
+#else
+	TMulticastDelegate<void(const FString&)> OnAssert;
+#endif
 
 private:
 	FOutputDeviceError* ParentDevice;

--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -411,8 +411,16 @@ TSharedRef<SWidget> FSentrySettingsCustomization::MakeLinuxBinariesStatusRow(FNa
 
 					FString CommandLine = FString::Printf(TEXT("BuildPlugin -Plugin=\"%s/Sentry.uplugin\" -Package=\"%s\" -CreateSubFolder -TargetPlatforms=Linux"), *PluginPath, *TempLinuxBinariesPath);
 
-					IUATHelperModule::Get().CreateUatTask(CommandLine, FText::FromString("Windows"), FText::FromString("Compiling Sentry for Linux"), FText::FromString("Compile Sentry Linux"),
-						FAppStyle::GetBrush(TEXT("MainFrame.CookContent")), nullptr, [this, TempLinuxBinariesPath](FString result, double X)
+					IUATHelperModule::Get().CreateUatTask(CommandLine, FText::FromString("Windows"),
+						FText::FromString("Compiling Sentry for Linux"),
+						FText::FromString("Compile Sentry Linux"),
+					#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+						FAppStyle::GetBrush(TEXT("MainFrame.CookContent")),
+						nullptr,
+					#else
+						FEditorStyle::GetBrush(TEXT("MainFrame.CookContent")),
+					#endif
+						[this, TempLinuxBinariesPath](FString result, double X)
 						{
 							if (result.Equals(TEXT("Completed")))
 							{


### PR DESCRIPTION
This PR addresses issues with building the latest Sentry plugin in UE 4.27. The most up-to-date implementation relied on engine's APIs that were unavailable or different in older versions, so these had to be resolved using some pre-processor directives.

The corresponding request came from a user via Discord: https://discord.com/channels/621778831602221064/1296475167316381818