### PR TITLE
Change log level for certain messages during SDK initialization

### DIFF
--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -84,13 +84,13 @@ void USentrySubsystem::Initialize()
 
 	if (!IsCurrentBuildConfigurationEnabled() || !IsCurrentBuildTargetEnabled())
 	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization skipped since event capturing is disabled for the current configuration/target/build in plugin settings."));
+		UE_LOG(LogSentrySdk, Log, TEXT("Sentry initialization skipped since event capturing is disabled for the current configuration/target/build in plugin settings."));
 		return;
 	}
 
 	if (IsPromotedBuildsOnlyEnabled() && !FApp::GetEngineIsPromotedBuild())
 	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry initialization skipped since event capturing is disabled for the non-promoted builds in plugin settings."));
+		UE_LOG(LogSentrySdk, Log, TEXT("Sentry initialization skipped since event capturing is disabled for the non-promoted builds in plugin settings."));
 		return;
 	}
 


### PR DESCRIPTION
This PR lowers the log level of certain messages printed during SDK initialization from `Warning` to `Log` to prevent unnecessary errors in contexts where a warning-free session is expected (e.g., when running build and tests via Epic's Horde).

Closes #938

#skip-changelog