### PR TITLE
Fix Sentry cURL transport can't send envelopes on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fix warnings caused by deprecated Cocoa SDK API usages ([#868](https://github.com/getsentry/sentry-unreal/pull/868))
+- Fix Sentry cURL transport can't send envelopes on Linux ([#882](https://github.com/getsentry/sentry-unreal/pull/882))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -273,6 +273,7 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 
 	ConfigureHandlerPath(options);
 	ConfigureDatabasePath(options);
+	ConfigureCertsPath(options);
 
 	sentry_options_set_release(options, TCHAR_TO_ANSI(settings->OverrideReleaseName
 		? *settings->Release

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -58,9 +58,10 @@ public:
 protected:
 	virtual void ConfigureHandlerPath(sentry_options_t* Options) {}
 	virtual void ConfigureDatabasePath(sentry_options_t* Options) {}
+	virtual void ConfigureCertsPath(sentry_options_t* Options) {}
 	virtual void ConfigureLogFileAttachment(sentry_options_t* Options) {}
 	virtual void ConfigureScreenshotAttachment(sentry_options_t* Options) {}
-	virtual void ConfigureGpuDumpAttachment(sentry_options_t* Options) {}
+	virtual void ConfigureGpuDumpAttachment(sentry_options_t* Options) {}	
 
 	FString GetHandlerPath() const;
 	FString GetDatabasePath() const;

--- a/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
@@ -1,5 +1,7 @@
 #include "LinuxSentrySubsystem.h"
 
+#include "SentryDefines.h"
+
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
 #include "Misc/Paths.h"
 
@@ -13,6 +15,32 @@ void FLinuxSentrySubsystem::ConfigureHandlerPath(sentry_options_t* Options)
 void FLinuxSentrySubsystem::ConfigureDatabasePath(sentry_options_t* Options)
 {
 	sentry_options_set_database_path(Options, TCHAR_TO_UTF8(*GetDatabasePath()));
+}
+
+void FLinuxSentrySubsystem::ConfigureCertsPath(sentry_options_t* Options)
+{
+	// In order to use CURL transport for sentry-native we have to manually specify path to a valid CA certificates on Linux.
+	// Unreal Engine itself follows a similar approach (see `CertBundlePath` implementation in CurlHttp.cpp for extra details)
+	static const char* KnownCertPaths[] =
+	{
+		"/etc/pki/tls/certs/ca-bundle.crt",
+		"/etc/ssl/certs/ca-certificates.crt",
+		"/etc/ssl/ca-bundle.pem"
+	};
+
+	for (const char* BundlePath : KnownCertPaths)
+	{
+		FString FileName(BundlePath);
+
+		if (FPaths::FileExists(FileName))
+		{
+			UE_LOG(LogSentrySdk, Log, TEXT("Sentry transport will use the certificate found at %s for verification."), *FileName);
+			sentry_options_set_ca_certs(Options, BundlePath);
+			return;
+		}
+	}
+
+	UE_LOG(LogSentrySdk, Warning, TEXT("Could not find CA certificates in any known location. Sentry transport may not function properly."));
 }
 
 void FLinuxSentrySubsystem::ConfigureLogFileAttachment(sentry_options_t* Options)

--- a/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
@@ -40,7 +40,8 @@ void FLinuxSentrySubsystem::ConfigureCertsPath(sentry_options_t* Options)
 		}
 	}
 
-	UE_LOG(LogSentrySdk, Warning, TEXT("Could not find CA certificates in any known location. Sentry transport may not function properly."));
+	UE_LOG(LogSentrySdk, Warning, TEXT("Could not find CA certificates in any known location. Sentry transport may not function properly for handled events"));
+
 }
 
 void FLinuxSentrySubsystem::ConfigureLogFileAttachment(sentry_options_t* Options)

--- a/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.h
@@ -9,6 +9,7 @@ class FLinuxSentrySubsystem : public FGenericPlatformSentrySubsystem
 protected:
 	virtual void ConfigureHandlerPath(sentry_options_t* Options) override;
 	virtual void ConfigureDatabasePath(sentry_options_t* Options) override;
+	virtual void ConfigureCertsPath(sentry_options_t* Options) override;
 	virtual void ConfigureLogFileAttachment(sentry_options_t* Options) override;
 	virtual void ConfigureScreenshotAttachment(sentry_options_t* Options) override;
 	virtual void ConfigureGpuDumpAttachment(sentry_options_t* Options) override;


### PR DESCRIPTION
This PR addresses an issue with using the cURL transport for `sentry-native` on Linux which was preventing envelopes from being sent to Sentry. The fix involves providing a valid CA certificate path during Native SDK initialization.

Unreal Engine follows a similar approach in its Unix-specific `IHttpRequest` implementation. This also explains why things worked as expected previously when a custom transport was in place (removed in #748).

Closes #876 