### PR TITLE
Fix initializer list parameters order to fix the build on Win/Linux

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -215,11 +215,11 @@ void FGenericPlatformSentrySubsystem::InitCrashReporter(const FString& release, 
 FGenericPlatformSentrySubsystem::FGenericPlatformSentrySubsystem()
 	: beforeSend(nullptr)
 	, beforeBreadcrumb(nullptr)
+	, crashReporter(nullptr)
 	, isEnabled(false)
 	, isStackTraceEnabled(true)
 	, isPiiAttachmentEnabled(false)
 	, isScreenshotAttachmentEnabled(false)
-	, crashReporter(nullptr)
 {
 }
 

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -9,6 +9,8 @@
 #include "SentrySettings.h"
 
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
+#include "GenericPlatform/GenericPlatformMisc.h"
+#include "Misc/EngineVersionComparison.h"
 
 void FMicrosoftSentrySubsystem::InitWithSettings(
 	const USentrySettings* Settings,
@@ -25,12 +27,14 @@ void FMicrosoftSentrySubsystem::InitWithSettings(
 			? ECrashHandlingType::Disabled
 			: ECrashHandlingType::Default);
 	}
-#endif // !UE_VERSION_OLDER_THAN(5, 2, 0)
 
 	if (FPlatformMisc::GetCrashHandlingType() == ECrashHandlingType::Default)
 	{
 		InitCrashReporter(Settings->Release, Settings->Environment);
 	}
+#else
+	InitCrashReporter(Settings->Release, Settings->Environment);
+#endif
 }
 
 void FMicrosoftSentrySubsystem::ConfigureHandlerPath(sentry_options_t* Options)

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -9,8 +9,11 @@
 #include "SentrySettings.h"
 
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
-#include "GenericPlatform/GenericPlatformMisc.h"
 #include "Misc/EngineVersionComparison.h"
+
+#if !UE_VERSION_OLDER_THAN(5, 2, 0)
+#include "GenericPlatform/GenericPlatformMisc.h"
+#endif
 
 void FMicrosoftSentrySubsystem::InitWithSettings(
 	const USentrySettings* Settings,


### PR DESCRIPTION
Fixes the build error introduced in #901 

#skip-changelog