### PR TITLE
Add/update copyright notice to all plugin scripts

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryAttachment.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryAttachment.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryAttachment.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryAttachment.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryAttachment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryBreadcrumb.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryBreadcrumb.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryBreadcrumb.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryBreadcrumb.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryBreadcrumb.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryEvent.h"
 #include "AndroidSentryId.h"

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryEvent.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryEvent.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryHint.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryHint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryHint.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryHint.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryHint.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryId.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryId.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryId.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryId.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryId.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryMessage.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryMessage.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryMessage.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryMessage.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryMessage.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySamplingContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySamplingContext.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentrySamplingContext.h"
 #include "AndroidSentryTransactionContext.h"

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySamplingContext.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryScope.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryScope.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryScope.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryScope.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentrySpan.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentrySubsystem.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryTransaction.h"
 #include "AndroidSentrySpan.h"

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionContext.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryTransactionContext.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionContext.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionContext.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionOptions.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionOptions.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryTransactionOptions.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionOptions.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionOptions.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryUser.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryUser.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryUser.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryUser.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryUser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryUserFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryUserFeedback.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryUserFeedback.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryUserFeedback.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryUserFeedback.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/Callbacks/AndroidSentryScopeCallback.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Callbacks/AndroidSentryScopeCallback.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryScopeCallback.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/Callbacks/AndroidSentryScopeCallback.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Callbacks/AndroidSentryScopeCallback.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryConverters.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryConverters.h"
 #include "AndroidSentryJavaClasses.h"

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryConverters.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryConverters.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryDataTypes.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryDataTypes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaClasses.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaClasses.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryJavaClasses.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaClasses.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaClasses.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaObjectWrapper.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaObjectWrapper.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryJavaObjectWrapper.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaObjectWrapper.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaObjectWrapper.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 package io.sentry.unreal;
 

--- a/plugin-dev/Source/Sentry/Private/Android/Jni/AndroidSentryJni.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Jni/AndroidSentryJni.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "Android/AndroidSentryBreadcrumb.h"
 #include "Android/AndroidSentryEvent.h"

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryAttachment.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryAttachment.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryAttachment.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryAttachment.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryAttachment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryBreadcrumb.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryBreadcrumb.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryBreadcrumb.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryBreadcrumb.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryBreadcrumb.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryEvent.h"
 #include "AppleSentryId.h"

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryId.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryId.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryId.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryId.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryId.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySamplingContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySamplingContext.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentrySamplingContext.h"
 #include "AppleSentryTransactionContext.h"

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySamplingContext.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryScope.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryScope.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryScope.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryScope.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentrySpan.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentrySubsystem.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryTransaction.h"
 #include "AppleSentrySpan.h"

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransactionContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransactionContext.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryTransactionContext.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransactionContext.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransactionContext.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUser.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUser.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryUser.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUser.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUserFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUserFeedback.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryUserFeedback.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUserFeedback.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUserFeedback.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/Convenience/AppleSentryInclude.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/Convenience/AppleSentryInclude.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryConverters.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Convenience/GenericPlatformSentryInclude.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Convenience/GenericPlatformSentryInclude.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryCrashContext.h"
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryCrashReporter.h"
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryBreadcrumb.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryBreadcrumb.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryBreadcrumb.h"
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryBreadcrumb.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryBreadcrumb.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryEvent.h"
 #include "GenericPlatformSentryId.h"

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryId.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryId.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryId.h"
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryId.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryId.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryScope.h"
 #include "GenericPlatformSentryBreadcrumb.h"

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySpan.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentrySpan.h"
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySpan.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentrySubsystem.h"
 #include "GenericPlatformSentryBreadcrumb.h"

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransaction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryTransaction.h"
 #include "GenericPlatformSentrySpan.h"

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransaction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransactionContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransactionContext.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryTransactionContext.h"
 #include "GenericPlatformSentryTransaction.h"

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransactionContext.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransactionContext.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryUser.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryUser.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryUser.h"
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryUser.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryUser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryUserFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryUserFeedback.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryUserFeedback.h"
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryUserFeedback.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryUserFeedback.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryConverters.h"
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryAttachment.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryAttachment.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if PLATFORM_ANDROID

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryBreadcrumb.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryBreadcrumb.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if PLATFORM_ANDROID

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryEvent.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryEvent.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if PLATFORM_ANDROID

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryHint.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryHint.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if PLATFORM_ANDROID

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryId.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryId.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if PLATFORM_ANDROID

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySamplingContext.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Null/NullSentrySamplingContext.h"

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryScope.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryScope.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if PLATFORM_ANDROID

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySpan.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Null/NullSentrySpan.h"

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySubsystem.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include COMPILED_PLATFORM_HEADER(SentrySubsystem.h)

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryTransaction.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Null/NullSentryTransaction.h"

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryTransactionContext.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryTransactionContext.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if PLATFORM_ANDROID

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryUser.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryUser.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if PLATFORM_ANDROID

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryUserFeedback.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryUserFeedback.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if PLATFORM_ANDROID

