### PR TITLE
Fix crash on Android when starting/ending session manually

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix crash on Android when starting/ending session manually ([#696](https://github.com/getsentry/sentry-unreal/pull/696))
+
 ### Dependencies
 
 - Bump Native SDK from v0.7.12 to v0.7.15 ([#690](https://github.com/getsentry/sentry-unreal/pull/690), [#693](https://github.com/getsentry/sentry-unreal/pull/693), [#695](https://github.com/getsentry/sentry-unreal/pull/695))

--- a/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/SentrySubsystemAndroid.cpp
@@ -248,12 +248,12 @@ void SentrySubsystemAndroid::SetLevel(ESentryLevel level)
 
 void SentrySubsystemAndroid::StartSession()
 {
-	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, "startSession", "()V", nullptr);
+	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::Sentry, "startSession", "()V", nullptr);
 }
 
 void SentrySubsystemAndroid::EndSession()
 {
-	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, "endSession", "()V", nullptr);
+	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::Sentry, "endSession", "()V", nullptr);
 }
 
 TSharedPtr<ISentryTransaction> SentrySubsystemAndroid::StartTransaction(const FString& name, const FString& operation)


### PR DESCRIPTION
This PR sets the right class name for native `startSession`/`endSession` methods invocation on Android.

Closes #694 