### PR TITLE
Allow upload script to support different bash locations

### DIFF
--- a/plugin-dev/Scripts/upload-debug-symbols.sh
+++ b/plugin-dev/Scripts/upload-debug-symbols.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 targetPlatform=$1
 targetName=$2


### PR DESCRIPTION
Using `/usr/bin/env` avoids making assumptions about where the bash executable is installed. See [this stack overflow post](https://stackoverflow.com/questions/21612980/why-is-usr-bin-env-bash-superior-to-bin-bash) for reference