--- a/plugin-dev/Source/Sentry/Private/IOS/IOSSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/IOS/IOSSentrySubsystem.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #include "IOS/IOSSentrySubsystem.h"
 
 #include "IOS/IOSAppDelegate.h"

--- a/plugin-dev/Source/Sentry/Private/IOS/IOSSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/IOS/IOSSentrySubsystem.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Apple/AppleSentrySubsystem.h"

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryAttachmentInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryAttachmentInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryBreadcrumbInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryBreadcrumbInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryEventInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryEventInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryHintInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryHintInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryIdInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryIdInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySamplingContextInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySamplingContextInterface.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryScopeInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryScopeInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySpanInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySpanInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryTransactionContextInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryTransactionContextInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryTransactionInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryTransactionInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryUserFeedbackInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryUserFeedbackInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryUserInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryUserInterface.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #include "LinuxSentrySubsystem.h"
 
 #include "SentryBeforeBreadcrumbHandler.h"

--- a/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #include "Mac/MacSentrySubsystem.h"
 
 #include "AppleSentryId.h"

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Apple/AppleSentrySubsystem.h"

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #include "MicrosoftSentrySubsystem.h"
 
 #if USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryAttachment.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryAttachment.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentryAttachmentInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryBreadcrumb.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryBreadcrumb.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentryBreadcrumbInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryEvent.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryEvent.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentryEventInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryHint.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryHint.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentryHintInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryId.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryId.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentryIdInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentrySamplingContext.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentrySamplingContextInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryScope.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryScope.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentryScopeInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentrySpan.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentrySpanInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryTransaction.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentryTransactionInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryTransactionContext.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryTransactionContext.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentryTransactionContextInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryUser.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryUser.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentryUserInterface.h"

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryUserFeedback.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryUserFeedback.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Interface/SentryUserFeedbackInterface.h"

--- a/plugin-dev/Source/Sentry/Private/SentryAttachment.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryAttachment.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryAttachment.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryBeforeBreadcrumbHandler.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryBeforeBreadcrumbHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryBeforeBreadcrumbHandler.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryBeforeSendHandler.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryBeforeSendHandler.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryBeforeSendHandler.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryBreadcrumb.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryBreadcrumb.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryBreadcrumb.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryDefines.h
+++ b/plugin-dev/Source/Sentry/Private/SentryDefines.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/SentryErrorOutputDevice.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryErrorOutputDevice.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryErrorOutputDevice.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryEvent.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryEvent.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryHint.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryHint.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryHint.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryLibrary.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryLibrary.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryLibrary.h"
 #include "SentryAttachment.h"

--- a/plugin-dev/Source/Sentry/Private/SentryModule.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryModule.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryModule.h"
 #include "SentryDefines.h"

