### PR TITLE
Add API allowing to get/set event fingerprint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add API allowing to get/set event fingerprint ([#920](https://github.com/getsentry/sentry-unreal/pull/920))
+
 ### Dependencies
 
 - Bump Java SDK (Android) from v8.11.1 to v8.12.0 ([#911](https://github.com/getsentry/sentry-unreal/pull/911))

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryEvent.cpp
@@ -26,6 +26,8 @@ void FAndroidSentryEvent::SetupClassMethods()
 	GetMessageMethod = GetMethod("getMessage", "()Lio/sentry/protocol/Message;");
 	SetLevelMethod = GetMethod("setLevel", "(Lio/sentry/SentryLevel;)V");
 	GetLevelMethod = GetMethod("getLevel", "()Lio/sentry/SentryLevel;");
+	SetFingerprintMethod = GetMethod("setFingerprints", "(Ljava/util/List;)V");
+	GetFingerprintMethod = GetMethod("getFingerprints()", "()Ljava/util/List;");
 	IsCrashMethod = GetMethod("isCrashed", "()Z");
 }
 
@@ -55,6 +57,17 @@ ESentryLevel FAndroidSentryEvent::GetLevel() const
 {
 	auto level = CallObjectMethod<jobject>(GetLevelMethod);
 	return FAndroidSentryConverters::SentryLevelToUnreal(*level);
+}
+
+void FAndroidSentryEvent::SetFingerprint(const TArray<FString>& fingerprint)
+{
+	CallMethod<void>(SetFingerprintMethod, FAndroidSentryConverters::StringArrayToNative(fingerprint)->GetJObject());
+}
+
+TArray<FString> FAndroidSentryEvent::GetFingerprint()
+{
+	auto fingerprint = CallObjectMethod<jobject>(GetFingerprintMethod);
+	return FAndroidSentryConverters::StringListToUnreal(*fingerprint);
 }
 
 bool FAndroidSentryEvent::IsCrash() const

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryEvent.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryEvent.h
@@ -19,6 +19,8 @@ public:
 	virtual FString GetMessage() const override;
 	virtual void SetLevel(ESentryLevel level) override;
 	virtual ESentryLevel GetLevel() const override;
+	virtual void SetFingerprint(const TArray<FString>& fingerprint) override;
+	virtual TArray<FString> GetFingerprint() override;
 	virtual bool IsCrash() const override;
 	virtual bool IsAnr() const override;
 
@@ -28,6 +30,8 @@ private:
 	FSentryJavaMethod GetMessageMethod;
 	FSentryJavaMethod SetLevelMethod;
 	FSentryJavaMethod GetLevelMethod;
+	FSentryJavaMethod SetFingerprintMethod;
+	FSentryJavaMethod GetFingerprintMethod;
 	FSentryJavaMethod IsCrashMethod;
 };
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
@@ -56,6 +56,16 @@ ESentryLevel FAppleSentryEvent::GetLevel() const
 	return FAppleSentryConverters::SentryLevelToUnreal(EventApple.level);
 }
 
+void FAppleSentryEvent::SetFingerprint(const TArray<FString>& fingerprint)
+{
+	EventApple.fingerprint = FAppleSentryConverters::StringArrayToNative(fingerprint);
+}
+
+TArray<FString> FAppleSentryEvent::GetFingerprint()
+{
+	return FAppleSentryConverters::StringArrayToUnreal(EventApple.fingerprint);
+}
+
 bool FAppleSentryEvent::IsCrash() const
 {
 	return EventApple.error != nullptr;

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.h
@@ -20,6 +20,8 @@ public:
 	virtual FString GetMessage() const override;
 	virtual void SetLevel(ESentryLevel level) override;
 	virtual ESentryLevel GetLevel() const override;
+	virtual void SetFingerprint(const TArray<FString>& fingerprint) override;
+	virtual TArray<FString> GetFingerprint() override;
 	virtual bool IsCrash() const override;
 	virtual bool IsAnr() const override;
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.cpp
@@ -64,6 +64,17 @@ ESentryLevel FGenericPlatformSentryEvent::GetLevel() const
 	return FGenericPlatformSentryConverters::SentryLevelToUnreal(level);
 }
 
+void FGenericPlatformSentryEvent::SetFingerprint(const TArray<FString>& fingerprint)
+{
+	sentry_value_set_by_key(Event, "fingerprint", FGenericPlatformSentryConverters::StringArrayToNative(Fingerprint));
+}
+
+TArray<FString> FGenericPlatformSentryEvent::GetFingerprint()
+{
+	sentry_value_t fingerprint = sentry_value_get_by_key(Event, "fingerprint");
+	return FGenericPlatformSentryConverters::StringArrayToUnreal(fingerprint);
+}
+
 bool FGenericPlatformSentryEvent::IsCrash() const
 {
 	return IsCrashEvent;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.cpp
@@ -66,7 +66,7 @@ ESentryLevel FGenericPlatformSentryEvent::GetLevel() const
 
 void FGenericPlatformSentryEvent::SetFingerprint(const TArray<FString>& fingerprint)
 {
-	sentry_value_set_by_key(Event, "fingerprint", FGenericPlatformSentryConverters::StringArrayToNative(Fingerprint));
+	sentry_value_set_by_key(Event, "fingerprint", FGenericPlatformSentryConverters::StringArrayToNative(fingerprint));
 }
 
 TArray<FString> FGenericPlatformSentryEvent::GetFingerprint()

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.h
@@ -22,6 +22,8 @@ public:
 	virtual FString GetMessage() const override;
 	virtual void SetLevel(ESentryLevel level) override;
 	virtual ESentryLevel GetLevel() const override;
+	virtual void SetFingerprint(const TArray<FString>& fingerprint) override;
+	virtual TArray<FString> GetFingerprint() override;
 	virtual bool IsCrash() const override;
 	virtual bool IsAnr() const override;
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryEventInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryEventInterface.h
@@ -18,6 +18,8 @@ public:
 	virtual FString GetMessage() const = 0;
 	virtual void SetLevel(ESentryLevel level) = 0;
 	virtual ESentryLevel GetLevel() const = 0;
+	virtual void SetFingerprint(const TArray<FString>& fingerprint) = 0;
+	virtual TArray<FString> GetFingerprint() = 0;
 	virtual bool IsCrash() const = 0;
 	virtual bool IsAnr() const = 0;
 };

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -2,6 +2,7 @@
 
 #include "SentryEvent.h"
 
+#include "Algo/Find.h"
 #include "HAL/PlatformSentryEvent.h"
 #include "Interface/SentryIdInterface.h"
 
@@ -52,6 +53,22 @@ ESentryLevel USentryEvent::GetLevel() const
 		return ESentryLevel::Debug;
 
 	return NativeImpl->GetLevel();
+}
+
+void USentryEvent::SetFingerprint(const TArray<FString>& Fingerprint)
+{
+	if (!NativeImpl)
+		return;
+
+	return NativeImpl->SetFingerprint(Fingerprint);
+}
+
+TArray<FString> USentryEvent::GetFingerprint() const
+{
+	if (!NativeImpl)
+		return TArray<FString>();
+
+	return NativeImpl->GetFingerprint();
 }
 
 bool USentryEvent::IsCrash() const

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
@@ -52,7 +52,7 @@ void SentryEventSpec::Define()
 
 		It("can be emptry", [this]()
 		{
-			TArray<FString> InFingerprint = { };
+			TArray<FString> InFingerprint = {};
 
 			SentryEvent->SetFingerprint(InFingerprint);
 			TArray<FString> OutFingerprint = SentryEvent->GetFingerprint();

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
@@ -34,6 +34,33 @@ void SentryEventSpec::Define()
 			TestFalse("Event ID is non-empty", SentryEvent->GetId().IsEmpty());
 		});
 	});
