### PR TITLE
Fix crash during garbage collection if `SentryId` was instantiated outside of game thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Breaking Changes
+
+- Change `SentryId` type from class to struct.
+
 ### Features
 
 - Allow Sentry CLI to authenticate via environment variables during debug symbols upload ([#836](https://github.com/getsentry/sentry-unreal/pull/836))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Allow Sentry CLI to authenticate via environment variables during debug symbols upload ([#836](https://github.com/getsentry/sentry-unreal/pull/836))
 
+### Fixes
+
+- Fix crash during garbage collection if SentryId was instantiated outside of game thread ([#840](https://github.com/getsentry/sentry-unreal/pull/840))
+
 ### Dependencies
 
 - Bump Java SDK (Android) from v8.4.0 to v8.5.0 ([#835](https://github.com/getsentry/sentry-unreal/pull/835))

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -10,14 +10,14 @@ void USentryEvent::Initialize()
 	NativeImpl = CreateSharedSentryEvent();
 }
 
-USentryId* USentryEvent::GetId() const
+FSentryId USentryEvent::GetId() const
 {
 	if (!NativeImpl)
-		return nullptr;
+		return FSentryId();
 
 	TSharedPtr<ISentryId> idNativeImpl = NativeImpl->GetId();
 
-	return USentryId::Create(idNativeImpl);
+	return FSentryId(idNativeImpl);
 }
 
 void USentryEvent::SetMessage(const FString &Message)

--- a/plugin-dev/Source/Sentry/Private/SentryId.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryId.cpp
@@ -4,12 +4,16 @@
 
 #include "HAL/PlatformSentryId.h"
 
-void USentryId::Initialize()
+FSentryId::FSentryId()
 {
-	NativeImpl = CreateSharedSentryId();
 }
 
-FString USentryId::ToString() const
+FSentryId::FSentryId(TSharedPtr<ISentryId> Id)
+{
+	NativeImpl = Id;
+}
+
+FString FSentryId::ToString() const
 {
 	if(!NativeImpl)
 		return FString();

--- a/plugin-dev/Source/Sentry/Private/SentryLibrary.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryLibrary.cpp
@@ -47,9 +47,9 @@ USentryUser* USentryLibrary::CreateSentryUser(const FString& Email, const FStrin
 	return User;
 }
 
-USentryUserFeedback* USentryLibrary::CreateSentryUserFeedback(USentryId* EventId, const FString& Name, const FString& Email, const FString& Comments)
+USentryUserFeedback* USentryLibrary::CreateSentryUserFeedback(const FSentryId& EventId, const FString& Name, const FString& Email, const FString& Comments)
 {
-	USentryUserFeedback* UserFeedback = USentryUserFeedback::Create(CreateSharedSentryUserFeedback(EventId->GetNativeObject()));
+	USentryUserFeedback* UserFeedback = USentryUserFeedback::Create(CreateSharedSentryUserFeedback(EventId.GetNativeObject()));
 
 	if (!Name.IsEmpty())
 		UserFeedback->SetName(Name);

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -7,7 +7,6 @@
 #include "SentryBreadcrumb.h"
 #include "SentryDefines.h"
 #include "SentryEvent.h"
-#include "SentryId.h"
 #include "SentryUser.h"
 #include "SentryUserFeedback.h"
 #include "SentryBeforeSendHandler.h"
@@ -234,32 +233,32 @@ void USentrySubsystem::ClearBreadcrumbs()
 	SubsystemNativeImpl->ClearBreadcrumbs();
 }
 
-USentryId* USentrySubsystem::CaptureMessage(const FString& Message, ESentryLevel Level)
+FSentryId USentrySubsystem::CaptureMessage(const FString& Message, ESentryLevel Level)
 {
 	check(SubsystemNativeImpl);
 
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 	{
-		return nullptr;
+		return FSentryId();
 	}
 
 	TSharedPtr<ISentryId> SentryId = SubsystemNativeImpl->CaptureMessage(Message, Level);
 
-	return USentryId::Create(SentryId);
+	return FSentryId(SentryId);
 }
 
-USentryId* USentrySubsystem::CaptureMessageWithScope(const FString& Message, const FConfigureScopeDelegate& OnConfigureScope, ESentryLevel Level)
+FSentryId USentrySubsystem::CaptureMessageWithScope(const FString& Message, const FConfigureScopeDelegate& OnConfigureScope, ESentryLevel Level)
 {
 	return CaptureMessageWithScope(Message, FConfigureScopeNativeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()), Level);
 }
 
-USentryId* USentrySubsystem::CaptureMessageWithScope(const FString& Message, const FConfigureScopeNativeDelegate& OnConfigureScope, ESentryLevel Level)
+FSentryId USentrySubsystem::CaptureMessageWithScope(const FString& Message, const FConfigureScopeNativeDelegate& OnConfigureScope, ESentryLevel Level)
 {
 	check(SubsystemNativeImpl);
 
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 	{
-		return nullptr;
+		return FSentryId();
 	}
 
 	TSharedPtr<ISentryId> SentryId = SubsystemNativeImpl->CaptureMessageWithScope(Message, FSentryScopeDelegate::CreateLambda([OnConfigureScope](TSharedPtr<ISentryScope> NativeScope)
@@ -268,37 +267,37 @@ USentryId* USentrySubsystem::CaptureMessageWithScope(const FString& Message, con
 		OnConfigureScope.ExecuteIfBound(UnrealScope);
 	}), Level);
 
-	return USentryId::Create(SentryId);
+	return FSentryId(SentryId);
 }
 
-USentryId* USentrySubsystem::CaptureEvent(USentryEvent* Event)
+FSentryId USentrySubsystem::CaptureEvent(USentryEvent* Event)
 {
 	check(SubsystemNativeImpl);
 	check(Event);
 
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 	{
-		return nullptr;
+		return FSentryId();
 	}
 
 	TSharedPtr<ISentryId> SentryId = SubsystemNativeImpl->CaptureEvent(Event->GetNativeObject());
 
-	return USentryId::Create(SentryId);
+	return FSentryId(SentryId);
 }
 
-USentryId* USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDelegate& OnConfigureScope)
+FSentryId USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDelegate& OnConfigureScope)
 {
 	return CaptureEventWithScope(Event, FConfigureScopeNativeDelegate::CreateUFunction(const_cast<UObject*>(OnConfigureScope.GetUObject()), OnConfigureScope.GetFunctionName()));
 }
 
-USentryId* USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeNativeDelegate& OnConfigureScope)
+FSentryId USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeNativeDelegate& OnConfigureScope)
 {
 	check(SubsystemNativeImpl);
 	check(Event);
 
 	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 	{
-		return nullptr;
+		return FSentryId();
 	}
 
 	TSharedPtr<ISentryId> SentryId = SubsystemNativeImpl->CaptureEventWithScope(Event->GetNativeObject(), FSentryScopeDelegate::CreateLambda([OnConfigureScope](TSharedPtr<ISentryScope> NativeScope)
@@ -307,7 +306,7 @@ USentryId* USentrySubsystem::CaptureEventWithScope(USentryEvent* Event, const FC
 		OnConfigureScope.ExecuteIfBound(UnrealScope);
 	}));
 
-	return USentryId::Create(SentryId);
+	return FSentryId(SentryId);
 }
 
 void USentrySubsystem::CaptureUserFeedback(USentryUserFeedback* UserFeedback)
@@ -323,12 +322,12 @@ void USentrySubsystem::CaptureUserFeedback(USentryUserFeedback* UserFeedback)
 	SubsystemNativeImpl->CaptureUserFeedback(UserFeedback->GetNativeObject());
 }
 
