### PR TITLE
chore: Fix `crashpad_handler` executable permission for Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,15 @@ jobs:
           name: Win64-Breakpad-sdk
           path: plugin-dev/Source/ThirdParty/Win64/Breakpad
 
+      # Workaround for https://github.com/actions/download-artifact/issues/14
+      # Adding execute permission for crashpad before preparing final packages
+      # allows to avoid issues with plugin initialization on Unix-based systems.
+      - name: Set permissions for crashpad_handler
+        shell: pwsh
+        run: |
+          chmod +x plugin-dev/Source/ThirdParty/Linux/bin/crashpad_handler
+          chmod +x plugin-dev/Source/ThirdParty/LinuxArm64/bin/crashpad_handler
+
       - name: Prepare Sentry packages for release
         shell: pwsh
         run: ./scripts/packaging/pack.ps1


### PR DESCRIPTION
This PR fixes an issue where `crashpad_handler` lacks `execute` permission on Unix-based systems when the plugin is downloaded from GitHub releases causing its initialization to fail. This issue is caused by a limitation in [actions/download-artifact](https://github.com/actions/download-artifact?tab=readme-ov-file#permission-loss) which does not preserve file permissions when downloading pre-built Unreal SDK dependencies from CI before preparing the final package.

Closes #821

#skip-changelog