### PR TITLE
Ensure execute permission is set for Sentry CLI and symbol upload script downloaded via editor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 - Fix warnings caused by deprecated Cocoa SDK API usages ([#868](https://github.com/getsentry/sentry-unreal/pull/868))
 - Fix Sentry cURL transport can't send envelopes on Linux ([#882](https://github.com/getsentry/sentry-unreal/pull/882))
-- Ensure execute permission is set for Sentry CLI and symbol upload script downloaded via editor ([#881](https://github.com/getsentry/sentry-unreal/pull/881))
+- The SDK now ensures the execute permission is set for Sentry CLI and symbol upload script when they have been downloaded via the Editor ([#881](https://github.com/getsentry/sentry-unreal/pull/881))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fix warnings caused by deprecated Cocoa SDK API usages ([#868](https://github.com/getsentry/sentry-unreal/pull/868))
+- Ensure execute permission is set for Sentry CLI and symbol upload script downloaded via editor ([#881](https://github.com/getsentry/sentry-unreal/pull/881))
 
 ### Dependencies
 

--- a/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
 
 #include "SentrySymToolsDownloader.h"
+#include "SentryModule.h"
 
 #include "Runtime/Launch/Resources/Version.h"
 #include "HttpModule.h"
@@ -38,8 +39,9 @@ void FSentrySymToolsDownloader::Download(const TFunction<void(bool)>& OnComplete
 	const FString SentryCliExecPath = GetSentryCliPath();
 	const FString CliDownloadUrl = FString::Printf(TEXT("https://github.com/getsentry/sentry-cli/releases/download/%s/%s"), *GetSentryCliVersion(), *SentryCliExecName);
 
+	const FString PluginVersion = FSentryModule::Get().GetPluginVersion();
 	const FString SymUploadScriptPath = GetSymUploadScriptPath();
-	const FString SymUploadScriptDownloadUrl = FString::Printf(TEXT("https://raw.githubusercontent.com/getsentry/sentry-unreal/main/plugin-dev/Scripts/%s"), *SentrySymUploadScriptName);
+	const FString SymUploadScriptDownloadUrl = FString::Printf(TEXT("https://raw.githubusercontent.com/getsentry/sentry-unreal/refs/tags/%s/plugin-dev/Scripts/%s"), *PluginVersion, *SentrySymUploadScriptName);
 
 	Download(SentryCliDownloadRequest, CliDownloadUrl, SentryCliExecPath, OnCompleted);
 	Download(SentryScriptDownloadRequest, SymUploadScriptDownloadUrl, SymUploadScriptPath, OnCompleted);

--- a/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
@@ -155,7 +155,7 @@ bool FSentrySymToolsDownloader::HasExecutePermission(const FString& FilePath) co
 	return false;
 #else
 	// No-op on Windows
-	retrun true;
+	return true;
 #endif
 }
 
@@ -171,6 +171,6 @@ bool FSentrySymToolsDownloader::SetExecutePermission(const FString& FilePath) co
 	return false;
 #else
 	// No-op on Windows
-	retrun true;
+	return true;
 #endif
 }

--- a/plugin-dev/Source/SentryEditor/Public/SentrySymToolsDownloader.h
+++ b/plugin-dev/Source/SentryEditor/Public/SentrySymToolsDownloader.h
@@ -27,6 +27,9 @@ private:
 	FString GetSentryCliVersion() const;
 	FString GetSymUploadScriptPath() const;
 
+	bool HasExecutePermission(const FString& FilePath) const;
+	bool SetExecutePermission(const FString& FilePath) const;
+
 	TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> SentryCliDownloadRequest;
 	TSharedPtr<IHttpRequest, ESPMode::ThreadSafe> SentryScriptDownloadRequest;
 


### PR DESCRIPTION
This PR fixes an issue where the Sentry CLI and symbol upload script were missing `execute` permissions when downloaded via the plugin settings menu (#385) - a common case for users who installed the Sentry plugin from FAB (Unreal Marketplace).

Also updated the script download URL to match the current plugin release rather than always pulling from `main`.

Related to #877 and #880