### PR TITLE
Fix invalid syntax in symbol upload batch script

### DIFF
--- a/plugin-dev/Scripts/upload-debug-symbols-win.bat
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.bat
@@ -21,7 +21,7 @@ if "%TargetType%"=="Editor" (
 )
 
 if "%TargetPlatform%"=="Android" (
-	echo Sentry: Debug symbols upload for Android is handled by Sentry's Gradle plugin (if enabled)
+	echo Sentry: Debug symbols upload for Android is handled by Sentry's Gradle plugin if enabled
 	exit /B 0
 )
 


### PR DESCRIPTION
Using braces when printing messages to the console in `.bat` scripts on Windows breaks the normal script execution flow.