### PR TITLE
Switch to using default Linux Arm64 runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
     uses: ./.github/workflows/sdk-build.yml
     with:
       target: LinuxArm64
-      runsOn: ubuntu-latest-4-cores-arm64
+      runsOn: ubuntu-22.04-arm
       container: arm64v8/ubuntu:20.04
 
   windows-crashpad-sdk:


### PR DESCRIPTION
Based on recent [GitHub changes](https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview) there's no need to use large Linux Arm64 runner for building Native SDK as the default one should suffice.

#skip-changelog