### PR TITLE
chore: Use default `ubuntu-latest` runner for Linux CI checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
 
   test:
     name: Test UE ${{ matrix.unreal }}
-    runs-on: ubuntu-latest-4-cores
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false


### PR DESCRIPTION
For now, the default `ubuntu-latest` runner provides enough disk space for downloading UE Linux Docker images and run related CI checks.

#skip-changelog