### PR TITLE
Fix issue with `MaxBreadcrumbs` setting is not respected on desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 - Add LinuxArm64 support for UE plugin ([#672](https://github.com/getsentry/sentry-unreal/pull/672))
 - Add UE 4.27, 5.0 and 5.1 to CI pipeline ([#675](https://github.com/getsentry/sentry-unreal/pull/675))
 
+### Fixes
+
+- Fix issue with `MaxBreadcrumbs` setting is not respected on desktop ([#688](https://github.com/getsentry/sentry-unreal/pull/688))
+
 ### Dependencies
 
 - Bump CLI from v2.37.0 to v2.38.2 ([#663](https://github.com/getsentry/sentry-unreal/pull/663), [#670](https://github.com/getsentry/sentry-unreal/pull/670), [#677](https://github.com/getsentry/sentry-unreal/pull/677))

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
@@ -27,7 +27,7 @@ SentryScopeDesktop::SentryScopeDesktop(const SentryScopeDesktop& Scope)
 	TagsDesktop = Scope.TagsDesktop;
 	ExtraDesktop = Scope.ExtraDesktop;
 	ContextsDesktop = Scope.ContextsDesktop;
-	BreadcrumbsDesktop = TRingBuffer(Scope.BreadcrumbsDesktop);
+	BreadcrumbsDesktop = TRingBuffer<TSharedPtr<SentryBreadcrumbDesktop>>(Scope.BreadcrumbsDesktop);
 	LevelDesktop = Scope.LevelDesktop;
 }
 

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.cpp
@@ -7,6 +7,8 @@
 #include "SentryBreadcrumb.h"
 #include "SentryAttachment.h"
 #include "SentryEvent.h"
+#include "SentryModule.h"
+#include "SentrySettings.h"
 
 #include "Infrastructure/SentryConvertorsDesktop.h"
 
@@ -25,7 +27,7 @@ SentryScopeDesktop::SentryScopeDesktop(const SentryScopeDesktop& Scope)
 	TagsDesktop = Scope.TagsDesktop;
 	ExtraDesktop = Scope.ExtraDesktop;
 	ContextsDesktop = Scope.ContextsDesktop;
-	BreadcrumbsDesktop = Scope.BreadcrumbsDesktop;
+	BreadcrumbsDesktop = TRingBuffer(Scope.BreadcrumbsDesktop);
 	LevelDesktop = Scope.LevelDesktop;
 }
 
@@ -35,13 +37,13 @@ SentryScopeDesktop::~SentryScopeDesktop()
 
 void SentryScopeDesktop::AddBreadcrumb(USentryBreadcrumb* breadcrumb)
 {
-	FScopeLock Lock(&CriticalSection);
-
-	BreadcrumbsDesktop.Add(StaticCastSharedPtr<SentryBreadcrumbDesktop>(breadcrumb->GetNativeImpl()));
+	AddBreadcrumb(StaticCastSharedPtr<SentryBreadcrumbDesktop>(breadcrumb->GetNativeImpl()));
 }
 
 void SentryScopeDesktop::ClearBreadcrumbs()
 {
+	FScopeLock Lock(&CriticalSection);
+
 	BreadcrumbsDesktop.Empty();
 }
 
@@ -263,7 +265,7 @@ void SentryScopeDesktop::Apply(TSharedPtr<SentryEventDesktop> event)
 		}
 	}
 
-	if(BreadcrumbsDesktop.Num() > 0)
+	if(!BreadcrumbsDesktop.IsEmpty())
 	{
 		sentry_value_t eventBreadcrumbs = sentry_value_get_by_key(nativeEvent, "breadcrumbs");
 		if(sentry_value_is_null(eventBreadcrumbs))
@@ -294,6 +296,11 @@ void SentryScopeDesktop::Apply(TSharedPtr<SentryEventDesktop> event)
 void SentryScopeDesktop::AddBreadcrumb(TSharedPtr<SentryBreadcrumbDesktop> breadcrumb)
 {
 	FScopeLock Lock(&CriticalSection);
+
+	if(BreadcrumbsDesktop.Num() >= FSentryModule::Get().GetSettings()->MaxBreadcrumbs)
+	{
+		BreadcrumbsDesktop.PopFront();
+	}
 
 	BreadcrumbsDesktop.Add(breadcrumb);
 }

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryScopeDesktop.h
@@ -2,6 +2,7 @@
 
 #pragma once
 
+#include "Containers/RingBuffer.h"
 #include "HAL/CriticalSection.h"
 
 #include "Interface/SentryScopeInterface.h"
@@ -62,7 +63,7 @@ private:
 
 	TMap<FString, TMap<FString, FString>> ContextsDesktop;
 
-	TArray<TSharedPtr<SentryBreadcrumbDesktop>> BreadcrumbsDesktop;
+	TRingBuffer<TSharedPtr<SentryBreadcrumbDesktop>> BreadcrumbsDesktop;
 
 	ESentryLevel LevelDesktop;
 


### PR DESCRIPTION
Since `sentry-native` doesn't support working with multiple scopes we've added a custom scope class implementation for Windows/Linux to align the UE plugin API across different platforms (see #328). `SentryScopeDesktop` stores breadcrumbs in its own cache and thus ignores `MaxBreadcrumbs` setting value provided during the Native SDK initialization. This PR adds a corresponding breadcrumbs amount check and changes the cache's container type to ringbuffer.

Closes #683 