### PR TITLE
Rearrange upload script to check of automatic upload earlier

### DIFF
--- a/plugin-dev/Scripts/upload-debug-symbols-win.bat
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.bat
@@ -20,18 +20,9 @@ if "%TargetType%"=="Editor" (
     exit /B 0
 )
 
-if "%TargetPlatform%"=="Win64" (
-    set CliExec=%PluginPath:"=%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
-) else if "%TargetPlatform%"=="Linux" (
-    set CliExec=%PluginPath:"=%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
-) else if "%TargetPlatform%"=="LinuxArm64" (
-    set CliExec=%PluginPath:"=%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
-) else if "%TargetPlatform%"=="Android" (
-    echo Warning: Sentry: Debug symbols upload for Android is handled by Sentry's gradle plugin if enabled
-    exit /B 0
-) else (
-    echo Warning: Sentry: Unexpected platform %TargetPlatform%. Skipping...
-    exit /B 0
+if "%TargetPlatform%"=="Android" (
+	echo Sentry: Debug symbols upload for Android is handled by Sentry's Gradle plugin (if enabled)
+	exit /B 0
 )
 
 call :ParseIniFile "%ConfigPath%\DefaultEngine.ini" /Script/Sentry.SentrySettings UploadSymbolsAutomatically UploadSymbols
@@ -103,8 +94,19 @@ if not exist "%PropertiesFile%" (
     exit /B 0
 )
 
+if "%TargetPlatform%"=="Win64" (
+    set CliExec=%PluginPath:"=%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
+) else if "%TargetPlatform%"=="Linux" (
+    set CliExec=%PluginPath:"=%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
+) else if "%TargetPlatform%"=="LinuxArm64" (
+    set CliExec=%PluginPath:"=%\Source\ThirdParty\CLI\sentry-cli-Windows-x86_64.exe
+) else (
+    echo Warning: Sentry: Unexpected platform %TargetPlatform%. Skipping...
+    exit /B 0
+)
+
 if not exist "%CliExec%" (
-    echo Warning: Sentry: Sentry CLI is not configured in plugin settings. Skipping...
+    echo Error: Sentry: Sentry CLI is missing. Skipping...
     exit /B 0
 )
 


### PR DESCRIPTION
The upload symbol scripts look at `DefaultEngine.ini` instead of platform-specific Engine config files, so there is no need to check for the platform (and for the CLI executable) before checking to see if automatic upload is even enabled.

This avoids the situation where a new platform (e.g. Xbox) is not configured in the upload script, which would cause a warning to appear in build logs even if upload is disabled.