### PR TITLE
Fix ensure when log message from non-game thread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Allow Sentry CLI to authenticate via environment variables during debug symbols upload ([#836](https://github.com/getsentry/sentry-unreal/pull/836))
 
+### Fixes
+
+- Fix ensure when log message from non-game thread ([#845](https://github.com/getsentry/sentry-unreal/pull/845))
+
 ### Dependencies
 
 - Bump Java SDK (Android) from v8.4.0 to v8.5.0 ([#835](https://github.com/getsentry/sentry-unreal/pull/835))

--- a/plugin-dev/Source/Sentry/Private/SentryOutputDevice.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryOutputDevice.cpp
@@ -7,6 +7,18 @@
 #include "SentrySubsystem.h"
 
 #include "Engine/Engine.h"
+#include "Utils/SentryLogUtils.h"
+
+FSentryOutputDevice::FSentryOutputDevice()
+{
+	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
+
+	BreadcrumbFlags.Add(ESentryLevel::Fatal, Settings->AutomaticBreadcrumbsForLogs.bOnFatalLog);
+	BreadcrumbFlags.Add(ESentryLevel::Error, Settings->AutomaticBreadcrumbsForLogs.bOnErrorLog);
+	BreadcrumbFlags.Add(ESentryLevel::Warning, Settings->AutomaticBreadcrumbsForLogs.bOnWarningLog);
+	BreadcrumbFlags.Add(ESentryLevel::Info, Settings->AutomaticBreadcrumbsForLogs.bOnInfoLog);
+	BreadcrumbFlags.Add(ESentryLevel::Debug, Settings->AutomaticBreadcrumbsForLogs.bOnDebugLog);
+}
 
 void FSentryOutputDevice::Serialize(const TCHAR* V, ELogVerbosity::Type Verbosity, const FName& Category)
 {
@@ -16,41 +28,9 @@ void FSentryOutputDevice::Serialize(const TCHAR* V, ELogVerbosity::Type Verbosit
 		return;
 	}
 
-	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
+	ESentryLevel BreadcrumbLevel = SentryLogUtils::ConvertLogVerbosityToSentryLevel(Verbosity);
 
-	bool bAddBreadcrumb;
-
-	ESentryLevel BreadcrumbLevel = ESentryLevel::Debug;
-
-	switch (Verbosity)
-	{
-	case ELogVerbosity::Fatal:
-		bAddBreadcrumb = Settings->AutomaticBreadcrumbsForLogs.bOnFatalLog;
-		BreadcrumbLevel = ESentryLevel::Fatal;
-		break;
-	case ELogVerbosity::Error:
-		bAddBreadcrumb = Settings->AutomaticBreadcrumbsForLogs.bOnErrorLog;
-		BreadcrumbLevel = ESentryLevel::Error;
-		break;
-	case ELogVerbosity::Warning:
-		bAddBreadcrumb = Settings->AutomaticBreadcrumbsForLogs.bOnWarningLog;
-		BreadcrumbLevel = ESentryLevel::Warning;
-		break;
-	case ELogVerbosity::Display:
-	case ELogVerbosity::Log:
-		bAddBreadcrumb = Settings->AutomaticBreadcrumbsForLogs.bOnInfoLog;
-		BreadcrumbLevel = ESentryLevel::Info;
-		break;
-	case ELogVerbosity::Verbose:
-	case ELogVerbosity::VeryVerbose:
-		bAddBreadcrumb = Settings->AutomaticBreadcrumbsForLogs.bOnDebugLog;
-		BreadcrumbLevel = ESentryLevel::Debug;
-		break;
-	default:
-		bAddBreadcrumb = false;
-	}
-
-	if(!bAddBreadcrumb)
+	if (!BreadcrumbFlags.Contains(BreadcrumbLevel) || !BreadcrumbFlags[BreadcrumbLevel])
 	{
 		return;
 	}

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.cpp
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.cpp
@@ -25,3 +25,24 @@ void SentryLogUtils::LogStackTrace(const TCHAR* Heading, const ELogVerbosity::Ty
 	FMemory::SystemFree(StackTrace);
 #endif
 }
+
+ESentryLevel SentryLogUtils::ConvertLogVerbosityToSentryLevel(const ELogVerbosity::Type LogVerbosity)
+{
+	switch (LogVerbosity)
+	{
+	case ELogVerbosity::Fatal:
+		return ESentryLevel::Fatal;
+	case ELogVerbosity::Error:
+		return ESentryLevel::Error;
+	case ELogVerbosity::Warning:
+		return ESentryLevel::Warning;
+	case ELogVerbosity::Display:
+	case ELogVerbosity::Log:
+		return ESentryLevel::Info;
+	case ELogVerbosity::Verbose:
+	case ELogVerbosity::VeryVerbose:
+		return ESentryLevel::Debug;
+	default:
+		return ESentryLevel::Debug;
+	}
+}

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.h
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.h
@@ -5,8 +5,11 @@
 #include "CoreTypes.h"
 #include "Logging/LogVerbosity.h"
 
+#include "SentryDataTypes.h"
+
 class SentryLogUtils
 {
 public:
 	static void LogStackTrace(const TCHAR* Heading, const ELogVerbosity::Type LogVerbosity, int FramesToSkip);
+	static ESentryLevel ConvertLogVerbosityToSentryLevel(const ELogVerbosity::Type LogVerbosity);
 };

--- a/plugin-dev/Source/Sentry/Public/SentryOutputDevice.h
+++ b/plugin-dev/Source/Sentry/Public/SentryOutputDevice.h
@@ -5,9 +5,13 @@
 #include "Misc/OutputDevice.h"
 #include "Misc/EngineVersionComparison.h"
 
+#include "SentryDataTypes.h"
+
 class FSentryOutputDevice : public FOutputDevice
 {
 public:
+	FSentryOutputDevice();
+
 	virtual void Serialize( const TCHAR* V, ELogVerbosity::Type Verbosity, const FName& Category) override;
 
 	virtual bool CanBeUsedOnAnyThread() const override;
@@ -16,4 +20,7 @@ public:
 #if !UE_VERSION_OLDER_THAN(5, 1, 0)
 	virtual bool CanBeUsedOnPanicThread() const override;
 #endif
+
+private:
+	TMap<ESentryLevel, bool> BreadcrumbFlags;
 };


### PR DESCRIPTION
This PR fixes an `ensure` failure that occurs when calling `FSentryModule::Get()` while processing log messages from a non-game thread.

Closes #843