### PR TITLE
Fix Sentry CLI config type setting name

### DIFF
--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -333,17 +333,17 @@ class SENTRY_API USentrySettings : public UObject
 
 	UPROPERTY(EditAnywhere, Category = "Debug Symbols",
 		Meta = (DisplayName = "Project Name", ToolTip = "Name of the project for which debug symbols should be uploaded.",
-			EditCondition = "UploadSymbolsAutomatically && SentryCliAuthType == ESentryDebugSymbolsAuthType::PropertiesFile", EditConditionHides))
+			EditCondition = "UploadSymbolsAutomatically && SentryCliConfigType == ESentryDebugSymbolsConfigType::PropertiesFile", EditConditionHides))
 	FString ProjectName;
 
 	UPROPERTY(EditAnywhere, Category = "Debug Symbols",
 		Meta = (DisplayName = "Organization Name", ToolTip = "Name of the organization associated with the project.",
-			EditCondition = "UploadSymbolsAutomatically && SentryCliAuthType == ESentryDebugSymbolsAuthType::PropertiesFile", EditConditionHides))
+			EditCondition = "UploadSymbolsAutomatically && SentryCliConfigType == ESentryDebugSymbolsConfigType::PropertiesFile", EditConditionHides))
 	FString OrgName;
 
 	UPROPERTY(EditAnywhere, Category = "Debug Symbols",
 		Meta = (DisplayName = "Authentication token", ToolTip = "Authentication token for performing actions against Sentry API.",
-			EditCondition = "UploadSymbolsAutomatically && SentryCliAuthType == ESentryDebugSymbolsAuthType::PropertiesFile", EditConditionHides))
+			EditCondition = "UploadSymbolsAutomatically && SentryCliConfigType == ESentryDebugSymbolsConfigType::PropertiesFile", EditConditionHides))
 	FString AuthToken;
 
 	UPROPERTY(Config, EditAnywhere, Category = "Debug Symbols",

--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -272,11 +272,11 @@ void FSentrySettingsCustomization::DrawDebugSymbolsNotice(IDetailLayoutBuilder& 
 			]
 		];
 
-	TSharedRef<SWidget> CliAuthPropertiesFileWidget = MakeSentryCliAuthTypeRow(
+	TSharedRef<SWidget> CliAuthPropertiesFileWidget = MakeSentryCliConfigTypeRow(
 		FText::FromString(TEXT("Note that the Sentry SDK creates a <RichTextBlock.TextHighlight>sentry.properties</> file at project root to store the configuration, "
 			"that should <RichTextBlock.TextHighlight>NOT</> be made publicly available.")));
 
-	TSharedRef<SWidget> CliAuthEnvVarWidget = MakeSentryCliAuthTypeRow(
+	TSharedRef<SWidget> CliAuthEnvVarWidget = MakeSentryCliConfigTypeRow(
 		FText::FromString(TEXT("Set up the environment variables <RichTextBlock.TextHighlight>SENTRY_AUTH_TOKEN</>, <RichTextBlock.TextHighlight>SENTRY_ORG</> and "
 			"<RichTextBlock.TextHighlight>SENTRY_PROJECT</> with the necessary information to upload debug symbols on the build agent.")));
 
@@ -287,7 +287,7 @@ void FSentrySettingsCustomization::DrawDebugSymbolsNotice(IDetailLayoutBuilder& 
 			.Padding(1)
 			[
 				SNew(SWidgetSwitcher)
-				.WidgetIndex(this, &FSentrySettingsCustomization::GetSentryCliAuthTypeAsInt)
+				.WidgetIndex(this, &FSentrySettingsCustomization::GetSentryCliConfigTypeAsInt)
 				+SWidgetSwitcher::Slot()
 				[
 					CliAuthPropertiesFileWidget
@@ -501,7 +501,7 @@ TSharedRef<SWidget> FSentrySettingsCustomization::MakeSentryCliStatusRow(FName I
 	return Result;
 }
 
-TSharedRef<SWidget> FSentrySettingsCustomization::MakeSentryCliAuthTypeRow(FText Message)
+TSharedRef<SWidget> FSentrySettingsCustomization::MakeSentryCliConfigTypeRow(FText Message)
 {
 #if UE_VERSION_OLDER_THAN(5, 0, 0)
 	const ISlateStyle& Style = FEditorStyle::Get();
@@ -647,7 +647,7 @@ int32 FSentrySettingsCustomization::GetSentryCliStatusAsInt() const
 	return 0;
 }
 
-int32 FSentrySettingsCustomization::GetSentryCliAuthTypeAsInt() const
+int32 FSentrySettingsCustomization::GetSentryCliConfigTypeAsInt() const
 {
 	return static_cast<int32>(FSentryModule::Get().GetSettings()->SentryCliConfigType);
 }

--- a/plugin-dev/Source/SentryEditor/Public/SentrySettingsCustomization.h
+++ b/plugin-dev/Source/SentryEditor/Public/SentrySettingsCustomization.h
@@ -44,7 +44,7 @@ private:
 	TSharedRef<SWidget> MakeGeneralSettingsStatusRow(FName IconName, FText Message, FText ButtonMessage);
 	TSharedRef<SWidget> MakeLinuxBinariesStatusRow(FName IconName, FText Message, FText ButtonMessage);
 	TSharedRef<SWidget> MakeSentryCliStatusRow(FName IconName, FText Message, FText ButtonMessage);
-	TSharedRef<SWidget> MakeSentryCliAuthTypeRow(FText Message);
+	TSharedRef<SWidget> MakeSentryCliConfigTypeRow(FText Message);
 
 	void UpdateProjectName();
 	void UpdateOrganizationName();
@@ -61,7 +61,7 @@ private:
 	int32 GetGeneralSettingsStatusAsInt() const;
 	int32 GetLinuxBinariesStatusAsInt() const;
 	int32 GetSentryCliStatusAsInt() const;
-	int32 GetSentryCliAuthTypeAsInt() const;
+	int32 GetSentryCliConfigTypeAsInt() const;
 
 	TSharedPtr<IPropertyHandle> ProjectNameHandle;
 	TSharedPtr<IPropertyHandle> OrganizationNameHandle;


### PR DESCRIPTION
Related to #836 

#skip-changelog