### PR TITLE
Fix CI pipeline breakage due to invalid large GitHub runner `uid`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,6 +242,8 @@ jobs:
             -package \
             -archive
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
+            ls -al '/home/ue4/Library/Logs/Unreal Engine/LocalBuildLogs'  "
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
             cp -r '/home/ue4/Library/Logs/Unreal Engine/LocalBuildLogs' Saved/Logs  "
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/${{ matrix.unreal == '4.27' && 'UE4Editor' || 'UnrealEditor' }} \
             /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,7 +207,8 @@ jobs:
           docker exec --user root unreal bash -c "
             chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
             chown -R $uid /home/ue4/UnrealEngine/Engine/${{ matrix.unreal == '4.27' && 'Programs/UnrealPak/Saved' || 'Binaries/ThirdParty/DotNet' }} ;
-            mkdir -p /home/ue4/UnrealEngine/Epic/UnrealEngine && chown -R $uid /home/ue4/UnrealEngine/Epic "
+            mkdir -p /home/ue4/UnrealEngine/Epic/UnrealEngine && chown -R $uid /home/ue4/UnrealEngine/Epic ;
+            mkdir -p /home/ue4/UnrealEngine/Engine/Source/Epic/UnrealEngine && chown -R $uid /home/ue4/UnrealEngine/Engine/Source/Epic "
 
       - name: Setup C++ runtime
         run: docker exec --user root unreal bash -c '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,6 +231,10 @@ jobs:
         id: run-tests
         run: |
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
+            ls -al '/home/ue4/Library/Logs'  "
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
+            ls -al '/home/ue4/Library/Logs/Unreal Engine'  "
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
             ls -al '/home/ue4/Library/Logs/Unreal Engine/LocalBuildLogs'  "
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
             -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,6 +230,8 @@ jobs:
       - name: Run tests
         id: run-tests
         run: |
+          docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
+            ls -al '/home/ue4/Library/Logs/Unreal Engine/LocalBuildLogs'  "
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
             -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -archivedirectory=/workspace/checkout/${{ matrix.app }}/Builds \
@@ -241,8 +243,6 @@ jobs:
             -prereqss \
             -package \
             -archive
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
-            ls -al '/home/ue4/Library/Logs/Unreal Engine/LocalBuildLogs'  "
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
             cp -r '/home/ue4/Library/Logs/Unreal Engine/LocalBuildLogs' Saved/Logs  "
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/${{ matrix.unreal == '4.27' && 'UE4Editor' || 'UnrealEditor' }} \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
           echo ${{ secrets.DOCKER_TOKEN }} | docker login ghcr.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           # We start the container with the user ID of the parent GH action user to avoid permission issues on volume.
           # For UE 5.4 we have to enable ipv6 to fix container startup issues. See https://github.com/adamrehn/ue4-docker/issues/357
-          uid=$(id -u) # the GH action user ID
+          uid=1000 # the GH action user ID
           gid=1000     # the ue4 group in the docker container
           user='gh'
           set -x
@@ -200,7 +200,7 @@ jobs:
       # docker would implicitly have to copy it to the container and we would run out of space on the GH runner.
       - name: Chown Docker container paths
         run: |
-          uid=$(id -u) # the GH action user ID
+          uid=1000 # the GH action user ID
           docker exec --user root unreal bash -c "
             chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
             chown -R $uid /home/ue4/UnrealEngine/Engine/${{ matrix.unreal == '4.27' && 'Programs/UnrealPak/Saved' || 'Binaries/ThirdParty/DotNet' }} "
@@ -230,12 +230,6 @@ jobs:
       - name: Run tests
         id: run-tests
         run: |
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
-            ls -al '/home/ue4/Library/Logs'  "
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
-            ls -al '/home/ue4/Library/Logs/Unreal Engine'  "
-          docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
-            ls -al '/home/ue4/Library/Logs/Unreal Engine/LocalBuildLogs'  "
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
             -project=/workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -archivedirectory=/workspace/checkout/${{ matrix.app }}/Builds \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,14 @@ jobs:
             --name unreal \
             --volume ${{ github.workspace }}:/workspace \
             --workdir /workspace \
