### PR TITLE
Add `sentry.properties` file content validation during debug symbol upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 - Allow Sentry CLI to authenticate via environment variables during debug symbols upload ([#836](https://github.com/getsentry/sentry-unreal/pull/836))
 - Added the ability to specify a separate DSN for crashes while in editor vs cooked title ([#853](https://github.com/getsentry/sentry-unreal/pull/853))
 - Add callback to pre-process breadcrumbs before adding ([#814](https://github.com/getsentry/sentry-unreal/pull/814))
+- Add `sentry.properties` file content validation during debug symbol upload ([#862](https://github.com/getsentry/sentry-unreal/pull/862))
 
 ### Fixes
 

--- a/plugin-dev/Scripts/upload-debug-symbols-win.bat
+++ b/plugin-dev/Scripts/upload-debug-symbols-win.bat
@@ -94,6 +94,21 @@ echo Sentry: Looking for properties file '%PropertiesFile%'
 
 if exist "%PropertiesFile%" (
     echo Sentry: Properties file found. Starting upload...
+    call :ParseIniFile "%PropertiesFile%" Sentry defaults.project ProjectName
+    if "!ProjectName!"=="" (
+        echo Error: Project name is not set. Skipping...
+        exit /B 0
+    )
+    call :ParseIniFile "%PropertiesFile%" Sentry defaults.org OrgName
+    if "!OrgName!"=="" ( 
+        echo Error: Project organization is not set. Skipping...
+        exit /B 0
+    )
+    call :ParseIniFile "%PropertiesFile%" Sentry auth.token AuthToken
+    if "!AuthToken!"=="" (
+        echo Error: Auth token is not set. Skipping...
+        exit /B 0
+    )
     set "SENTRY_PROPERTIES=%PropertiesFile%"
 ) else (
     echo Sentry: Properties file not found. Falling back to environment variables.

--- a/plugin-dev/Scripts/upload-debug-symbols.sh
+++ b/plugin-dev/Scripts/upload-debug-symbols.sh
@@ -92,6 +92,21 @@ echo "Sentry: Looking for properties file '$SENTRY_PROPERTIES'"
 
 if [ -f "$PROPERTIES_FILE" ]; then
     echo "Sentry: Properties file found. Starting upload..."
+    ProjectName=$(awk -F "=" '/defaults.project/ {print $2}' "$PROPERTIES_FILE")
+    if [ -z "$ProjectName" ]; then        
+        echo "Error: Project name is not set. Skipping..."
+        exit
+    fi
+    OrgName=$(awk -F "=" '/defaults.org/ {print $2}' "$PROPERTIES_FILE")
+    if [ -z "$OrgName" ]; then        
+        echo "Error: Project organization is not set. Skipping..."
+        exit
+    fi
+    AuthToken=$(awk -F "=" '/auth.token/ {print $2}' "$PROPERTIES_FILE")
+    if [ -z "$AuthToken" ]; then        
+        echo "Error: Auth token is not set. Skipping..."
+        exit
+    fi
     export SENTRY_PROPERTIES=$PROPERTIES_FILE
 else
     echo "Sentry: Properties file not found. Falling back to environment variables."


### PR DESCRIPTION
This PR adds additional checks to the symbol upload scripts to notify the user if any required values are missing from the sentry.properties file.

Closes #856