-void USentrySubsystem::CaptureUserFeedbackWithParams(USentryId* EventId, const FString& Email, const FString& Comments, const FString& Name)
+void USentrySubsystem::CaptureUserFeedbackWithParams(const FSentryId& EventId, const FString& Email, const FString& Comments, const FString& Name)
 {
 	check(SubsystemNativeImpl);
-	check(EventId);
+	check(EventId.IsValid());
 
-	USentryUserFeedback* UserFeedback = USentryUserFeedback::Create(CreateSharedSentryUserFeedback(EventId->GetNativeObject()));
+	USentryUserFeedback* UserFeedback = USentryUserFeedback::Create(CreateSharedSentryUserFeedback(EventId.GetNativeObject()));
 	check(UserFeedback);
 
 	UserFeedback->SetEmail(Email);

--- a/plugin-dev/Source/Sentry/Private/SentryUserFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryUserFeedback.cpp
@@ -5,11 +5,11 @@
 
 #include "HAL/PlatformSentryUserFeedback.h"
 
-void USentryUserFeedback::Initialize(USentryId* EventId)
+void USentryUserFeedback::Initialize(const FSentryId& EventId)
 {
-	if (ensure(IsValid(EventId)))
+	if (ensure(EventId.GetNativeObject()))
 	{
-		NativeImpl = CreateSharedSentryUserFeedback(EventId->GetNativeObject());
+		NativeImpl = CreateSharedSentryUserFeedback(EventId.GetNativeObject());
 	}
 }
 

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
@@ -2,6 +2,7 @@
 
 #include "SentryTests.h"
 #include "SentryEvent.h"
+#include "SentryId.h"
 
 #include "Misc/AutomationTest.h"
 
@@ -31,7 +32,7 @@ void SentryEventSpec::Define()
 
 			TestEqual("Event level", SentryEvent->GetLevel(), ESentryLevel::Fatal);
 			TestEqual("Event message", SentryEvent->GetMessage(), TestMessage);
-			TestNotNull("Event ID is non-null", SentryEvent->GetId());
+			TestTrue("Event ID is valid", SentryEvent->GetId().IsValid());
 		});
 	});
 }