+            --user $uid:$gid \
+            --env HOME="/home/$user" \
+            --env PATH="/home/$user/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
             --network ip6net -p 80:80 \
             ghcr.io/epicgames/unreal-engine:dev-slim-${{ matrix.unreal }}.1
           docker logout ghcr.io
+          # Add the user so it has a home directory (needed to run tests later on)
+          docker exec --user root unreal useradd -u $uid -g $gid --create-home $user
           # Ensure CA certs are in the right directory (needed for running tests)
           docker exec --user root unreal bash -c "
             mkdir -p /etc/pki/tls/certs ;
@@ -223,7 +228,7 @@ jobs:
 
       - name: Set permissions for ${{ matrix.app }}
         # sentry-native requires write access to sample project directory in order to initialize itself properly
-        run: docker exec --user root -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
+        run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests
         id: run-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,16 +179,13 @@ jobs:
           # For UE 5.4 we have to enable ipv6 to fix container startup issues. See https://github.com/adamrehn/ue4-docker/issues/357
           uid=$(id -u) # the GH action user ID
           gid=1000     # the ue4 group in the docker container
-          user='ue4'
+          user='gh'
           set -x
           docker network create --ipv6 --subnet 2001:0DB8::/112 ip6net
           docker run -td \
             --name unreal \
             --volume ${{ github.workspace }}:/workspace \
             --workdir /workspace \
-            --user $uid:$gid \
-            --env HOME="/home/$user" \
-            --env PATH="/home/$user/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
             --network ip6net -p 80:80 \
             ghcr.io/epicgames/unreal-engine:dev-slim-${{ matrix.unreal }}.1
           docker logout ghcr.io
@@ -226,7 +223,7 @@ jobs:
 
       - name: Set permissions for ${{ matrix.app }}
         # sentry-native requires write access to sample project directory in order to initialize itself properly
-        run: docker exec -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
+        run: docker exec --user root -w /workspace/checkout unreal chmod -R +x ${{ matrix.app }}
 
       - name: Run tests
         id: run-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -177,7 +177,7 @@ jobs:
           echo ${{ secrets.DOCKER_TOKEN }} | docker login ghcr.io -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
           # We start the container with the user ID of the parent GH action user to avoid permission issues on volume.
           # For UE 5.4 we have to enable ipv6 to fix container startup issues. See https://github.com/adamrehn/ue4-docker/issues/357
-          uid=1000 # the GH action user ID
+          uid=$(id -u) # the GH action user ID
           gid=1000     # the ue4 group in the docker container
           user='gh'
           set -x
@@ -187,6 +187,7 @@ jobs:
             --volume ${{ github.workspace }}:/workspace \
             --workdir /workspace \
             --user $uid:$gid \
+            --env HOME="/home/$user" \
             --env PATH="/home/$user/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
             --network ip6net -p 80:80 \
             ghcr.io/epicgames/unreal-engine:dev-slim-${{ matrix.unreal }}.1
@@ -200,7 +201,7 @@ jobs:
       # docker would implicitly have to copy it to the container and we would run out of space on the GH runner.
       - name: Chown Docker container paths
         run: |
-          uid=1000 # the GH action user ID
+          uid=$(id -u) # the GH action user ID
           docker exec --user root unreal bash -c "
             chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
             chown -R $uid /home/ue4/UnrealEngine/Engine/${{ matrix.unreal == '4.27' && 'Programs/UnrealPak/Saved' || 'Binaries/ThirdParty/DotNet' }} "

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,13 +179,16 @@ jobs:
           # For UE 5.4 we have to enable ipv6 to fix container startup issues. See https://github.com/adamrehn/ue4-docker/issues/357
           uid=$(id -u) # the GH action user ID
           gid=1000     # the ue4 group in the docker container
-          user='gh'
+          user='ue4'
           set -x
           docker network create --ipv6 --subnet 2001:0DB8::/112 ip6net
           docker run -td \
             --name unreal \
             --volume ${{ github.workspace }}:/workspace \
             --workdir /workspace \
+            --user $uid:$gid \
+            --env HOME="/home/$user" \
+            --env PATH="/home/$user/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
             --network ip6net -p 80:80 \
             ghcr.io/epicgames/unreal-engine:dev-slim-${{ matrix.unreal }}.1
           docker logout ghcr.io
