### PR TITLE
Remove BOM from source files

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySamplingContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySamplingContext.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentrySamplingContext.h"
 #include "AndroidSentryTransactionContext.h"

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySamplingContext.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentrySpan.h"
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AndroidSentryTransaction.h"
 #include "AndroidSentrySpan.h"

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySamplingContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySamplingContext.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentrySamplingContext.h"
 #include "AppleSentryTransactionContext.h"

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySamplingContext.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentrySpan.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "AppleSentryTransaction.h"
 #include "AppleSentrySpan.h"

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryCrashContext.h"
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryScope.h"
 #include "GenericPlatformSentryBreadcrumb.h"

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySamplingContextInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySamplingContextInterface.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/SentryOutputDevice.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryOutputDevice.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryOutputDevice.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentrySamplingContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySamplingContext.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentrySamplingContext.h"
 #include "SentryTransactionContext.h"

--- a/plugin-dev/Source/Sentry/Private/SentryTraceSampler.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryTraceSampler.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryTraceSampler.h"
 #include "SentrySamplingContext.h"

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryScope.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryScope.spec.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryScope.h"
 #include "SentryEvent.h"

--- a/plugin-dev/Source/Sentry/Private/Tests/SentryTests.h
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryTests.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.cpp
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryLogUtils.h"
 

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.h
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryLogUtils.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.cpp
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryScreenshotUtils.h"
 

--- a/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.h
+++ b/plugin-dev/Source/Sentry/Private/Utils/SentryScreenshotUtils.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryOutputDevice.h
+++ b/plugin-dev/Source/Sentry/Public/SentryOutputDevice.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentrySamplingContext.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySamplingContext.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/Sentry/Public/SentryTraceSampler.h
+++ b/plugin-dev/Source/Sentry/Public/SentryTraceSampler.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/SentryEditor/Private/SentryEditorModule.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentryEditorModule.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentryEditorModule.h"
 #include "SentrySettings.h"

--- a/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySymToolsDownloader.cpp
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "SentrySymToolsDownloader.h"
 #include "SentryModule.h"

--- a/plugin-dev/Source/SentryEditor/Public/SentryEditorModule.h
+++ b/plugin-dev/Source/SentryEditor/Public/SentryEditorModule.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/SentryEditor/Public/SentrySymToolsDownloader.h
+++ b/plugin-dev/Source/SentryEditor/Public/SentrySymToolsDownloader.h
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #pragma once
 

--- a/plugin-dev/Source/SentryEditor/SentryEditor.Build.cs
+++ b/plugin-dev/Source/SentryEditor/SentryEditor.Build.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2025 Sentry. All Rights Reserved.
+// Copyright (c) 2025 Sentry. All Rights Reserved.
 
 using UnrealBuildTool;
 


### PR DESCRIPTION
BOM causes Perforce's encoding detection to flag the file as "utf8" instead of "text" which can be undesirable.  Remove these BOMs to make to mitigate getting into this particular niche issue.