### PR TITLE
Disable Windows Media Player plugin for sample project

### DIFF
--- a/sample/SentryPlayground.uproject
+++ b/sample/SentryPlayground.uproject
@@ -30,6 +30,10 @@
 		{
 			"Name": "EditorTests",
 			"Enabled": true
+		},
+		{
+			"Name": "WindowsMoviePlayer",
+			"Enabled": false
 		}
 	],
 	"TargetPlatforms": [


### PR DESCRIPTION
This PR disables `Windows Media Player` plugin for sample project in order to run automation tests in Windows docker images as part of the plugin's CI pipeline.

The above plugin relies on Windows Media Foundation which is missing from the Windows Server Core base image used to build UE Windows Docker images causing the engine to quit with assertion during tests.

Related to #722 , https://github.com/adamrehn/ue4-docker/issues/269

#skip-changelog