### PR TITLE
Fix platform classes redefinition when packaging for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Add native local scope for Windows/Linux ([#928](https://github.com/getsentry/sentry-unreal/pull/928))
 - Add option to delay app shutdown until Crashpad completes crash report upload ([#953](https://github.com/getsentry/sentry-unreal/pull/953))
 
+### Fixes
+
+- Sampling context, span and transaction classes are no longer re-defined when packaging for Android ([#959](https://github.com/getsentry/sentry-unreal/pull/959))
+
 ### Dependencies
 
 - Bump Java SDK (Android) from v8.13.1 to v8.13.2 ([#932](https://github.com/getsentry/sentry-unreal/pull/932))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `Environment` and `Dist` get/set functions were removed from the `Scope` class and now these properties have to be set in plugin settings instead. This unifies their usage across all platforms supported by the Unreal SDK.
 - `ConfigureScope` function was removed from `SentrySubsystem` class following the [Hub & Scope refactoring guidelines](https://develop.sentry.dev/sdk/miscellaneous/hub_and_scope_refactoring/) which recommend deprecating this API.
+- `Initialize` function was removed from `SamplingContext` class which is supposed to be created internally by the SDK.
 
 ### Features
 

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySamplingContext.h
@@ -2,11 +2,10 @@
 
 #pragma once
 
+#if PLATFORM_ANDROID
+#include "Android/AndroidSentrySamplingContext.h"
+#elif PLATFORM_APPLE
+#include "Apple/AppleSentrySamplingContext.h"
+#else
 #include "Null/NullSentrySamplingContext.h"
-
-static TSharedPtr<ISentrySamplingContext> CreateSharedSentrySamplingContext()
-{
-	// Sampling context is supposed to be created internally by the SDK using the platform-specific implementations.
-	// Currently, it doesn't provide default constructor for Apple/Android thus we can only return Null-version here.
-	return MakeShareable(new FNullSentrySamplingContext);
-}
+#endif

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentrySpan.h
@@ -2,11 +2,12 @@
 
 #pragma once
 
+#if PLATFORM_ANDROID
+#include "Android/AndroidSentrySpan.h"
+#elif PLATFORM_APPLE
+#include "Apple/AppleSentrySpan.h"
+#elif USE_SENTRY_NATIVE
+#include "GenericPlatform/GenericPlatformSentrySpan.h"
+#else
 #include "Null/NullSentrySpan.h"
-
-static TSharedPtr<ISentrySpan> CreateSharedSentrySpan()
-{
-	// Span is supposed to be created internally by the SDK using the platform-specific implementations.
-	// Currently, it doesn't provide default constructor for Apple/Android thus we can only return Null-version here.
-	return MakeShareable(new FPlatformSentrySpan);
-}
+#endif

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryTransaction.h
@@ -2,11 +2,12 @@
 
 #pragma once
 
+#if PLATFORM_ANDROID
+#include "Android/AndroidSentryTransaction.h"
+#elif PLATFORM_APPLE
+#include "Apple/AppleSentryTransaction.h"
+#elif USE_SENTRY_NATIVE
+#include "GenericPlatform/GenericPlatformSentryTransaction.h"
+#else
 #include "Null/NullSentryTransaction.h"
-
-static TSharedPtr<ISentryTransaction> CreateSharedSentryTransaction()
-{
-	// Transaction is supposed to be created internally by the SDK using the platform-specific implementations.
-	// Currently, it doesn't provide default constructor for Apple/Android thus we can only return Null-version here.
-	return MakeShareable(new FNullSentryTransaction);
-}
+#endif

--- a/plugin-dev/Source/Sentry/Private/SentrySamplingContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySamplingContext.cpp
@@ -5,11 +5,6 @@
 
 #include "HAL/PlatformSentrySamplingContext.h"
 
-void USentrySamplingContext::Initialize()
-{
-	NativeImpl = CreateSharedSentrySamplingContext();
-}
-
 USentryTransactionContext* USentrySamplingContext::GetTransactionContext() const
 {
 	if (!NativeImpl)

--- a/plugin-dev/Source/Sentry/Private/SentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySpan.cpp
@@ -1,9 +1,9 @@
 // Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentrySpan.h"
-
-#include "Interface/SentrySpanInterface.h"
 #include "SentryDefines.h"
+
+#include "HAL/PlatformSentrySpan.h"
 
 USentrySpan* USentrySpan::StartChild(const FString& Operation, const FString& Description)
 {

--- a/plugin-dev/Source/Sentry/Private/SentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryTransaction.cpp
@@ -1,11 +1,10 @@
 // Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryTransaction.h"
-
 #include "SentryDefines.h"
 #include "SentrySpan.h"
 
-#include "Interface/SentryTransactionInterface.h"
+#include "HAL/PlatformSentryTransaction.h"
 
 USentrySpan* USentryTransaction::StartChildSpan(const FString& Operation, const FString& Description)
 {

--- a/plugin-dev/Source/Sentry/Public/SentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySamplingContext.h
@@ -11,16 +11,18 @@
 class ISentrySamplingContext;
 class USentryTransactionContext;
 
+/**
+ * Context used by trace sampler to determine if transaction is going to be sampled.
+ *
+ * NOTE: USentrySamplingContext should not be constructed with NewObject<...>() etc., and should instead
+ *       only be created internally by the SDK using the platform-specific implementations.
+ */
 UCLASS(BlueprintType, NotBlueprintable, HideDropdown)
 class SENTRY_API USentrySamplingContext : public UObject, public TSentryImplWrapper<ISentrySamplingContext, USentrySamplingContext>
 {
 	GENERATED_BODY()
 
 public:
-	/** Initializes the sampling context. */
-	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void Initialize();
-
 	/** Gets transaction context used for sampling. */
 	UFUNCTION(BlueprintPure, Category = "Sentry")
 	USentryTransactionContext* GetTransactionContext() const;

--- a/plugin-dev/Source/Sentry/Public/SentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Public/SentryTransaction.h
@@ -14,6 +14,9 @@ class USentrySpan;
 
 /**
  * Representation of an activity to measure or track.
+ *
+ * NOTE: USentryTransaction should not be constructed with NewObject<...>() etc., and should instead
+ *       only be created by calling methods like StartTransaction(...) on USentrySubsystem.
  */
 UCLASS(BlueprintType, NotBlueprintable, HideDropdown)
 class SENTRY_API USentryTransaction : public UObject, public TSentryImplWrapper<ISentryTransaction, USentryTransaction>


### PR DESCRIPTION
This PR fixes build errors when packaging for Android caused by sampling context, span and transaction classes re-definition:
```
/Work/sentry-unreal/plugin-dev/Source/Sentry/Private/Null/NullSentrySamplingContext.h:16:36: error: typedef redefinition with different types ('FNullSentrySamplingContext' vs 'FAndroidSentrySamplingContext')
UATHelper: Packaging (Android (ASTC)): typedef FNullSentrySamplingContext FPlatformSentrySamplingContext;
UATHelper: Packaging (Android (ASTC)):                                    ^
UATHelper: Packaging (Android (ASTC)): /Work/sentry-unreal/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySamplingContext.h:24:39: note: previous definition is here
UATHelper: Packaging (Android (ASTC)): typedef FAndroidSentrySamplingContext FPlatformSentrySamplingContext;
UATHelper: Packaging (Android (ASTC)):                                       ^
UATHelper: Packaging (Android (ASTC)): 1 error generated.
PackagingResults: Error: typedef redefinition with different types ('FNullSentrySamplingContext' vs 'FAndroidSentrySamplingContext')
```
Also added notes indicating that these classes should be instantiated internally by the SDK and removed the corresponding helper function used to create them.