### PR TITLE
Windows default crash handling mechanism is no longer disabled if SDK initialization failed 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Windows default crash handling mechanism is no longer disabled if SDK initialization failed ([#901](https://github.com/getsentry/sentry-unreal/pull/901))
+
 ### Dependencies
 
 - Bump CLI from v2.43.1 to v2.44.0 ([#896](https://github.com/getsentry/sentry-unreal/pull/896))

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -204,14 +204,22 @@ sentry_value_t FGenericPlatformSentrySubsystem::OnCrash(const sentry_ucontext_t*
 
 }
 
+void FGenericPlatformSentrySubsystem::InitCrashReporter(const FString& release, const FString& environment)
+{
+	crashReporter = MakeShareable(new FGenericPlatformSentryCrashReporter);
+
+	crashReporter->SetRelease(release);
+	crashReporter->SetEnvironment(environment);
+}
+
 FGenericPlatformSentrySubsystem::FGenericPlatformSentrySubsystem()
 	: beforeSend(nullptr)
 	, beforeBreadcrumb(nullptr)
-	, crashReporter(MakeShareable(new FGenericPlatformSentryCrashReporter))
 	, isEnabled(false)
 	, isStackTraceEnabled(true)
 	, isPiiAttachmentEnabled(false)
 	, isScreenshotAttachmentEnabled(false)
+	, crashReporter(nullptr)
 {
 }
 
@@ -306,9 +314,6 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 
 	isStackTraceEnabled = settings->AttachStacktrace;
 	isPiiAttachmentEnabled = settings->SendDefaultPii;
-
-	crashReporter->SetRelease(settings->Release);
-	crashReporter->SetEnvironment(settings->Environment);
 }
 
 void FGenericPlatformSentrySubsystem::Close()
@@ -477,14 +482,20 @@ void FGenericPlatformSentrySubsystem::SetUser(TSharedPtr<ISentryUser> InUser)
 
 	sentry_set_user(user->GetNativeObject());
 
-	crashReporter->SetUser(user);
+	if (crashReporter)
+	{
+		crashReporter->SetUser(user);
+	}
 }
 
 void FGenericPlatformSentrySubsystem::RemoveUser()
 {
 	sentry_remove_user();
 
-	crashReporter->RemoveUser();
+	if (crashReporter)
+	{
+		crashReporter->RemoveUser();
+	}
 }
 
 void FGenericPlatformSentrySubsystem::ConfigureScope(const FSentryScopeDelegate& onConfigureScope)
@@ -496,21 +507,30 @@ void FGenericPlatformSentrySubsystem::SetContext(const FString& key, const TMap<
 {
 	GetCurrentScope()->SetContext(key, values);
 
-	crashReporter->SetContext(key, values);
+	if (crashReporter)
+	{
+		crashReporter->SetContext(key, values);
+	}
 }
 
 void FGenericPlatformSentrySubsystem::SetTag(const FString& key, const FString& value)
 {
 	GetCurrentScope()->SetTagValue(key, value);
 
-	crashReporter->SetTag(key, value);
+	if (crashReporter)
+	{
+		crashReporter->SetTag(key, value);
+	}
 }
 
 void FGenericPlatformSentrySubsystem::RemoveTag(const FString& key)
 {
 	GetCurrentScope()->RemoveTag(key);
 
-	crashReporter->RemoveTag(key);
+	if (crashReporter)
+	{
+		crashReporter->RemoveTag(key);
+	}
 }
 
 void FGenericPlatformSentrySubsystem::SetLevel(ESentryLevel level)

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -72,6 +72,8 @@ protected:
 	virtual sentry_value_t OnBeforeBreadcrumb(sentry_value_t breadcrumb, void* hint, void* closure);
 	virtual sentry_value_t OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure);
 
+	void InitCrashReporter(const FString& release, const FString& environment);
+
 private:
 	/**
 	 * Static wrappers that are passed to the Sentry library.

--- a/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
@@ -1,6 +1,9 @@
 #include "LinuxSentrySubsystem.h"
 
 #include "SentryDefines.h"
+#include "SentrySettings.h"
+#include "SentryBeforeSendHandler.h"
+#include "SentryBeforeBreadcrumbHandler.h"
 
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
 #include "Misc/Paths.h"

--- a/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
@@ -7,6 +7,17 @@
 
 #if USE_SENTRY_NATIVE
 
+void FLinuxSentrySubsystem::InitWithSettings(
+	const USentrySettings* Settings,
+	USentryBeforeSendHandler* BeforeSendHandler,
+	USentryBeforeBreadcrumbHandler* BeforeBreadcrumbHandler,
+	USentryTraceSampler* TraceSampler)
+{
+	FGenericPlatformSentrySubsystem::InitWithSettings(Settings, BeforeSendHandler, BeforeBreadcrumbHandler, TraceSampler);
+
+	InitCrashReporter(Settings->Release, Settings->Environment);
+}
+
 void FLinuxSentrySubsystem::ConfigureHandlerPath(sentry_options_t* Options)
 {
 	sentry_options_set_handler_path(Options, TCHAR_TO_UTF8(*GetHandlerPath()));

--- a/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.h
@@ -6,6 +6,14 @@
 
 class FLinuxSentrySubsystem : public FGenericPlatformSentrySubsystem
 {
+public:
+	virtual void InitWithSettings(
+		const USentrySettings* Settings,
+		USentryBeforeSendHandler* BeforeSendHandler,
+		USentryBeforeBreadcrumbHandler* BeforeBreadcrumbHandler,
+		USentryTraceSampler* TraceSampler
+	) override;
+
 protected:
 	virtual void ConfigureHandlerPath(sentry_options_t* Options) override;
 	virtual void ConfigureDatabasePath(sentry_options_t* Options) override;

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -7,6 +7,7 @@
 #include "SentryDefines.h"
 #include "SentryModule.h"
 #include "SentrySettings.h"
+
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
 
 void FMicrosoftSentrySubsystem::InitWithSettings(
@@ -18,10 +19,18 @@ void FMicrosoftSentrySubsystem::InitWithSettings(
 	FGenericPlatformSentrySubsystem::InitWithSettings(Settings, BeforeSendHandler, BeforeBreadcrumbHandler, TraceSampler);
 
 #if !UE_VERSION_OLDER_THAN(5, 2, 0)
-	FPlatformMisc::SetCrashHandlingType(Settings->EnableAutoCrashCapturing
-		? ECrashHandlingType::Disabled
-		: ECrashHandlingType::Default);
+	if (IsEnabled())
+	{
+		FPlatformMisc::SetCrashHandlingType(Settings->EnableAutoCrashCapturing
+			? ECrashHandlingType::Disabled
+			: ECrashHandlingType::Default);
+	}
 #endif // !UE_VERSION_OLDER_THAN(5, 2, 0)
+
+	if (FPlatformMisc::GetCrashHandlingType() == ECrashHandlingType::Default)
+	{
+		InitCrashReporter(Settings->Release, Settings->Environment);
+	}
 }
 
 void FMicrosoftSentrySubsystem::ConfigureHandlerPath(sentry_options_t* Options)


### PR DESCRIPTION
This PR fixes an issue where `SEH` (`Structured Exception Handling`) was being automatically disabled on Windows even when Sentry SDK initialization failed.

It also updates the logic for when and how Sentry’s CRC wrapper is instantiated on platforms using `sentry-native`:
- On Windows, `FGenericPlatformSentryCrashReporter` is created only if `SEH` is disabled.
- On Linux, it is always created since engine's API does not allow disabling the default crash handling mechanism there.

Related to #899 