### PR TITLE
chore: Update CI workflow triggers to avoid duplicate runs during releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,10 @@ name: package-plugin-workflow
 
 on: 
   push:
+    branches:
+      - main
+      - release/*
+  pull_request:
     paths-ignore:
       - "**.md"
 


### PR DESCRIPTION
This PR fixes a similar issue to the one previously raised for Unity (https://github.com/getsentry/sentry-unity/issues/1845)

#skip-changelog