--- a/plugin-dev/Source/Sentry/Private/SentryOutputDevice.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryOutputDevice.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryOutputDevice.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentrySamplingContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySamplingContext.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentrySamplingContext.h"
 #include "SentryTransactionContext.h"

--- a/plugin-dev/Source/Sentry/Private/SentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryScope.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryScope.h"
 #include "SentryAttachment.h"

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentrySettings.h"
 #include "SentryBeforeSendHandler.h"

--- a/plugin-dev/Source/Sentry/Private/SentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySpan.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentrySpan.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentrySubsystem.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryTraceSampler.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryTraceSampler.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryTraceSampler.h"
 #include "SentrySamplingContext.h"

--- a/plugin-dev/Source/Sentry/Private/SentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryTransaction.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryTransaction.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryTransactionContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryTransactionContext.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryTransactionContext.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryUser.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryUser.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryUser.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentryUserFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryUserFeedback.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryUserFeedback.h"
 

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryBreadcrumb.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryBreadcrumb.spec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryBreadcrumb.h"
 #include "SentryTests.h"

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryEvent.spec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryEvent.h"
 #include "SentryTests.h"

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryScope.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryScope.spec.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryScope.h"
 #include "SentryEvent.h"

--- a/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentrySubsystem.spec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentrySubsystem.h"
 #include "SentryEvent.h"

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryTests.h
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryTests.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryUser.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryUser.spec.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryUser.h"
 #include "SentryTests.h"

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryFileUtils.cpp
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryFileUtils.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryFileUtils.h"
 #include "SentryDefines.h"

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryFileUtils.h
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryFileUtils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.cpp
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryLogUtils.h"
 

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.h
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.cpp
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryScreenshotUtils.h"
 

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.h
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Windows/Infrastructure/WindowsSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/Windows/Infrastructure/WindowsSentryConverters.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #include "WindowsSentryConverters.h"
 
 #if USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Windows/Infrastructure/WindowsSentryConverters.h
+++ b/plugin-dev/Source/Sentry/Private/Windows/Infrastructure/WindowsSentryConverters.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #include "WindowsSentrySubsystem.h"
 
 #if USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #if USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Public/SentryAttachment.h
+++ b/plugin-dev/Source/Sentry/Public/SentryAttachment.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryBeforeBreadcrumbHandler.h
+++ b/plugin-dev/Source/Sentry/Public/SentryBeforeBreadcrumbHandler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryBeforeSendHandler.h
+++ b/plugin-dev/Source/Sentry/Public/SentryBeforeSendHandler.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryBreadcrumb.h
+++ b/plugin-dev/Source/Sentry/Public/SentryBreadcrumb.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryDataTypes.h
+++ b/plugin-dev/Source/Sentry/Public/SentryDataTypes.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryErrorOutputDevice.h
+++ b/plugin-dev/Source/Sentry/Public/SentryErrorOutputDevice.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryEvent.h
+++ b/plugin-dev/Source/Sentry/Public/SentryEvent.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryHint.h
+++ b/plugin-dev/Source/Sentry/Public/SentryHint.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryLibrary.h
+++ b/plugin-dev/Source/Sentry/Public/SentryLibrary.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryModule.h
+++ b/plugin-dev/Source/Sentry/Public/SentryModule.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryOutputDevice.h
+++ b/plugin-dev/Source/Sentry/Public/SentryOutputDevice.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySamplingContext.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryScope.h
+++ b/plugin-dev/Source/Sentry/Public/SentryScope.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentrySpan.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySpan.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryTraceSampler.h
+++ b/plugin-dev/Source/Sentry/Public/SentryTraceSampler.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2024 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Public/SentryTransaction.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2023 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryTransactionContext.h
+++ b/plugin-dev/Source/Sentry/Public/SentryTransactionContext.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2024 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryUser.h
+++ b/plugin-dev/Source/Sentry/Public/SentryUser.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryUserFeedback.h
+++ b/plugin-dev/Source/Sentry/Public/SentryUserFeedback.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 using UnrealBuildTool;
 using System;