--- a/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
@@ -26,26 +26,21 @@ void SentrySubsystemSpec::Define()
 	BeforeEach([this]()
 	{
 		SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
-
-		if(SentrySubsystem && !SentrySubsystem->IsEnabled())
-		{
-			SentrySubsystem->Initialize();
-		}
 	});
 
 	Describe("Capture Message", [this]()
 	{
 		It("should return a non-null Event ID if message captured", [this]()
 		{
-			const USentryId* eventId = SentrySubsystem->CaptureMessage(FString(TEXT("Automation: Sentry test message")), ESentryLevel::Debug);
-			TestNotNull("Event ID is non-null", eventId);
+			FSentryId eventId = SentrySubsystem->CaptureMessage(FString(TEXT("Automation: Sentry test message")), ESentryLevel::Debug);
+			TestTrue("Event ID is valid", eventId.IsValid());
 		});
 
 		It("should always return non-null Event ID if scoped version used", [this]()
 		{
 			const FConfigureScopeNativeDelegate testDelegate;
-			const USentryId* eventId = SentrySubsystem->CaptureMessageWithScope(FString(TEXT("Automation: Sentry test message with scope")), testDelegate, ESentryLevel::Debug);
-			TestNotNull("Event ID is non-null", eventId);
+			FSentryId eventId = SentrySubsystem->CaptureMessageWithScope(FString(TEXT("Automation: Sentry test message with scope")), testDelegate, ESentryLevel::Debug);
+			TestTrue("Event ID is valid", eventId.IsValid());
 		});
 	});
 
@@ -56,8 +51,8 @@ void SentrySubsystemSpec::Define()
 			USentryEvent* testEvent = USentryEvent::Create(CreateSharedSentryEvent());
 			testEvent->SetMessage(TEXT("Automation: Sentry test event message"));
 
