### PR TITLE
Fix macOS/iOS build errors due to missing `NS_SWIFT_SENDABLE` macro definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add API allowing to start/finish transactions and spans with explicit timings ([#715](https://github.com/getsentry/sentry-unreal/pull/715))
 - Add GPU crash dump attachments ([#712](https://github.com/getsentry/sentry-unreal/pull/712))
 
+### Fixes
+
+- Fix macOS/iOS build errors due to missing `NS_SWIFT_SENDABLE` macro definition ([#721](https://github.com/getsentry/sentry-unreal/pull/721))
+
 ### Dependencies
 
 - Bump Native SDK from v0.7.16 to v0.7.17 ([#717](https://github.com/getsentry/sentry-unreal/pull/717))

--- a/plugin-dev/Source/Sentry/Private/Apple/Convenience/SentryInclude.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/Convenience/SentryInclude.h
@@ -4,6 +4,10 @@
 
 #include "HAL/Platform.h"
 
+#ifndef NS_SWIFT_SENDABLE
+#define NS_SWIFT_SENDABLE
+#endif
+
 #if PLATFORM_MAC
 #include <Sentry/Sentry.h>
 #include <Sentry/PrivateSentrySDKOnly.h>


### PR DESCRIPTION
During a recent attempt to publish the plugin package to the Unreal Engine Marketplace the following errors occurred:

```
Users/build/Build/U5M-Marketplace-Mac/Sync/LocalBuilds/PluginTemp/HostProject/Plugins/Sentry/Source/ThirdParty/Mac/include/Sentry/SentryOptions.h:145:79: error: expected ';' at end of declaration list
@property (nullable, nonatomic, copy) SentryBeforeSendEventCallback beforeSend NS_SWIFT_SENDABLE;

/Users/build/Build/U5M-Marketplace-Mac/Sync/LocalBuilds/PluginTemp/HostProject/Plugins/Sentry/Source/ThirdParty/Mac/include/Sentry/SentryOptions.h:145:80: error: C++ requires a type specifier for all declarations
@property (nullable, nonatomic, copy) SentryBeforeSendEventCallback beforeSend NS_SWIFT_SENDABLE;

/Users/build/Build/U5M-Marketplace-Mac/Sync/LocalBuilds/PluginTemp/HostProject/Plugins/Sentry/Source/ThirdParty/Mac/include/Sentry/SentryOptions.h:145:80: error: cannot declare variable inside @interface or @protocol
@property (nullable, nonatomic, copy) SentryBeforeSendEventCallback beforeSend NS_SWIFT_SENDABLE;

...

fatal error: too many errors emitted, stopping now [-ferror-limit=]
20 errors generated.
[3/9] Compile Module.Sentry.1_of_3.cpp
[4/9] Compile Module.SentryEditor.cpp
[5/9] Compile Module.Sentry.3_of_3.cpp
[6/9] Link UnrealEditor-Sentry.dylib cancelled
[7/9] Link UnrealEditor-SentryEditor.dylib cancelled
[8/9] WriteMetadata UnrealEditor.target cancelled
[9/9] sh Executing post build script (PostBuild-1.sh)
Sentry: Symbol upload script is missing. Skipping post build step.
Took 33.12142s to run dotnet, ExitCode=6
UnrealBuildTool failed. See log for more details. (/Users/build/Build/U5M-Marketplace-Mac/Sync/Engine/Programs/AutomationTool/Saved/Logs/BuildMarketPlaceItems/UBT-UnrealEditor-Mac-Development.txt)
AutomationTool executed for 0h 0m 33s
AutomationTool exiting with ExitCode=6 (6)
RunUAT ERROR: AutomationTool was unable to run successfully. Exited with code: 6
Took 34.26s to run RunUAT.sh, ExitCode=6
Build failed for plugin Sentry_5.1
```

The build farms where plugin pre-compilation for UE 5.1 occurs might be using an older version of Xcode (pre-13) or targeting an older macOS version (pre-12) where the `NS_SWIFT_SENDABLE` macro is unavailable. Adding a check to verify if the macro is defined should help address these issues.