### PR TITLE
Update sample project settings

### DIFF
--- a/sample/Config/DefaultEngine.ini
+++ b/sample/Config/DefaultEngine.ini
@@ -231,3 +231,7 @@ bGeneratedSYMBundle=True
 CrashReporterUrl="https://o447951.ingest.sentry.io/api/6253052/unreal/93c7a68867db43539980de54f09b139a/"
 Dsn="https://93c7a68867db43539980de54f09b139a@o447951.ingest.sentry.io/6253052"
 
+[/Script/MacTargetPlatform.XcodeProjectSettings]
+BundleIdentifier=io.sentry.unreal.sample
+CodeSigningPrefix=
+

--- a/sample/Source/SentryPlayground.Target.cs
+++ b/sample/Source/SentryPlayground.Target.cs
@@ -10,6 +10,9 @@ public class SentryPlaygroundTarget : TargetRules
 		Type = TargetType.Game;
 		DefaultBuildSettings = BuildSettingsVersion.Latest;
 
+		MacPlatform.bUseDSYMFiles = true;
+		IOSPlatform.bGeneratedSYM = true;
+
 #if UE_5_1_OR_LATER
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;
 #endif

--- a/sample/Source/SentryPlayground.Target.cs
+++ b/sample/Source/SentryPlayground.Target.cs
@@ -10,8 +10,10 @@ public class SentryPlaygroundTarget : TargetRules
 		Type = TargetType.Game;
 		DefaultBuildSettings = BuildSettingsVersion.Latest;
 
+#if UE_5_0_OR_LATER
 		MacPlatform.bUseDSYMFiles = true;
 		IOSPlatform.bGeneratedSYM = true;
+#endif
 
 #if UE_5_1_OR_LATER
 		IncludeOrderVersion = EngineIncludeOrderVersion.Latest;


### PR DESCRIPTION
This PR updates sample project settings:
- Enable `dSym` files generation during the build so that Sentry CLI can uploaded them to Sentry and properly symbolicate Mac/iOS events' callstack (#917)
- Set bundle identifier for iOS (required for using Unreal's `Modern Xcode Workflow`)

#skip-changelog