### PR TITLE
Fix incorrect game log attachment on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix incorrect game log attachment on Android ([#743](https://github.com/getsentry/sentry-unreal/pull/743))
+
 ### Dependencies
 
 - Bump CLI from v2.39.1 to v2.41.0 ([#725](https://github.com/getsentry/sentry-unreal/pull/725), [#740](https://github.com/getsentry/sentry-unreal/pull/740))

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryFileUtils.cpp
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryFileUtils.cpp
@@ -35,13 +35,12 @@ FString SentryFileUtils::GetGameLogBackupPath()
 
 	for (int i = 0; i < GameLogBackupFiles.Num(); ++i)
 	{
-		FString GameLogFullPath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*(FPaths::ProjectLogDir() / GameLogBackupFiles[i]));
-		GameLogBackupFiles[i] = GameLogFullPath;
+		GameLogBackupFiles[i] = FPaths::ProjectLogDir() / GameLogBackupFiles[i];
 	}
 
 	GameLogBackupFiles.Sort(FSentrySortFileByDatePredicate());
 
-	return GameLogBackupFiles[0];
+	return IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*GameLogBackupFiles[0]);
 }
 
 FString SentryFileUtils::GetGpuDumpPath()


### PR DESCRIPTION
This PR resolves an issue where the wrong game log file was attached to captured crash events on Android. The bug was caused by improper sorting of backup log files which occurred due to an incorrect file path format used to retrieve the file's last modified timestamp.

Related to #302