### PR TITLE
Remove `Epic Account Id` and `Login Id` from crash context

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.cpp
@@ -55,12 +55,6 @@ void FGenericPlatformSentryCrashContext::Apply(TSharedPtr<ISentryScope> Scope)
 	ContextValues.Add("Memory Stats Page Size", FString::FromInt(SessionContext.MemoryStats.PageSize));
 	ContextValues.Add("Memory Stats Total Virtual", FString::Printf(TEXT("%lld"), SessionContext.MemoryStats.TotalVirtual));
 
-	if(Settings->SendDefaultPii)
-	{
-		ContextValues.Add("Epic Account Id", SessionContext.EpicAccountId);
-		ContextValues.Add("Login Id", SessionContext.LoginIdStr);
-	}
-
 	Scope->SetContext(TEXT("Crash Info"), ContextValues);
 }
 


### PR DESCRIPTION
This PR removes `Epic Account Id` and `Login Id` from the crash context which is built using engine's APIs as these fields are intended for internal use by Epic Games and provide no additional value externally.

Related to https://github.com/getsentry/sentry-docs/pull/13532

#skip-changelog