### PR TITLE
Add Command Line Arguments to DefaultContext

### DIFF
--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -489,6 +489,7 @@ void USentrySubsystem::AddDefaultContext()
 	DefaultContext.Add(TEXT("Is standalone"), FApp::IsStandalone() ? TEXT("True") : TEXT("False"));
 	DefaultContext.Add(TEXT("Is unattended"), FApp::IsUnattended() ? TEXT("True") : TEXT("False"));
 	DefaultContext.Add(TEXT("Game name"), FApp::GetName());
+	DefaultContext.Add(TEXT("Command Line Arguments"), FCommandLine::GetOriginal());
 
 	SubsystemNativeImpl->SetContext(TEXT("Unreal Engine"), DefaultContext);
 }


### PR DESCRIPTION
The command line arguments seem like a really useful piece of information to have when debugging crashes. This adds them to the DefaultContext so that they're readily available in Sentry