--- a/plugin-dev/Source/SentryEditor/Private/SentryEditorModule.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentryEditorModule.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryEditorModule.h"
 #include "SentrySettings.h"

--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentrySettingsCustomization.h"
 #include "SentryModule.h"

--- a/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentrySymToolsDownloader.h"
 #include "SentryModule.h"

--- a/plugin-dev/Source/SentryEditor/Public/SentryEditorModule.h
+++ b/plugin-dev/Source/SentryEditor/Public/SentryEditorModule.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/SentryEditor/Public/SentrySettingsCustomization.h
+++ b/plugin-dev/Source/SentryEditor/Public/SentrySettingsCustomization.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/SentryEditor/Public/SentrySymToolsDownloader.h
+++ b/plugin-dev/Source/SentryEditor/Public/SentrySymToolsDownloader.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/SentryEditor/SentryEditor.Build.cs
+++ b/plugin-dev/Source/SentryEditor/SentryEditor.Build.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2022 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 using UnrealBuildTool;
 

--- a/sample/Source/SentryPlayground.Target.cs
+++ b/sample/Source/SentryPlayground.Target.cs
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 using UnrealBuildTool;
 using System.Collections.Generic;

--- a/sample/Source/SentryPlayground/CppBeforeSendHandler.cpp
+++ b/sample/Source/SentryPlayground/CppBeforeSendHandler.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "CppBeforeSendHandler.h"
 

--- a/sample/Source/SentryPlayground/CppBeforeSendHandler.h
+++ b/sample/Source/SentryPlayground/CppBeforeSendHandler.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2023 Sentry. All Rights Reserved.
+﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/sample/Source/SentryPlayground/SentryPlayground.Build.cs
+++ b/sample/Source/SentryPlayground/SentryPlayground.Build.cs
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 using UnrealBuildTool;
 

--- a/sample/Source/SentryPlayground/SentryPlayground.cpp
+++ b/sample/Source/SentryPlayground/SentryPlayground.cpp
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryPlayground.h"
 #include "Modules/ModuleManager.h"

--- a/sample/Source/SentryPlayground/SentryPlayground.h
+++ b/sample/Source/SentryPlayground/SentryPlayground.h
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/sample/Source/SentryPlayground/SentryPlaygroundGameInstance.cpp
+++ b/sample/Source/SentryPlayground/SentryPlaygroundGameInstance.cpp
@@ -1,5 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryPlaygroundGameInstance.h"
 

--- a/sample/Source/SentryPlayground/SentryPlaygroundGameInstance.h
+++ b/sample/Source/SentryPlayground/SentryPlaygroundGameInstance.h
@@ -1,4 +1,4 @@
-// Fill out your copyright notice in the Description page of Project Settings.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/sample/Source/SentryPlayground/SentryPlaygroundGameModeBase.cpp
+++ b/sample/Source/SentryPlayground/SentryPlaygroundGameModeBase.cpp
@@ -1,5 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
-
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryPlaygroundGameModeBase.h"
 

--- a/sample/Source/SentryPlayground/SentryPlaygroundGameModeBase.h
+++ b/sample/Source/SentryPlayground/SentryPlaygroundGameModeBase.h
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp
+++ b/sample/Source/SentryPlayground/SentryPlaygroundUtils.cpp
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #include "SentryPlaygroundUtils.h"
 
 #include "HAL/FileManager.h"

--- a/sample/Source/SentryPlayground/SentryPlaygroundUtils.h
+++ b/sample/Source/SentryPlayground/SentryPlaygroundUtils.h
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
 #pragma once
 
 #include "Kismet/BlueprintFunctionLibrary.h"

--- a/sample/Source/SentryPlaygroundEditor.Target.cs
+++ b/sample/Source/SentryPlaygroundEditor.Target.cs
@@ -1,4 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 using UnrealBuildTool;
 using System.Collections.Generic;


### PR DESCRIPTION
This PR adds (updates) `Copyright (c) 2025 Sentry. All Rights Reserved` copyright notice to all header/source files in the plugin in order to comply with UE Marketplace (FAB) publishing rules ([2.6.2.b](https://www.unrealengine.com/en-US/marketplace-guidelines#262b)).


#skip-changelog