### PR TITLE
Avoid trying to use Slate for screenshots in Sentry during a crash if not on the game thread or slate thread, to avoid causing errors in Slate.

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.cpp
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.cpp
@@ -38,6 +38,12 @@ bool SentryScreenshotUtils::CaptureScreenshot(const FString& ScreenshotSavePath)
 		return false;
 	}
 
+	if (!(IsInGameThread() || IsInSlateThread()))
+	{
+		UE_LOG(LogSentrySdk, Error, TEXT("Can't take a screenshot when not in the game thread or slate thread"));
+		return false;
+	}
+
 	TSharedPtr<SWindow> WindowPtr = GameViewportClient->GetWindow();
 	TSharedRef<SWidget> WindowRef = WindowPtr.ToSharedRef();
 


### PR DESCRIPTION
Check if we're on a thread that can use Slate to capture a screenshot before attempting to do so.

Fixes #755
