### PR TITLE
Add support for Xbox Series X|S

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ plugin-dev/Source/ThirdParty/Linux
 plugin-dev/Source/ThirdParty/LinuxArm64
 plugin-dev/Source/ThirdParty/Mac
 plugin-dev/Source/ThirdParty/Win64
+plugin-dev/Source/ThirdParty/XSX
 plugin-dev/Source/ThirdParty/CLI/*
 !plugin-dev/Source/ThirdParty/.gitkeep
 !plugin-dev/Source/ThirdParty/CLI/.gitkeep

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Remove custom transport implementation for Linux ([#748](https://github.com/getsentry/sentry-unreal/pull/748))
 - Refactor code to better align with Unreal's structure ([#745](https://github.com/getsentry/sentry-unreal/pull/745))
+- Added support for Xbox Series X|S
 
 ### Fixes
 

--- a/README.md
+++ b/README.md
@@ -9,54 +9,60 @@
 Sentry SDK for Unreal Engine
 ===========
 
-This project is an SDK for Unreal Engine that wraps different Sentry's SDKs for both desktop and mobile. Also, it [has a stable support for the Unreal Engine crash reporter](https://docs.sentry.io/platforms/unreal/setup-crashreport/).
+This project is an SDK for Unreal Engine that wraps different Sentry's SDKs for desktopm mobile, and console. Also, it [has a stable support for the Unreal Engine Crash Reporter](https://docs.sentry.io/platforms/unreal/setup-crashreport/).
 
 ## Downloads
 
 The SDK can be downloaded from the [Releases] page, which also lists the
 changelog of every version, or from the [UE Marketplace] page via Epic Games launcher.
 
-[releases]: https://github.com/getsentry/sentry-unreal/releases
+[Releases]: https://github.com/getsentry/sentry-unreal/releases
 [UE Marketplace]: https://www.unrealengine.com/marketplace/en-US/product/sentry-01
 
 If manual download from the [Releases] page is a preferred way for plugin integration using the package with the `github` suffix in its name is recommended.
 
-## Supported Platforms and Unreal Engine version
+## Supported Platforms and Unreal Engine Versions
 
 The SDK currently supports and is tested on the following platforms:
 
 - Windows
 - macOS
-- Linux 
+- Linux
 - Android
 - iOS
+- Xbox Series X|S
 
 The SDK compiles with three latest engine versions.
 
 Blog posts:
-* [Building the Sentry Unreal Engine SDK with GitHub Actions](https://blog.sentry.io/building-the-sentry-unreal-engine-sdk-with-github-actions/)
+
+- [Building the Sentry Unreal Engine SDK with GitHub Actions](https://blog.sentry.io/building-the-sentry-unreal-engine-sdk-with-github-actions/)
 
 ## Known Limitations
 
-- On all platforms captured crashes are uploaded to Sentry only after relaunching the crashed app since the in-process handler cannot do this within the same session. The only exceptions are Windows (if using the GitHub package) and Linux for which the out-of-process crashpad handler is used and crashes are uploaded immediately.
-
+- On all platforms, captured crashes are uploaded to Sentry only after relaunching the crashed app since the in-process handler cannot do this within the same session. The only exceptions are Windows (if using the GitHub package) and Linux for which the out-of-process `crashpad` handler is used and crashes are uploaded immediately.
+- Xbox Series X|S is configured with `breakpad` (in-process crash handling) instead of `crashpad` due to the nature of Xbox packaged builds.
 - To automatically capture crashes in Windows game builds that were made using engine versions prior to UE 5.2, the [Crash Reporter has to be configured](https://docs.sentry.io/platforms/unreal/setup-crashreport/) first.
-  
-- Using UGS binaries requires tagging of files to ensure the crashpad_handler.exe is present. For inclusion in build graph, you'd want something like this: 
-```
-<Tag Files="#EditorBinaries$(EditorPlatform)" Filter="*.target" With="#TargetReceipts"/>
-<TagReceipt Files="#TargetReceipts" RuntimeDependencies="true" With="#RuntimeDependencies"/>
-<Tag Files="#RuntimeDependencies" Filter="sentry.dll;crashpad_handler.exe" With="#BinariesToArchive$(EditorPlatform)"/>
+- Using Unreal Game Sync (UGS) binaries requires tagging of files to ensure the `crashpad_handler.exe` is present. For inclusion in BuildGraph, you'd want something like this:
+
+```xml
+<Tag Files="#EditorBinaries$(EditorPlatform)" 
+     Filter="*.target" 
+     With="#TargetReceipts" />
+<Tag Files="#RuntimeDependencies"
+     Filter="sentry.dll;crashpad_handler.exe"
+     With="#BinariesToArchive$(EditorPlatform)" />
+<TagReceipt Files="#TargetReceipts"
+            RuntimeDependencies="true"
+            With="#RuntimeDependencies" />
  ```
 
-- In UE 5.2 or newer game log attached to crashes captured with `sentry-native` integration instead of [crash reporter](https://docs.sentry.io/platforms/unreal/setup-crashreport/) could be truncated. This is caused by current `crashpad` behavior which sends crashes to Sentry right away while UE is still about to write some bits of information to the log file.
-
+- In UE 5.2 or newer game log attached to crashes captured with `sentry-native` integration instead of [Crash Reporter](https://docs.sentry.io/platforms/unreal/setup-crashreport/) could be truncated. This is caused by current `crashpad` behavior which sends crashes to Sentry right away while UE is still about to write some bits of information to the log file.
 - Only crash events captured on Android contain the full callstack. Events that were captured manually won't have the native C++ part there.
-
 - On Windows/Linux if crash event was captured during the garbage collection the `BeforeSendHandler` will not be invoked.
-
 - It may be required to upgrade the C++ standard library (`libstdc++`) on older Linux distributions (such as Ubuntu 18.04 and 20.04) to ensure crashpad handler proper functionality within the deployment environment. This can be achieved with something like this:
-```
+
+```bash
 sudo apt-get update
 sudo add-apt-repository ppa:ubuntu-toolchain-r/test
 sudo apt-get install -y libstdc++6
@@ -70,8 +76,8 @@ Please see the [contribution guide](./CONTRIBUTING.md).
 
 ## Resources
 
-* [![Documentation](https://img.shields.io/badge/documentation-sentry.io-green.svg)](https://docs.sentry.io/platforms/unreal/)
-* [![Discussions](https://img.shields.io/github/discussions/getsentry/sentry-unreal.svg)](https://github.com/getsentry/sentry-unreal/discussions)
-* [![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)  
-* [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](http://stackoverflow.com/questions/tagged/sentry)
-* [![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)
+- [![Documentation](https://img.shields.io/badge/documentation-sentry.io-green.svg)](https://docs.sentry.io/platforms/unreal/)
+- [![Discussions](https://img.shields.io/github/discussions/getsentry/sentry-unreal.svg)](https://github.com/getsentry/sentry-unreal/discussions)
+- [![Discord Chat](https://img.shields.io/discord/621778831602221064?logo=discord&logoColor=ffffff&color=7389D8)](https://discord.gg/PXa5Apfe7K)  
+- [![Stack Overflow](https://img.shields.io/badge/stack%20overflow-sentry-green.svg)](http://stackoverflow.com/questions/tagged/sentry)
+- [![Twitter Follow](https://img.shields.io/twitter/follow/getsentry?label=getsentry&style=social)](https://twitter.com/intent/follow?screen_name=getsentry)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Sentry SDK for Unreal Engine
 ===========
 
-This project is an SDK for Unreal Engine that wraps different Sentry's SDKs for desktopm mobile, and console. Also, it [has a stable support for the Unreal Engine Crash Reporter](https://docs.sentry.io/platforms/unreal/setup-crashreport/).
+This project is an SDK for Unreal Engine that wraps different Sentry's SDKs for desktop, mobile, and console. Also, it [has stable support for the Unreal Engine Crash Reporter](https://docs.sentry.io/platforms/unreal/setup-crashreport/).
 
 ## Downloads
 
@@ -42,6 +42,7 @@ Blog posts:
 
 - On all platforms, captured crashes are uploaded to Sentry only after relaunching the crashed app since the in-process handler cannot do this within the same session. The only exceptions are Windows (if using the GitHub package) and Linux for which the out-of-process `crashpad` handler is used and crashes are uploaded immediately.
 - Xbox Series X|S is configured with `breakpad` (in-process crash handling) instead of `crashpad` due to the nature of Xbox packaged builds.
+- Automatic crash handling and crash dump writing on Xbox Series X|S will require Engine code modifications that replicate Structured Exception Handling (SEH) changes made to Windows (until Epic upstreams the proposal).
 - To automatically capture crashes in Windows game builds that were made using engine versions prior to UE 5.2, the [Crash Reporter has to be configured](https://docs.sentry.io/platforms/unreal/setup-crashreport/) first.
 - Using Unreal Game Sync (UGS) binaries requires tagging of files to ensure the `crashpad_handler.exe` is present. For inclusion in BuildGraph, you'd want something like this:
 

--- a/plugin-dev/Sentry.uplugin
+++ b/plugin-dev/Sentry.uplugin
@@ -19,7 +19,7 @@
 			"Name": "Sentry",
 			"Type": "Runtime",
 			"LoadingPhase": "Default",
-			"WhitelistPlatforms": [ "Win64", "Mac", "Android", "IOS", "Linux", "LinuxArm64" ]
+			"WhitelistPlatforms": [ "Win64", "Mac", "Android", "IOS", "Linux", "LinuxArm64", "XSX" ]
 		},
 		{
 			"Name": "SentryEditor",

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Convenience/SentryInclude.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Convenience/SentryInclude.h
@@ -4,9 +4,9 @@
 
 #include "HAL/Platform.h"
 
-#if PLATFORM_WINDOWS
+#if PLATFORM_MICROSOFT
 #include "Microsoft/WindowsHWrapper.h"
-#endif // PLATFORM_WINDOWS
+#endif // PLATFORM_MICROSOFT
 
 #if USE_SENTRY_NATIVE
 #include "sentry.h"

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySubsystem.h
@@ -8,4 +8,6 @@
 #include "Windows/WindowsSentrySubsystem.h"
 #elif PLATFORM_LINUX
 #include "Linux/LinuxSentrySubsystem.h"
+#elif PLATFORM_XSX
+#include "Xbox/XboxSentrySubsystem.h"
 #endif

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -8,6 +8,20 @@
 #include "SentryModule.h"
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
 
+void FMicrosoftSentrySubsystem::InitWithSettings(
+	const USentrySettings* Settings,
+	USentryBeforeSendHandler* BeforeSendHandler,
+	USentryTraceSampler* TraceSampler)
+{
+	FGenericPlatformSentrySubsystem::InitWithSettings(Settings, BeforeSendHandler, TraceSampler);
+
+#if !UE_VERSION_OLDER_THAN(5, 2, 0)
+	FPlatformMisc::SetCrashHandlingType(Settings->EnableAutoCrashCapturing
+		? ECrashHandlingType::Disabled
+		: ECrashHandlingType::Default);
+#endif // !UE_VERSION_OLDER_THAN(5, 2, 0)
+}
+
 void FMicrosoftSentrySubsystem::ConfigureHandlerPath(sentry_options_t* Options)
 {
 	if (!FSentryModule::Get().IsMarketplaceVersion())

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
@@ -8,6 +8,13 @@
 
 class FMicrosoftSentrySubsystem : public FGenericPlatformSentrySubsystem
 {
+public:
+	virtual void InitWithSettings(
+		const USentrySettings* Settings,
+		USentryBeforeSendHandler* BeforeSendHandler,
+		USentryTraceSampler* TraceSampler
+	) override;
+
 protected:
 	virtual void ConfigureHandlerPath(sentry_options_t* Options) override;
 	virtual void ConfigureDatabasePath(sentry_options_t* Options) override;

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -712,7 +712,7 @@ void USentrySubsystem::ConfigureOutputDeviceError()
 			// Shut things down before exiting to ensure all the outgoing events are sent to Sentry
 			Close();
 
-			FPlatformMisc::RequestExit( true);
+			FPlatformMisc::RequestExit(true, TEXT("USentrySubsystem::OutputDeviceError->OnAssert"));
 		});
 
 		GError = OutputDeviceError.Get();

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -675,6 +675,8 @@ bool USentrySubsystem::IsCurrentPlatformEnabled()
 	IsBuildPlatformEnabled = Settings->EnableBuildPlatforms.bEnableAndroid;
 #elif PLATFORM_MAC
 	IsBuildPlatformEnabled = Settings->EnableBuildPlatforms.bEnableMac;
+#elif PLATFORM_XSX
+	IsBuildPlatformEnabled = Settings->EnableBuildPlatforms.bEnableXSX;
 #endif
 
 	return IsBuildPlatformEnabled;

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -112,7 +112,7 @@ void USentrySubsystem::Initialize()
 
 	AddDefaultContext();
 
-#if PLATFORM_WINDOWS || PLATFORM_LINUX || PLATFORM_MAC
+#if PLATFORM_WINDOWS || PLATFORM_LINUX || PLATFORM_MAC || PLATFORM_XSX
 	AddGpuContext();
 	AddDeviceContext();
 #endif

--- a/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
@@ -8,20 +8,6 @@
 #include "Windows/WindowsPlatformStackWalk.h"
 #include "Windows/Infrastructure/WindowsSentryConverters.h"
 
-void FWindowsSentrySubsystem::InitWithSettings(
-	const USentrySettings* Settings,
-	USentryBeforeSendHandler* BeforeSendHandler,
-	USentryTraceSampler* TraceSampler)
-{
-	FMicrosoftSentrySubsystem::InitWithSettings(Settings, BeforeSendHandler, TraceSampler);
-
-#if !UE_VERSION_OLDER_THAN(5, 2, 0)
-	FPlatformMisc::SetCrashHandlingType(Settings->EnableAutoCrashCapturing
-		? ECrashHandlingType::Disabled
-		: ECrashHandlingType::Default);
-#endif // !UE_VERSION_OLDER_THAN(5, 2, 0)
-}
-
 void FWindowsSentrySubsystem::ConfigureGpuDumpAttachment(sentry_options_t *Options)
 {
 	sentry_options_add_attachmentw(Options, *GetGpuDumpBackupPath());

--- a/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.h
@@ -6,13 +6,6 @@
 
 class FWindowsSentrySubsystem : public FMicrosoftSentrySubsystem
 {
-public:
-	virtual void InitWithSettings(
-		const USentrySettings* Settings,
-		USentryBeforeSendHandler* BeforeSendHandler,
-		USentryTraceSampler* TraceSampler
-	) override;
-
 protected:
 	virtual void ConfigureGpuDumpAttachment(sentry_options_t* Options) override;
 	virtual FString GetHandlerExecutableName() const override { return TEXT("crashpad_handler.exe"); }

--- a/plugin-dev/Source/Sentry/Private/Xbox/XboxSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Xbox/XboxSentrySubsystem.h
@@ -1,10 +1,15 @@
 #pragma once
 
-#include "GenericPlatform/GenericPlatformSentrySubsystem.h"
+#if USE_SENTRY_NATIVE
 
-class FXboxSentrySubsystem : public FGenericPlatformSentrySubsystem
+#include "Microsoft/MicrosoftSentrySubsystem.h"
+
+class FXboxSentrySubsystem : public FMicrosoftSentrySubsystem
 {
-
+public:
+	virtual void ConfigureHandlerPath(sentry_options_t* Options) override {}
 };
 
 typedef FXboxSentrySubsystem FPlatformSentrySubsystem;
+
+#endif // USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Xbox/XboxSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Xbox/XboxSentrySubsystem.h
@@ -1,0 +1,10 @@
+#pragma once
+
+#include "GenericPlatform/GenericPlatformSentrySubsystem.h"
+
+class FXboxSentrySubsystem : public FGenericPlatformSentrySubsystem
+{
+
+};
+
+typedef FXboxSentrySubsystem FPlatformSentrySubsystem;

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -196,6 +196,10 @@ struct FEnableBuildPlatforms
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "General",
 		Meta = (DisplayName = "Mac", ToolTip = "Flag indicating whether event capturing should be enabled for the Mac platform type."))
 	bool bEnableMac = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "General",
+		Meta = (DisplayName = "XSX", ToolTip = "Flag indicating whether event capturing should be enabled for the Xbox Series X|S platform type."))
+	bool bEnableXSX = true;
 };
 
 /**

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -290,8 +290,8 @@ class SENTRY_API USentrySettings : public UObject
 		Meta = (DisplayName = "Custom `beforeSend` event handler", ToolTip = "Custom handler for processing events before sending them to Sentry."))
 	TSubclassOf<USentryBeforeSendHandler> BeforeSendHandler;
 
-	UPROPERTY(Config, EditAnywhere, Category = "General|Windows",
-		Meta = (DisplayName = "Override Windows default crash capturing mechanism (UE 5.2+)", ToolTip = "Flag indicating whether to capture crashes automatically on Windows as an alternative to Crash Reporter."))
+	UPROPERTY(Config, EditAnywhere, Category = "General|Native",
+		Meta = (DisplayName = "Override default crash capturing mechanism (for Windows/Xbox only) (UE 5.2+)", ToolTip = "Flag indicating whether to capture crashes automatically on Windows and Xbox Series X|S as an alternative to Crash Reporter."))
 	bool EnableAutoCrashCapturing;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Native",

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -183,7 +183,7 @@ public class Sentry : ModuleRules
 			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "sentry.lib"));
 			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "breakpad_client.lib"));
 
-			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "sentry.dll"), Path.Combine(PlatformThirdPartyPath, "bin", "sentry.dll"));
+			RuntimeDependencies.Add("$(BinaryOutputDir)/sentry.dll", Path.Combine(PlatformThirdPartyPath, "bin", "sentry.dll"));
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
 			PublicDefinitions.Add("SENTRY_BUILD_STATIC=1");

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -175,7 +175,15 @@ public class Sentry : ModuleRules
 		// Additional routine for Xbox
 		if (Target.Platform == UnrealTargetPlatform.XSX)
 		{
+			PublicIncludePaths.Add(Path.Combine(PlatformThirdPartyPath, "include"));
+			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private", "Xbox"));
 
+			PublicDependencyModuleNames.Add("WinHttp");
+
+			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "sentry.lib"));
+			RuntimeDependencies.Add(Path.Combine(PlatformThirdPartyPath, "bin", "sentry.dll"));
+
+			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
 		}
 	}
 }

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -171,5 +171,11 @@ public class Sentry : ModuleRules
 			PublicDefinitions.Add("SENTRY_NO_UIKIT=1");
 			PublicDefinitions.Add("APPLICATION_EXTENSION_API_ONLY_NO=0");
 		}
+
+		// Additional routine for Xbox
+		if (Target.Platform == UnrealTargetPlatform.XSX)
+		{
+
+		}
 	}
 }

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -181,9 +181,12 @@ public class Sentry : ModuleRules
 			PublicDependencyModuleNames.Add("WinHttp");
 
 			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "sentry.lib"));
-			RuntimeDependencies.Add(Path.Combine(PlatformThirdPartyPath, "bin", "sentry.dll"));
+			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "breakpad_client.lib"));
+
+			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "sentry.dll"), Path.Combine(PlatformThirdPartyPath, "bin", "sentry.dll"));
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=1");
+			PublicDefinitions.Add("SENTRY_BUILD_STATIC=1");
 		}
 	}
 }

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -137,7 +137,7 @@ function buildSentryNativeXbox()
 {
     Push-Location -Path "$modulesDir/sentry-native"
 
-    cmake -B "build" -G "Visual Studio 17 2022" -A "Gaming.Xbox.Scarlett.x64" -DXdkEditionTarget="240602" -DCMAKE_TOOLCHAIN_FILE="./toolchains/xbox/gxdk_xs_toolchain.cmake" -D SENTRY_SDK_NAME=sentry.native.unreal
+    cmake -B "build" -G "Visual Studio 17 2022" -A "Gaming.Xbox.Scarlett.x64" -DXdkEditionTarget="240602" -DCMAKE_TOOLCHAIN_FILE="./toolchains/xbox/gxdk_xs_toolchain.cmake" -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BACKEND=breakpad
     cmake --build build --config RelWithDebInfo
     cmake --install build --prefix install --config RelWithDebInfo
 

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -137,7 +137,7 @@ function buildSentryNativeXbox()
 {
     Push-Location -Path "$modulesDir/sentry-native"
 
-    cmake -B "build" -G "Visual Studio 17 2022" -A "Gaming.Xbox.Scarlett.x64" -DXdkEditionTarget="240602" -DCMAKE_TOOLCHAIN_FILE="./toolchains/xbox/gxdk_xs_toolchain.cmake" -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BACKEND=breakpad
+    cmake -B "build" -G "Visual Studio 17 2022" -A "Gaming.Xbox.Scarlett.x64" -DXdkEditionTarget="240602" -DCMAKE_TOOLCHAIN_FILE="./toolchains/xbox/gxdk_xs_toolchain.cmake" -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BACKEND=breakpad -D SENTRY_BUILD_SHARED_LIBS=OFF
     cmake --build build --config RelWithDebInfo
     cmake --install build --prefix install --config RelWithDebInfo
 

--- a/scripts/download-sdks.ps1
+++ b/scripts/download-sdks.ps1
@@ -48,7 +48,7 @@ foreach ($sdk in $sdks)
     Write-Host "Downloading $sdk SDK to $sdkDir ..."
     if (Test-Path $sdkDir)
     {
-        Remove-Item "$outDir/$sdk" -Recurse
+        Remove-Item "$sdkDir" -Recurse
     }
 
     gh run download $runId -n "$sdk-sdk" -D $sdkDir


### PR DESCRIPTION
- Updated `build-deps.ps1` to build the Xbox-specific version of Sentry Native
- Added `FXboxSentrySubsystem` to encapsulate behavior
- Cleaned up documentation and added known limitations for Xbox

**TODO**:
- Add reference to UDN post once Epic has acknowledged change to replicate SEH behavior from Windows to Xbox