-			const USentryId* eventId = SentrySubsystem->CaptureEvent(testEvent);
-			TestNotNull("Event ID is non-null", eventId);
+			FSentryId eventId = SentrySubsystem->CaptureEvent(testEvent);
+			TestTrue("Event ID is valid", eventId.IsValid());
 		});
 
 		It("should always return non-null Event ID if scoped version used", [this]()
@@ -67,8 +62,8 @@ void SentrySubsystemSpec::Define()
 
 			const FConfigureScopeNativeDelegate testDelegate;
 
-			const USentryId* eventId = SentrySubsystem->CaptureEventWithScope(testEvent, testDelegate);
-			TestNotNull("Event ID is non-null", eventId);
+			FSentryId eventId = SentrySubsystem->CaptureEventWithScope(testEvent, testDelegate);
+			TestTrue("Event ID is valid", eventId.IsValid());
 		});
 	});
 
@@ -152,11 +147,6 @@ void SentrySubsystemSpec::Define()
 			TestEqual("Trace header", outTraceKey, TEXT("sentry-trace"));
 			TestEqual("Trace ID", outTraceParts[0], TEXT("2674eb52d5874b13b560236d6c79ce8a"));
 		});
-	});
-
-	AfterEach([this]
-	{
-		SentrySubsystem->Close();
 	});
 }
 

--- a/plugin-dev/Source/Sentry/Public/SentryEvent.h
+++ b/plugin-dev/Source/Sentry/Public/SentryEvent.h
@@ -4,10 +4,10 @@
 
 #include "SentryDataTypes.h"
 #include "SentryImplWrapper.h"
+#include "SentryId.h"
 
 #include "SentryEvent.generated.h"
 
-class USentryId;
 class ISentryEvent;
 
 /**
@@ -25,7 +25,7 @@ public:
 
 	/** Gets id of the event. */
 	UFUNCTION(BlueprintPure, Category = "Sentry")
-	USentryId* GetId() const;
+	FSentryId GetId() const;
 
 	/** Sets message of the event. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentryId.h
+++ b/plugin-dev/Source/Sentry/Public/SentryId.h
@@ -11,17 +11,21 @@ class ISentryId;
 /**
  * Unique identifier of the event.
  */
-UCLASS(BlueprintType, NotBlueprintable, HideDropdown)
-class SENTRY_API USentryId : public UObject, public TSentryImplWrapper<ISentryId, USentryId>
+USTRUCT(BlueprintType)
+struct SENTRY_API FSentryId
 {
 	GENERATED_BODY()
 
-public:
-	/** Initializes the identifier. */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void Initialize();
+	FSentryId();
+	FSentryId(TSharedPtr<ISentryId> Id);
 
 	/** Gets string representation of the event ID. */
-	UFUNCTION(BlueprintPure, Category = "Sentry")
 	FString ToString() const;
+
+	bool IsValid() const { return NativeImpl.IsValid(); }
+
+	TSharedPtr<ISentryId> GetNativeObject() const { return NativeImpl; }
+
+private:
+	TSharedPtr<ISentryId> NativeImpl;
 };

--- a/plugin-dev/Source/Sentry/Public/SentryLibrary.h
+++ b/plugin-dev/Source/Sentry/Public/SentryLibrary.h
@@ -5,6 +5,7 @@
 #include "Kismet/BlueprintFunctionLibrary.h"
 
 #include "SentryDataTypes.h"
+#include "SentryId.h"
 
 #include "SentryLibrary.generated.h"
 
@@ -13,7 +14,6 @@ class USentryEvent;
 class USentryBreadcrumb;
 class USentryUser;
 class USentryUserFeedback;
