### PR TITLE
Add a way to get the event ID of an event for Desktop.

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryEventDesktop.cpp
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryEventDesktop.cpp
@@ -2,6 +2,8 @@
 
 #include "SentryEventDesktop.h"
 #include "SentryDefines.h"
+#include "SentryId.h"
+#include "SentryIdDesktop.h"
 
 #include "Infrastructure/SentryConvertersDesktop.h"
 
@@ -33,6 +35,16 @@ void SentryEventDesktop::SetMessage(const FString& message)
 	sentry_value_t messageСontainer = sentry_value_new_object();
 	sentry_value_set_by_key(messageСontainer, "formatted", sentry_value_new_string(TCHAR_TO_UTF8(*message)));
 	sentry_value_set_by_key(EventDesktop, "message", messageСontainer);
+}
+
+USentryId* SentryEventDesktop::GetId() const
+{
+	sentry_value_t id = sentry_value_get_by_key(EventDesktop, "event_id");
+	sentry_uuid_t uuid = sentry_uuid_from_string(sentry_value_as_string(id));
+	TSharedPtr<ISentryId> idNativeImpl = MakeShareable(new SentryIdDesktop(uuid));
+	USentryId* unrealId = NewObject<USentryId>();
+	unrealId->InitWithNativeImpl(idNativeImpl);
+	return unrealId;
 }
 
 FString SentryEventDesktop::GetMessage() const

--- a/plugin-dev/Source/Sentry/Private/Desktop/SentryEventDesktop.h
+++ b/plugin-dev/Source/Sentry/Private/Desktop/SentryEventDesktop.h
@@ -18,6 +18,7 @@ public:
 	sentry_value_t GetNativeObject();
 
 	virtual void SetMessage(const FString& message) override;
+	virtual USentryId* GetId() const override;
 	virtual FString GetMessage() const override;
 	virtual void SetLevel(ESentryLevel level) override;
 	virtual ESentryLevel GetLevel() const override;

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryEventInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryEventInterface.h
@@ -5,6 +5,9 @@
 #include "CoreMinimal.h"
 
 #include "SentryDataTypes.h"
+#include "Interface/SentryIdInterface.h"
+
+class USentryId;
 
 class ISentryEvent
 {
@@ -12,6 +15,7 @@ public:
 	virtual ~ISentryEvent() = default;
 
 	virtual void SetMessage(const FString& message) = 0;
+	virtual USentryId* GetId() const = 0;
 	virtual FString GetMessage() const = 0;
 	virtual void SetLevel(ESentryLevel level) = 0;
 	virtual ESentryLevel GetLevel() const = 0;

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -48,6 +48,14 @@ void USentryEvent::SetMessage(const FString& Message)
 	EventNativeImpl->SetMessage(Message);
 }
 
+USentryId* USentryEvent::GetId() const
+{
+	if(!EventNativeImpl)
+		return nullptr;
+
+	return EventNativeImpl->GetId();
+}
+
 FString USentryEvent::GetMessage() const
 {
 	if(!EventNativeImpl)

--- a/plugin-dev/Source/Sentry/Public/SentryEvent.h
+++ b/plugin-dev/Source/Sentry/Public/SentryEvent.h
@@ -3,9 +3,11 @@
 #pragma once
 
 #include "SentryDataTypes.h"
+#include <Templates/SharedPointer.h>
 
 #include "SentryEvent.generated.h"
 
+class USentryId;
 class ISentryEvent;
 
 /**
@@ -31,6 +33,10 @@ public:
 	/** Sets message of the event. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
 	void SetMessage(const FString& Message);
+
+	/** Gets id of the event. */
+	UFUNCTION(BlueprintPure, Category = "Sentry")
+	USentryId* GetId() const;
 
 	/** Gets message of the event. */
 	UFUNCTION(BlueprintPure, Category = "Sentry")


### PR DESCRIPTION
Partial implementation of adding a GetId() to ISentryEvent, implemented only for Desktop here to return the event_id from sentry-native.  Haven't looked into how this would be implemented on Android, Mac, etc..  Provided as a working example for Desktop only, not to merge as-is.

Addresses #757 