+
+	Describe("Event fingerprint", [this]()
+	{
+		It("should persist its value", [this]()
+		{
+			TArray<FString> InFingerprint = { TEXT("F1"), TEXT("F2"), TEXT("F3") };
+
+			SentryEvent->SetFingerprint(InFingerprint);
+			TArray<FString> OutFingerprint = SentryEvent->GetFingerprint();
+
+			TestEqual("Fingerprint elements count", OutFingerprint.Num(), InFingerprint.Num());
+			TestEqual("Fingerprint first element", OutFingerprint[0], InFingerprint[0]);
+			TestEqual("Fingerprint second element", OutFingerprint[1], InFingerprint[1]);
+			TestEqual("Fingerprint third element", OutFingerprint[2], InFingerprint[2]);
+		});
+
+		It("can be emptry", [this]()
+		{
+			TArray<FString> InFingerprint = { };
+
+			SentryEvent->SetFingerprint(InFingerprint);
+			TArray<FString> OutFingerprint = SentryEvent->GetFingerprint();
+
+			TestEqual("Fingerprint elements count", OutFingerprint.Num(), InFingerprint.Num());
+			TestTrue("Fingerprint is empty", OutFingerprint.IsEmpty());
+		});
+	});
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
@@ -58,7 +58,7 @@ void SentryEventSpec::Define()
 			TArray<FString> OutFingerprint = SentryEvent->GetFingerprint();
 
 			TestEqual("Fingerprint elements count", OutFingerprint.Num(), InFingerprint.Num());
-			TestTrue("Fingerprint is empty", OutFingerprint.IsEmpty());
+			TestEqual("Fingerprint is empty", OutFingerprint.Num(), 0);
 		});
 	});
 }

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.cpp
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.cpp
@@ -57,7 +57,7 @@ bool SentryScreenshotUtils::CaptureScreenshot(const FString& ScreenshotSavePath)
 
 #if UE_VERSION_OLDER_THAN(5, 0, 0)
 	GetHighResScreenshotConfig().MergeMaskIntoAlpha(*Bitmap);
-	TArray<uint8> *CompressedBitmap = new TArray<uint8>();
+	TArray<uint8>* CompressedBitmap = new TArray<uint8>();
 	FImageUtils::CompressImageArray(ViewportSize.X, ViewportSize.Y, *Bitmap, *CompressedBitmap);
 #else
 	GetHighResScreenshotConfig().MergeMaskIntoAlpha(*Bitmap, FIntRect());

--- a/plugin-dev/Source/Sentry/Public/SentryEvent.h
+++ b/plugin-dev/Source/Sentry/Public/SentryEvent.h
@@ -43,6 +43,14 @@ public:
 	UFUNCTION(BlueprintPure, Category = "Sentry")
 	ESentryLevel GetLevel() const;
 
+	/** Sets fingerprint of the event. */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	void SetFingerprint(const TArray<FString>& Fingerprint);
+
+	/** Gets fingerprint of the event. */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	TArray<FString> GetFingerprint() const;
+
 	/** Gets flag indicating whether the event is a crash. */
 	UFUNCTION(BlueprintPure, Category = "Sentry")
 	bool IsCrash() const;


### PR DESCRIPTION
This PR extends the Event class interface by adding getter and setter functions for the event fingerprint.

Related to https://github.com/getsentry/sentry-docs/issues/13733#event-17680741348