### PR TITLE
chore: Add `EngineVersion` key to plugin descriptor only for marketplace version

### DIFF
--- a/scripts/packaging/pack.ps1
+++ b/scripts/packaging/pack.ps1
@@ -57,6 +57,8 @@ function packFiles([string] $publishingPlatform)
         $packageName = "sentry-unreal-$version-engine$engineVersion-$publishingPlatform.zip"
         Write-Host "Creating a release package for Unreal $engineVersion as $packageName"
 
+        $newPluginSpec = $pluginSpec
+
         # Add EngineVersion key only for marketplace package to avoid warnings in licensee versions of Unreal
         # where github package is used (https://github.com/getsentry/sentry-unreal/issues/811)
         if ($publishingPlatform -eq "marketplace")

--- a/scripts/packaging/pack.ps1
+++ b/scripts/packaging/pack.ps1
@@ -57,7 +57,12 @@ function packFiles([string] $publishingPlatform)
         $packageName = "sentry-unreal-$version-engine$engineVersion-$publishingPlatform.zip"
         Write-Host "Creating a release package for Unreal $engineVersion as $packageName"
 
-        $newPluginSpec = @($pluginSpec[0..0]) + @('	"EngineVersion" : "' + $engineVersion + '.0",') + @($pluginSpec[1..($pluginSpec.count)])
+        # Add EngineVersion key only for marketplace package to avoid warnings in licensee versions of Unreal
+        # where github package is used (https://github.com/getsentry/sentry-unreal/issues/811)
+        if ($publishingPlatform -eq "marketplace")
+        {
+            $newPluginSpec = @($pluginSpec[0..0]) + @('	"EngineVersion" : "' + $engineVersion + '.0",') + @($pluginSpec[1..($pluginSpec.count)])
+        }
 
         # Handle platform name difference for UE 4.27
         if ($engineVersion -eq "4.27")


### PR DESCRIPTION
This PR updates the packaging script to add the `EngineVersion` key to the `Sentry.uplugin` descriptor only for the marketplace version of the plugin.

For UE Marketplace publishing only the major engine version (e.g., `5.5.0`) needs to be specified. In licensee versions of Unreal the patch version may differ from zero which can trigger unnecessary warnings that some organizations treat as errors.

Closes #811 

#skip-changelog