### PR TITLE
chore: Build sentry-native in Ubuntu 20.04 docker container for better compatibility with old Linux distros

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: package-plugin-workflow
 
-on: 
+on:
   push:
     branches:
       - main
@@ -33,12 +33,14 @@ jobs:
     with:
       target: Linux
       runsOn: ubuntu-22.04
+      container: ubuntu:20.04
 
   linux-arm64-sdk:
     uses: ./.github/workflows/sdk-build.yml
     with:
       target: LinuxArm64
       runsOn: ubuntu-22.04-arm
+      container: arm64v8/ubuntu:20.04
 
   windows-crashpad-sdk:
     uses: ./.github/workflows/sdk-build.yml

--- a/.github/workflows/sdk-build.yml
+++ b/.github/workflows/sdk-build.yml
@@ -21,6 +21,17 @@ jobs:
       run:
         shell: bash
     steps:
+      - name: Configure env for Linux docker containers
+        if: ${{ inputs.target == 'Linux' || inputs.target == 'LinuxArm64' }}
+        run: |
+          apt-get update
+          apt-get -y install sudo
+          apt-get -y install wget
+          apt-get -y install cmake
+          apt-get -y install software-properties-common
+          apt-get -y install git
+          git config --global --add safe.directory $(pwd)
+
       - uses: actions/checkout@v4
 
       - name: Select submodule


### PR DESCRIPTION
Building `sentry-native` on older `Ubuntu 20.04` allows to use Unreal SDK with a wider range of Linux distros (i.e. `Amazon Linux` VMs) due to older `glibc` versions support.

Similar approach was taken in Unity SDK (https://github.com/getsentry/sentry-unity/issues/2114) after GitHub deprecated `ubuntu20.04` runners.

Also, related to #664, #864

#skip-changelog