### PR TITLE
Exclude plugin sources that use sentry-native if build platform isn't supported

### DIFF
--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -161,5 +161,14 @@ public class Sentry : ModuleRules
 
 			AddEngineThirdPartyPrivateStaticDependencies(Target, "libcurl");
 		}
+		else
+		{
+			// Exclude sources in `Private/GenericPlatform` that use sentry-native API from the build if target platform isn't supported
+			// Plugin extensions that add support for more platforms (e.g. consoles) can override this define if needed
+			PublicDefinitions.Add("USE_SENTRY_NATIVE=0");
+
+			// TODO: Add a valid link to docs (https://github.com/getsentry/sentry-docs/issues/13861)
+			Console.WriteLine("To use Sentry SDK on game consoles follow the instructions at https://docs.sentry.io/platforms/consoles");
+		}
 	}
 }


### PR DESCRIPTION
Related to https://github.com/getsentry/sentry-unreal/issues/32 and https://github.com/getsentry/sentry-docs/issues/13861.

#skip-changelog