### PR TITLE
chore: Use 32-core runner for CI checks

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-32-cores
 
     steps:
       - name: Free disk space

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: windows-latest
+    runs-on: windows-latest-32-cores
 
     steps:
       - name: Log in to GitHub package registry


### PR DESCRIPTION
This PR updates CI to use `ubuntu-latest-32-cores` and `windows-latest-32-cores` GitHub runners for Unreal SDK packaging and tests.

Below are benchmarks comparing CI job durations using the new 32-core runners against the latest runs on the standard `ubuntu-latest` and `windows-latest` GitHub runners:

**Linux Build Times (32-Core vs Regular)**
| UE Version | 32-Core Runner | Regular Runner | Time Saved (min) | Speedup (%) |
|------------|----------------|---------------------|------------------|-------------|
| 4.27       | 11.2 min       | 18.1 min            | 6.9 min          | 38.0%       |
| 5.1        | 27.7 min       | 53.6 min            | 25.9 min         | 48.4%       |
| 5.2        | 15.0 min       | 33.0 min            | 18.0 min         | 54.6%       |
| 5.3        | 17.0 min       | 41.6 min            | 24.6 min         | 59.1%       |
| 5.4        | 14.8 min       | 47.8 min            | 33.0 min         | 69.0%       |
| 5.5        | 17.5 min       | 55.1 min            | 37.6 min         | 68.3%       |

**Windows Build Times (32-Core vs Regular)**
| UE Version | 32-Core Runner | Regular Runner | Time Saved (min) | Speedup (%) |
|------------|----------------|---------------------|------------------|-------------|
| 4.27       | 18.1 min       | 43.8 min            | 25.7 min         | 58.7%       |
| 5.0        | 23.3 min       | 68.0 min            | 44.7 min         | 65.7%       |
| 5.1        | 28.9 min       | 99.0 min            | 70.1 min         | 70.8%       |
| 5.2        | 26.2 min       | 79.0 min            | 52.8 min         | 66.9%       |
| 5.3        | 26.4 min       | 78.0 min            | 51.6 min         | 66.2%       |
| 5.4        | 28.8 min       | 101.0 min           | 72.2 min         | 71.5%       |
| 5.5        | 33.7 min       | 114.0 min           | 80.3 min         | 70.4%       |

Overall, using 32-core runners significantly reduces CI pipeline time - from around 2 hours to approximately 30 minutes. Especially this is noticeable for Windows jobs which tend to be the most time-consuming.

It may be worth updating the workflow to run CI checks only for open pull requests rather than on every push to make this change more cost-efficient.

#skip-changelog