### PR TITLE
Fix screenshot attachment display at Sentry event page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Remove `EnableTargetPlatforms` from plugin settings ([#809](https://github.com/getsentry/sentry-unreal/pull/809))
 - Remove Native SDK build from source in Unreal ([#808](https://github.com/getsentry/sentry-unreal/pull/808))
 
+### Fixes
+
+- Fix screenshot attachment display at Sentry event page ([#813](https://github.com/getsentry/sentry-unreal/pull/813))
+
 ### Dependencies
 
 - Bump Cocoa SDK (iOS and Mac) from v8.45.0 to v8.46.0 ([#810](https://github.com/getsentry/sentry-unreal/pull/810))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Fixes
 
-- Fix screenshot attachment display at Sentry event page ([#813](https://github.com/getsentry/sentry-unreal/pull/813))
+- Captured screenshots are now displayed correctly on the issues details ([#813](https://github.com/getsentry/sentry-unreal/pull/813))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -558,7 +558,7 @@ FString FGenericPlatformSentrySubsystem::GetDatabasePath() const
 
 FString FGenericPlatformSentrySubsystem::GetScreenshotPath() const
 {
-	const FString ScreenshotPath = FPaths::Combine(GetDatabasePath(), TEXT("screenshots"), TEXT("crash_screenshot.png"));
+	const FString ScreenshotPath = FPaths::Combine(GetDatabasePath(), TEXT("screenshots"), TEXT("screenshot.png"));
 	const FString ScreenshotFullPath = FPaths::ConvertRelativePathToFull(ScreenshotPath);
 
 	return ScreenshotFullPath;


### PR DESCRIPTION
This PR renames captured screenshot file from `crash_screenshot.png` to `screenshot.png` to fix corresponding attachment display on Sentry event page. Using this pre-defined name for screen captures allows them to show up in a separate `Screenshots` tab.
<img width="987" alt="Screenshot 2025-03-07 at 09 49 43" src="https://github.com/user-attachments/assets/b1f8ee65-3bef-4ae1-949c-06e3e21faf59" />