-class USentryId;
 class USentryAttachment;
 
 /**
@@ -56,7 +56,7 @@ public:
 	 * @param Comments Comments of the user about what happened.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	static USentryUserFeedback* CreateSentryUserFeedback(USentryId* EventId, const FString& Name, const FString& Email, const FString& Comments);
+	static USentryUserFeedback* CreateSentryUserFeedback(const FSentryId& EventId, const FString& Name, const FString& Email, const FString& Comments);
 
 	/**
 	 * Creates breadcrumb.

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -7,13 +7,13 @@
 
 #include "SentryDataTypes.h"
 #include "SentryScope.h"
+#include "SentryId.h"
 
 #include "SentrySubsystem.generated.h"
 
 class USentrySettings;
 class USentryBreadcrumb;
 class USentryEvent;
-class USentryId;
 class USentryUserFeedback;
 class USentryUser;
 class USentryBeforeSendHandler;
@@ -108,7 +108,7 @@ public:
 	 * @param Level The message level.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentryId* CaptureMessage(const FString& Message, ESentryLevel Level = ESentryLevel::Info);
+	FSentryId CaptureMessage(const FString& Message, ESentryLevel Level = ESentryLevel::Info);
 
 	/**
 	 * Captures the message with a configurable scope.
@@ -122,8 +122,8 @@ public:
 	 * @note: Not supported for Windows/Linux.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry", meta = (AutoCreateRefTerm = "OnConfigureScope"))
-	USentryId* CaptureMessageWithScope(const FString& Message, const FConfigureScopeDelegate& OnConfigureScope, ESentryLevel Level = ESentryLevel::Info);
-	USentryId* CaptureMessageWithScope(const FString& Message, const FConfigureScopeNativeDelegate& OnConfigureScope, ESentryLevel Level = ESentryLevel::Info);
+	FSentryId CaptureMessageWithScope(const FString& Message, const FConfigureScopeDelegate& OnConfigureScope, ESentryLevel Level = ESentryLevel::Info);
+	FSentryId CaptureMessageWithScope(const FString& Message, const FConfigureScopeNativeDelegate& OnConfigureScope, ESentryLevel Level = ESentryLevel::Info);
 
 	/**
 	 * Captures a manually created event and sends it to Sentry.
@@ -131,7 +131,7 @@ public:
 	 * @param Event The event to send to Sentry.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentryId* CaptureEvent(USentryEvent* Event);
+	FSentryId CaptureEvent(USentryEvent* Event);
 
 	/**
 	 * Captures a manually created event and sends it to Sentry.
@@ -142,8 +142,8 @@ public:
 	 * @note: Not supported for Windows/Linux.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentryId* CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDelegate& OnConfigureScope);
-	USentryId* CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeNativeDelegate& OnConfigureScope);
+	FSentryId CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeDelegate& OnConfigureScope);
+	FSentryId CaptureEventWithScope(USentryEvent* Event, const FConfigureScopeNativeDelegate& OnConfigureScope);
 
 	/**
 	 * Captures a user feedback.
@@ -166,7 +166,7 @@ public:
 	 * @note: Not supported for Windows/Linux.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void CaptureUserFeedbackWithParams(USentryId* EventId, const FString& Email, const FString& Comments, const FString& Name);
+	void CaptureUserFeedbackWithParams(const FSentryId& EventId, const FString& Email, const FString& Comments, const FString& Name);
 
 	/**
 	 * Sets a user for the current scope.

--- a/plugin-dev/Source/Sentry/Public/SentryUserFeedback.h
+++ b/plugin-dev/Source/Sentry/Public/SentryUserFeedback.h
@@ -3,10 +3,10 @@
 #pragma once
 
 #include "SentryImplWrapper.h"
+#include "SentryId.h"
 
 #include "SentryUserFeedback.generated.h"
 
-class USentryId;
 class ISentryUserFeedback;
 
 /**
@@ -24,7 +24,7 @@ public:
 	 * @param EventId The associated event identifier.
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void Initialize(USentryId* EventId);
+	void Initialize(const FSentryId& EventId);
 
 	/** Sets the name of the user. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")


### PR DESCRIPTION
This PR changes `SentryId` type from `UCLASS` to `USTRUCT` to avoid potential crashes during garbage collection if the corresponding object was instantiated outside the game thread.

For extra context: a somewhat similar issue used to occur when instantiating `USentryEvent` during `beforeSend`/`beforeCrash` hook processing (#560).

Closes #736

Also related to #514, #559