@@ -193,6 +196,15 @@ jobs:
           docker exec --user root unreal bash -c "
             mkdir -p /etc/pki/tls/certs ;
             cp /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt "
+
+      # Chown some paths to the GH user to make UE5 work properly. We can't just chown the whole UnrealEngine or
+      # docker would implicitly have to copy it to the container and we would run out of space on the GH runner.
+      - name: Chown Docker container paths
+        run: |
+          uid=$(id -u) # the GH action user ID
+          docker exec --user root unreal bash -c "
+            chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
+            chown -R $uid /home/ue4/UnrealEngine/Engine/${{ matrix.unreal == '4.27' && 'Programs/UnrealPak/Saved' || 'Binaries/ThirdParty/DotNet' }} "
 
       - name: Setup C++ runtime
         run: docker exec --user root unreal bash -c '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,7 +206,8 @@ jobs:
           uid=$(id -u) # the GH action user ID
           docker exec --user root unreal bash -c "
             chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
-            chown -R $uid /home/ue4/UnrealEngine/Engine/${{ matrix.unreal == '4.27' && 'Programs/UnrealPak/Saved' || 'Binaries/ThirdParty/DotNet' }} "
+            chown -R $uid /home/ue4/UnrealEngine/Engine/${{ matrix.unreal == '4.27' && 'Programs/UnrealPak/Saved' || 'Binaries/ThirdParty/DotNet' }} ;
+            mkdir -p /home/ue4/UnrealEngine/Epic/UnrealEngine && chown -R $uid /home/ue4/UnrealEngine/Epic "
 
       - name: Setup C++ runtime
         run: docker exec --user root unreal bash -c '
@@ -245,7 +246,7 @@ jobs:
             -package \
             -archive
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal bash -c "
-            cp -r '/home/ue4/Library/Logs/Unreal Engine/LocalBuildLogs' Saved/Logs  "
+            cp -r '/home/gh/Library/Logs/Unreal Engine/LocalBuildLogs' Saved/Logs  "
           docker exec -w /workspace/checkout/${{ matrix.app }} unreal /home/ue4/UnrealEngine/Engine/Binaries/Linux/${{ matrix.unreal == '4.27' && 'UE4Editor' || 'UnrealEditor' }} \
             /workspace/checkout/${{ matrix.app }}/SentryPlayground.uproject \
             -ReportExportPath=/workspace/checkout/${{ matrix.app }}/Saved/Automation \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,9 +186,6 @@ jobs:
             --name unreal \
             --volume ${{ github.workspace }}:/workspace \
             --workdir /workspace \
-            --user $uid:$gid \
-            --env HOME="/home/$user" \
-            --env PATH="/home/$user/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
             --network ip6net -p 80:80 \
             ghcr.io/epicgames/unreal-engine:dev-slim-${{ matrix.unreal }}.1
           docker logout ghcr.io
@@ -196,15 +193,6 @@ jobs:
           docker exec --user root unreal bash -c "
             mkdir -p /etc/pki/tls/certs ;
             cp /etc/ssl/certs/ca-certificates.crt /etc/pki/tls/certs/ca-bundle.crt "
-
-      # Chown some paths to the GH user to make UE5 work properly. We can't just chown the whole UnrealEngine or
-      # docker would implicitly have to copy it to the container and we would run out of space on the GH runner.
-      - name: Chown Docker container paths
-        run: |
-          uid=$(id -u) # the GH action user ID
-          docker exec --user root unreal bash -c "
-            chown -R $uid /home/ue4/UnrealEngine/Engine/Binaries/ThirdParty/Mono/Linux ;
-            chown -R $uid /home/ue4/UnrealEngine/Engine/${{ matrix.unreal == '4.27' && 'Programs/UnrealPak/Saved' || 'Binaries/ThirdParty/DotNet' }} "
 
       - name: Setup C++ runtime
         run: docker exec --user root unreal bash -c '


### PR DESCRIPTION
This PR fixes the CI pipeline by addressing issues introduced after the recent change of the default `uid` value for large GitHub runners which prevented access to certain directories within the UE Docker container

Related to #658

#skip-changelog