### PR TITLE
Add runtime attachments support for Windows/Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 ### Features
 
 - Adopt generic variant type in public APIs ([#971](https://github.com/getsentry/sentry-unreal/pull/971))
+- Add runtime attachments support for Windows/Linux ([#982](https://github.com/getsentry/sentry-unreal/pull/982))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -144,6 +144,11 @@ void FAndroidSentrySubsystem::RemoveAttachment(TSharedPtr<ISentryAttachment> att
 		attachmentAndroid->GetJObject());
 }
 
+void FAndroidSentrySubsystem::ClearAttachments()
+{
+	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, "clearAttachments", "()V");
+}
+
 TSharedPtr<ISentryId> FAndroidSentrySubsystem::CaptureMessage(const FString& message, ESentryLevel level)
 {
 	auto id = FSentryJavaObjectWrapper::CallStaticObjectMethod<jobject>(SentryJavaClasses::Sentry, "captureMessage", "(Ljava/lang/String;Lio/sentry/SentryLevel;)Lio/sentry/protocol/SentryId;",

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -2,6 +2,7 @@
 
 #include "AndroidSentrySubsystem.h"
 
+#include "AndroidSentryAttachment.h"
 #include "AndroidSentryBreadcrumb.h"
 #include "AndroidSentryEvent.h"
 #include "AndroidSentryId.h"
@@ -125,6 +126,22 @@ void FAndroidSentrySubsystem::AddBreadcrumbWithParams(const FString& Message, co
 void FAndroidSentrySubsystem::ClearBreadcrumbs()
 {
 	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::Sentry, "clearBreadcrumbs", "()V");
+}
+
+void FAndroidSentrySubsystem::AddAttachment(TSharedPtr<ISentryAttachment> attachment)
+{
+	TSharedPtr<FAndroidSentryAttachment> attachmentAndroid = StaticCastSharedPtr<FAndroidSentryAttachment>(attachment);
+
+	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, "addAttachment", "(Lio/sentry/Attachment;)V",
+		attachmentAndroid->GetJObject());
+}
+
+void FAndroidSentrySubsystem::RemoveAttachment(TSharedPtr<ISentryAttachment> attachment)
+{
+	TSharedPtr<FAndroidSentryAttachment> attachmentAndroid = StaticCastSharedPtr<FAndroidSentryAttachment>(attachment);
+
+	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, "removeAttachment", "(Lio/sentry/Attachment;)V",
+		attachmentAndroid->GetJObject());
 }
 
 TSharedPtr<ISentryId> FAndroidSentrySubsystem::CaptureMessage(const FString& message, ESentryLevel level)

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
@@ -16,6 +16,7 @@ public:
 	virtual void ClearBreadcrumbs() override;
 	virtual void AddAttachment(TSharedPtr<ISentryAttachment> attachment) override;
 	virtual void RemoveAttachment(TSharedPtr<ISentryAttachment> attachment) override;
+	virtual void ClearAttachments() override;
 	virtual TSharedPtr<ISentryId> CaptureMessage(const FString& message, ESentryLevel level) override;
 	virtual TSharedPtr<ISentryId> CaptureMessageWithScope(const FString& message, ESentryLevel level, const FSentryScopeDelegate& onConfigureScope) override;
 	virtual TSharedPtr<ISentryId> CaptureEvent(TSharedPtr<ISentryEvent> event) override;

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
@@ -14,6 +14,8 @@ public:
 	virtual void AddBreadcrumb(TSharedPtr<ISentryBreadcrumb> breadcrumb) override;
 	virtual void AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FSentryVariant>& Data, ESentryLevel Level) override;
 	virtual void ClearBreadcrumbs() override;
+	virtual void AddAttachment(TSharedPtr<ISentryAttachment> attachment) override;
+	virtual void RemoveAttachment(TSharedPtr<ISentryAttachment> attachment) override;
 	virtual TSharedPtr<ISentryId> CaptureMessage(const FString& message, ESentryLevel level) override;
 	virtual TSharedPtr<ISentryId> CaptureMessageWithScope(const FString& message, ESentryLevel level, const FSentryScopeDelegate& onConfigureScope) override;
 	virtual TSharedPtr<ISentryId> CaptureEvent(TSharedPtr<ISentryEvent> event) override;

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -232,6 +232,6 @@ public class SentryBridgeJava {
 	}
 
 	public static void removeAttachment(final Attachment attachment) {
-		Sentry.getGlobalScope().getAttachments().remove(attachment);
+		// Currently, Android SDK doesn't have API allowing to remove individual attachments
 	}
 }

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+import io.sentry.Attachment;
 import io.sentry.Breadcrumb;
 import io.sentry.Hint;
 import io.sentry.IScopes;
@@ -224,5 +225,13 @@ public class SentryBridgeJava {
 
 	public static void setScopeExtra(final IScope scope, final String key, final Object values) {
 		scope.setExtra(key, values.toString());
+	}
+
+	public static void addAttachment(final Attachment attachment) {
+		Sentry.getGlobalScope().addAttachment(attachment);
+	}
+
+	public static void removeAttachment(final Attachment attachment) {
+		Sentry.getGlobalScope().getAttachments().remove(attachment);
 	}
 }

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -234,4 +234,9 @@ public class SentryBridgeJava {
 	public static void removeAttachment(final Attachment attachment) {
 		// Currently, Android SDK doesn't have API allowing to remove individual attachments
 	}
+
+	public static void clearAttachments() {
+		Sentry.getGlobalScope().clearAttachments();
+	}
+
 }

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -2,6 +2,7 @@
 
 #include "AppleSentrySubsystem.h"
 
+#include "AppleSentryAttachment.h"
 #include "AppleSentryBreadcrumb.h"
 #include "AppleSentryEvent.h"
 #include "AppleSentryId.h"
@@ -199,6 +200,24 @@ void FAppleSentrySubsystem::ClearBreadcrumbs()
 {
 	[SentrySDK configureScope:^(SentryScope* scope) {
 		[scope clearBreadcrumbs];
+	}];
+}
+
+void FAppleSentrySubsystem::AddAttachment(TSharedPtr<ISentryAttachment> attachment)
+{
+	TSharedPtr<FAppleSentryAttachment> attachmentApple = StaticCastSharedPtr<FAppleSentryAttachment>(attachment);
+
+	[SentrySDK configureScope:^(SentryScope* scope) {
+		[scope addAttachment:attachmentApple->GetNativeObject()];
+	}];
+}
+
+void FAppleSentrySubsystem::RemoveAttachment(TSharedPtr<ISentryAttachment> attachment)
+{
+	TSharedPtr<FAppleSentryAttachment> attachmentApple = StaticCastSharedPtr<FAppleSentryAttachment>(attachment);
+
+	[SentrySDK configureScope:^(SentryScope* scope) {
+		[scope.attachmentArray removeObject:attachmentApple->GetNativeObject()];
 	}];
 }
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -214,7 +214,7 @@ void FAppleSentrySubsystem::AddAttachment(TSharedPtr<ISentryAttachment> attachme
 
 void FAppleSentrySubsystem::RemoveAttachment(TSharedPtr<ISentryAttachment> attachment)
 {
-	// CUrrently, Cocoa SDK doesn't have API allowing to remove individual attachments
+	// Currently, Cocoa SDK doesn't have API allowing to remove individual attachments
 }
 
 TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureMessage(const FString& message, ESentryLevel level)

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -214,11 +214,7 @@ void FAppleSentrySubsystem::AddAttachment(TSharedPtr<ISentryAttachment> attachme
 
 void FAppleSentrySubsystem::RemoveAttachment(TSharedPtr<ISentryAttachment> attachment)
 {
-	TSharedPtr<FAppleSentryAttachment> attachmentApple = StaticCastSharedPtr<FAppleSentryAttachment>(attachment);
-
-	[SentrySDK configureScope:^(SentryScope* scope) {
-		[scope.attachmentArray removeObject:attachmentApple->GetNativeObject()];
-	}];
+	// CUrrently, Cocoa SDK doesn't have API allowing to remove individual attachments
 }
 
 TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureMessage(const FString& message, ESentryLevel level)

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -217,6 +217,13 @@ void FAppleSentrySubsystem::RemoveAttachment(TSharedPtr<ISentryAttachment> attac
 	// Currently, Cocoa SDK doesn't have API allowing to remove individual attachments
 }
 
+void FAppleSentrySubsystem::ClearAttachments()
+{
+	[SentrySDK configureScope:^(SentryScope* scope) {
+		[scope clearAttachments];
+	}];
+}
+
 TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureMessage(const FString& message, ESentryLevel level)
 {
 	FSentryScopeDelegate onConfigureScope;

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -16,6 +16,7 @@ public:
 	virtual void ClearBreadcrumbs() override;
 	virtual void AddAttachment(TSharedPtr<ISentryAttachment> attachment) override;
 	virtual void RemoveAttachment(TSharedPtr<ISentryAttachment> attachment) override;
+	virtual void ClearAttachments() override;
 	virtual TSharedPtr<ISentryId> CaptureMessage(const FString& message, ESentryLevel level) override;
 	virtual TSharedPtr<ISentryId> CaptureMessageWithScope(const FString& message, ESentryLevel level, const FSentryScopeDelegate& onConfigureScope) override;
 	virtual TSharedPtr<ISentryId> CaptureEvent(TSharedPtr<ISentryEvent> event) override;

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -14,6 +14,8 @@ public:
 	virtual void AddBreadcrumb(TSharedPtr<ISentryBreadcrumb> breadcrumb) override;
 	virtual void AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FSentryVariant>& Data, ESentryLevel Level) override;
 	virtual void ClearBreadcrumbs() override;
+	virtual void AddAttachment(TSharedPtr<ISentryAttachment> attachment) override;
+	virtual void RemoveAttachment(TSharedPtr<ISentryAttachment> attachment) override;
 	virtual TSharedPtr<ISentryId> CaptureMessage(const FString& message, ESentryLevel level) override;
 	virtual TSharedPtr<ISentryId> CaptureMessageWithScope(const FString& message, ESentryLevel level, const FSentryScopeDelegate& onConfigureScope) override;
 	virtual TSharedPtr<ISentryId> CaptureEvent(TSharedPtr<ISentryEvent> event) override;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
+#include "GenericPlatformSentryAttachment.h"
+
+#if USE_SENTRY_NATIVE
+
+FGenericPlatformSentryAttachment::FGenericPlatformSentryAttachment(const TArray<uint8>& data, const FString& filename, const FString& contentType)
+	: Data(data), Filename(filename), ContentType(contentType)
+{
+}
+
+FGenericPlatformSentryAttachment::FGenericPlatformSentryAttachment(const FString& path, const FString& filename, const FString& contentType)
+	: Path(path), Filename(filename), ContentType(contentType)
+{
+}
+
+TArray<uint8> FGenericPlatformSentryAttachment::GetData() const
+{
+	return Data;
+}
+
+FString FGenericPlatformSentryAttachment::GetPath() const
+{
+	return Path;
+}
+
+FString FGenericPlatformSentryAttachment::GetFilename() const
+{
+	return Filename;
+}
+
+FString FGenericPlatformSentryAttachment::GetContentType() const
+{
+	return ContentType;
+}
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
@@ -14,6 +14,21 @@ FGenericPlatformSentryAttachment::FGenericPlatformSentryAttachment(const FString
 {
 }
 
+FGenericPlatformSentryAttachment::~FGenericPlatformSentryAttachment()
+{
+	// Put custom destructor logic here if needed
+}
+
+void FGenericPlatformSentryAttachment::SetNativeObject(sentry_attachment_t* attachment)
+{
+	Attachment = attachment;
+}
+
+sentry_attachment_t* FGenericPlatformSentryAttachment::GetNativeObject()
+{
+	return Attachment;
+}
+
 TArray<uint8> FGenericPlatformSentryAttachment::GetData() const
 {
 	return Data;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
@@ -49,4 +49,9 @@ FString FGenericPlatformSentryAttachment::GetContentType() const
 	return ContentType;
 }
 
+const TArray<uint8>& FGenericPlatformSentryAttachment::GetDataByRef() const
+{
+	return Data;
+}
+
 #endif

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
@@ -5,12 +5,12 @@
 #if USE_SENTRY_NATIVE
 
 FGenericPlatformSentryAttachment::FGenericPlatformSentryAttachment(const TArray<uint8>& data, const FString& filename, const FString& contentType)
-	: Data(data), Filename(filename), ContentType(contentType)
+	: Data(data), Filename(filename), ContentType(contentType), Attachment(nullptr)
 {
 }
 
 FGenericPlatformSentryAttachment::FGenericPlatformSentryAttachment(const FString& path, const FString& filename, const FString& contentType)
-	: Path(path), Filename(filename), ContentType(contentType)
+	: Path(path), Filename(filename), ContentType(contentType), Attachment(nullptr)
 {
 }
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.h
@@ -13,6 +13,10 @@ class FGenericPlatformSentryAttachment : public ISentryAttachment
 public:
 	FGenericPlatformSentryAttachment(const TArray<uint8>& data, const FString& filename, const FString& contentType);
 	FGenericPlatformSentryAttachment(const FString& path, const FString& filename, const FString& contentType);
+	virtual ~FGenericPlatformSentryAttachment() override;
+
+	void SetNativeObject(sentry_attachment_t* attachment);
+	sentry_attachment_t* GetNativeObject();
 
 	virtual TArray<uint8> GetData() const override;
 	virtual FString GetPath() const override;
@@ -24,6 +28,8 @@ private:
 	FString Path;
 	FString Filename;
 	FString ContentType;
+
+	sentry_attachment_t* Attachment;
 };
 
 typedef FGenericPlatformSentryAttachment FPlatformSentryAttachment;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.h
@@ -23,6 +23,8 @@ public:
 	virtual FString GetFilename() const override;
 	virtual FString GetContentType() const override;
 
+	const TArray<uint8>& GetDataByRef() const;
+
 private:
 	TArray<uint8> Data;
 	FString Path;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
+#pragma once
+
+#include "Convenience/GenericPlatformSentryInclude.h"
+
+#include "Interface/SentryAttachmentInterface.h"
+
+#if USE_SENTRY_NATIVE
+
+class FGenericPlatformSentryAttachment : public ISentryAttachment
+{
+public:
+	FGenericPlatformSentryAttachment(const TArray<uint8>& data, const FString& filename, const FString& contentType);
+	FGenericPlatformSentryAttachment(const FString& path, const FString& filename, const FString& contentType);
+
+	virtual TArray<uint8> GetData() const override;
+	virtual FString GetPath() const override;
+	virtual FString GetFilename() const override;
+	virtual FString GetContentType() const override;
+
+private:
+	TArray<uint8> Data;
+	FString Path;
+	FString Filename;
+	FString ContentType;
+};
+
+typedef FGenericPlatformSentryAttachment FPlatformSentryAttachment;
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
@@ -247,7 +247,7 @@ void FGenericPlatformSentryScope::AddFileAttachment(TSharedPtr<FGenericPlatformS
 
 void FGenericPlatformSentryScope::AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
 {
-	TArray<uint8> byteBuf = attachment->GetData();
+	const TArray<uint8>& byteBuf = attachment->GetDataByRef();
 
 	sentry_attachment_t* nativeAttachment =
 		sentry_scope_attach_bytes(scope, reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*attachment->GetFilename()));

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
@@ -250,7 +250,7 @@ void FGenericPlatformSentryScope::AddByteAttachment(TSharedPtr<FGenericPlatformS
 	const TArray<uint8>& byteBuf = attachment->GetData();
 
 	sentry_attachment_t* nativeAttachment =
-		sentry_scope_attach_bytes(scope,  reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*attachment->GetFilename()));
+		sentry_scope_attach_bytes(scope, reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*attachment->GetFilename()));
 
 	if (!attachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Sentry. All Rights Reserved.
 
 #include "GenericPlatformSentryScope.h"
+#include "GenericPlatformSentryAttachment.h"
 #include "GenericPlatformSentryBreadcrumb.h"
 #include "GenericPlatformSentryEvent.h"
 
@@ -39,12 +40,12 @@ void FGenericPlatformSentryScope::ClearBreadcrumbs()
 
 void FGenericPlatformSentryScope::AddAttachment(TSharedPtr<ISentryAttachment> attachment)
 {
-	// Not available for generic platform
+	Attachments.Add(StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment));
 }
 
 void FGenericPlatformSentryScope::ClearAttachments()
 {
-	// Not available for generic platform
+	Attachments.Empty();
 }
 
 void FGenericPlatformSentryScope::SetTag(const FString& key, const FString& value)
@@ -195,6 +196,18 @@ void FGenericPlatformSentryScope::Apply(sentry_scope_t* scope)
 		sentry_scope_add_breadcrumb(scope, nativeBreadcrumb);
 	}
 
+	for (auto& Attachment : Attachments)
+	{
+		if (!Attachment->GetPath().IsEmpty())
+		{
+			AddFileAttachment(Attachment, scope);
+		}
+		else
+		{
+			AddByteAttachment(Attachment, scope);
+		}
+	}
+
 	if (Fingerprint.Num() > 0)
 	{
 		sentry_scope_set_fingerprints(scope, FGenericPlatformSentryConverters::StringArrayToNative(Fingerprint));
@@ -216,6 +229,33 @@ void FGenericPlatformSentryScope::Apply(sentry_scope_t* scope)
 	}
 
 	sentry_scope_set_level(scope, FGenericPlatformSentryConverters::SentryLevelToNative(Level));
+}
+
+void FGenericPlatformSentryScope::AddFileAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
+{
+	sentry_attachment_t* nativeAttachment =
+		sentry_scope_attach_file(scope, TCHAR_TO_UTF8(*attachment->GetPath()));
+
+	if (!attachment->GetFilename().IsEmpty())
+		sentry_attachment_set_filename(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetFilename()));
+
+	if (!attachment->GetContentType().IsEmpty())
+		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
+
+	attachment->SetNativeObject(nativeAttachment);
+}
+
+void FGenericPlatformSentryScope::AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
+{
+	const TArray<uint8>& byteBuf = attachment->GetData();
+
+	sentry_attachment_t* nativeAttachment =
+		sentry_scope_attach_bytes(scope,  reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*attachment->GetFilename()));
+
+	if (!attachment->GetContentType().IsEmpty())
+		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
+
+	attachment->SetNativeObject(nativeAttachment);
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
@@ -247,7 +247,7 @@ void FGenericPlatformSentryScope::AddFileAttachment(TSharedPtr<FGenericPlatformS
 
 void FGenericPlatformSentryScope::AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
 {
-	const TArray<uint8>& byteBuf = attachment->GetData();
+	TArray<uint8> byteBuf = attachment->GetData();
 
 	sentry_attachment_t* nativeAttachment =
 		sentry_scope_attach_bytes(scope, reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*attachment->GetFilename()));

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.h
@@ -9,6 +9,7 @@
 
 #if USE_SENTRY_NATIVE
 
+class FGenericPlatformSentryAttachment;
 class FGenericPlatformSentryBreadcrumb;
 class FGenericPlatformSentryEvent;
 
@@ -46,6 +47,10 @@ public:
 
 	void Apply(sentry_scope_t* scope);
 
+protected:
+	virtual void AddFileAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope);
+	virtual void AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope);
+
 private:
 	FString Dist;
 	FString Environment;
@@ -58,6 +63,8 @@ private:
 	TMap<FString, TMap<FString, FSentryVariant>> Contexts;
 
 	TRingBuffer<TSharedPtr<FGenericPlatformSentryBreadcrumb>> Breadcrumbs;
+
+	TArray<TSharedPtr<FGenericPlatformSentryAttachment>> Attachments;
 
 	ESentryLevel Level;
 };

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.h
@@ -69,6 +69,8 @@ private:
 	ESentryLevel Level;
 };
 
+#if !PLATFORM_MICROSOFT
 typedef FGenericPlatformSentryScope FPlatformSentryScope;
+#endif
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -220,6 +220,8 @@ void FGenericPlatformSentrySubsystem::AddFileAttachment(TSharedPtr<ISentryAttach
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetContentType()));
 
 	platformAttachment->SetNativeObject(nativeAttachment);
+
+	attachments.Add(platformAttachment);
 }
 
 void FGenericPlatformSentrySubsystem::AddByteAttachment(TSharedPtr<ISentryAttachment> attachment)
@@ -235,6 +237,8 @@ void FGenericPlatformSentrySubsystem::AddByteAttachment(TSharedPtr<ISentryAttach
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetContentType()));
 
 	platformAttachment->SetNativeObject(nativeAttachment);
+
+	attachments.Add(platformAttachment);
 }
 
 FGenericPlatformSentrySubsystem::FGenericPlatformSentrySubsystem()
@@ -437,6 +441,16 @@ void FGenericPlatformSentrySubsystem::RemoveAttachment(TSharedPtr<ISentryAttachm
 	sentry_remove_attachment(nativeAttachment);
 
 	platformAttachment->SetNativeObject(nullptr);
+}
+
+void FGenericPlatformSentrySubsystem::ClearAttachments()
+{
+	for (auto& attachment : attachments)
+	{
+		RemoveAttachment(attachment);
+	}
+
+	attachments.Empty();
 }
 
 TSharedPtr<ISentryId> FGenericPlatformSentrySubsystem::CaptureMessage(const FString& message, ESentryLevel level)

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -226,7 +226,7 @@ void FGenericPlatformSentrySubsystem::AddByteAttachment(TSharedPtr<ISentryAttach
 {
 	TSharedPtr<FGenericPlatformSentryAttachment> platformAttachment = StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment);
 
-	const TArray<uint8>& byteBuf = platformAttachment->GetData();
+	const TArray<uint8>& byteBuf = platformAttachment->GetDataByRef();
 
 	sentry_attachment_t* nativeAttachment =
 		sentry_attach_bytes(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*platformAttachment->GetFilename()));

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -431,7 +431,12 @@ void FGenericPlatformSentrySubsystem::RemoveAttachment(TSharedPtr<ISentryAttachm
 
 	sentry_attachment_t* nativeAttachment = platformAttachment->GetNativeObject();
 
+	if (!nativeAttachment)
+		return;
+
 	sentry_remove_attachment(nativeAttachment);
+
+	platformAttachment->SetNativeObject(nullptr);
 }
 
 TSharedPtr<ISentryId> FGenericPlatformSentrySubsystem::CaptureMessage(const FString& message, ESentryLevel level)

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -211,7 +211,7 @@ void FGenericPlatformSentrySubsystem::AddFileAttachment(TSharedPtr<ISentryAttach
 	TSharedPtr<FGenericPlatformSentryAttachment> platformAttachment = StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment);
 
 	sentry_attachment_t* nativeAttachment =
-	sentry_attach_file(TCHAR_TO_UTF8(*platformAttachment->GetPath()));
+		sentry_attach_file(TCHAR_TO_UTF8(*platformAttachment->GetPath()));
 
 	if (!platformAttachment->GetFilename().IsEmpty())
 		sentry_attachment_set_filename(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetFilename()));

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -28,6 +28,7 @@ public:
 	virtual void ClearBreadcrumbs() override;
 	virtual void AddAttachment(TSharedPtr<ISentryAttachment> attachment) override;
 	virtual void RemoveAttachment(TSharedPtr<ISentryAttachment> attachment) override;
+	virtual void ClearAttachments() override;
 	virtual TSharedPtr<ISentryId> CaptureMessage(const FString& message, ESentryLevel level) override;
 	virtual TSharedPtr<ISentryId> CaptureMessageWithScope(const FString& message, ESentryLevel level, const FSentryScopeDelegate& onConfigureScope) override;
 	virtual TSharedPtr<ISentryId> CaptureEvent(TSharedPtr<ISentryEvent> event) override;
@@ -76,6 +77,8 @@ protected:
 
 	virtual void AddFileAttachment(TSharedPtr<ISentryAttachment> attachment);
 	virtual void AddByteAttachment(TSharedPtr<ISentryAttachment> attachment);
+
+	TArray<TSharedPtr<FGenericPlatformSentryAttachment>> attachments;
 
 private:
 	/**

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -8,6 +8,7 @@
 
 #include "HAL/CriticalSection.h"
 
+class FGenericPlatformSentryAttachment;
 class FGenericPlatformSentryScope;
 class FGenericPlatformSentryCrashReporter;
 
@@ -25,6 +26,8 @@ public:
 	virtual void AddBreadcrumb(TSharedPtr<ISentryBreadcrumb> breadcrumb) override;
 	virtual void AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FSentryVariant>& Data, ESentryLevel Level) override;
 	virtual void ClearBreadcrumbs() override;
+	virtual void AddAttachment(TSharedPtr<ISentryAttachment> attachment) override;
+	virtual void RemoveAttachment(TSharedPtr<ISentryAttachment> attachment) override;
 	virtual TSharedPtr<ISentryId> CaptureMessage(const FString& message, ESentryLevel level) override;
 	virtual TSharedPtr<ISentryId> CaptureMessageWithScope(const FString& message, ESentryLevel level, const FSentryScopeDelegate& onConfigureScope) override;
 	virtual TSharedPtr<ISentryId> CaptureEvent(TSharedPtr<ISentryEvent> event) override;
@@ -70,6 +73,9 @@ protected:
 	virtual sentry_value_t OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure);
 
 	void InitCrashReporter(const FString& release, const FString& environment);
+
+	virtual void AddFileAttachment(TSharedPtr<ISentryAttachment> attachment);
+	virtual void AddByteAttachment(TSharedPtr<ISentryAttachment> attachment);
 
 private:
 	/**

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryAttachment.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryAttachment.h
@@ -6,6 +6,8 @@
 #include "Android/AndroidSentryAttachment.h"
 #elif PLATFORM_APPLE
 #include "Apple/AppleSentryAttachment.h"
+#elif USE_SENTRY_NATIVE
+#include "GenericPlatform/GenericPlatformSentryAttachment.h"
 #else
 #include "Null/NullSentryAttachment.h"
 #endif

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryScope.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryScope.h
@@ -6,6 +6,8 @@
 #include "Android/AndroidSentryScope.h"
 #elif PLATFORM_APPLE
 #include "Apple/AppleSentryScope.h"
+#elif PLATFORM_MICROSOFT
+#include "Microsoft/MicrosoftSentryScope.h"
 #elif USE_SENTRY_NATIVE
 #include "GenericPlatform/GenericPlatformSentryScope.h"
 #else

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
@@ -38,6 +38,7 @@ public:
 	virtual void ClearBreadcrumbs() = 0;
 	virtual void AddAttachment(TSharedPtr<ISentryAttachment> attachment) = 0;
 	virtual void RemoveAttachment(TSharedPtr<ISentryAttachment> attachment) = 0;
+	virtual void ClearAttachments() = 0;
 	virtual TSharedPtr<ISentryId> CaptureMessage(const FString& message, ESentryLevel level) = 0;
 	virtual TSharedPtr<ISentryId> CaptureMessageWithScope(const FString& message, ESentryLevel level, const FSentryScopeDelegate& onConfigureScope) = 0;
 	virtual TSharedPtr<ISentryId> CaptureEvent(TSharedPtr<ISentryEvent> event) = 0;

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
@@ -7,6 +7,7 @@
 #include "SentryDataTypes.h"
 #include "SentryVariant.h"
 
+class ISentryAttachment;
 class ISentryBreadcrumb;
 class ISentryEvent;
 class ISentryUserFeedback;
@@ -35,6 +36,8 @@ public:
 	virtual void AddBreadcrumb(TSharedPtr<ISentryBreadcrumb> breadcrumb) = 0;
 	virtual void AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FSentryVariant>& Data, ESentryLevel Level) = 0;
 	virtual void ClearBreadcrumbs() = 0;
+	virtual void AddAttachment(TSharedPtr<ISentryAttachment> attachment) = 0;
+	virtual void RemoveAttachment(TSharedPtr<ISentryAttachment> attachment) = 0;
 	virtual TSharedPtr<ISentryId> CaptureMessage(const FString& message, ESentryLevel level) = 0;
 	virtual TSharedPtr<ISentryId> CaptureMessageWithScope(const FString& message, ESentryLevel level, const FSentryScopeDelegate& onConfigureScope) = 0;
 	virtual TSharedPtr<ISentryId> CaptureEvent(TSharedPtr<ISentryEvent> event) = 0;

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryScope.cpp
@@ -20,7 +20,7 @@ void FMicrosoftSentryScope::AddFileAttachment(TSharedPtr<FGenericPlatformSentryA
 
 void FMicrosoftSentryScope::AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
 {
-	const TArray<uint8>& byteBuf = attachment->GetData();
+	const TArray<uint8>& byteBuf = attachment->GetDataByRef();
 
 	sentry_attachment_t* nativeAttachment =
 		sentry_scope_attach_bytesw(scope, reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *attachment->GetFilename());

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryScope.cpp
@@ -7,7 +7,7 @@
 void FMicrosoftSentryScope::AddFileAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
 {
 	sentry_attachment_t* nativeAttachment =
-	sentry_scope_attach_filew(scope, *attachment->GetPath());
+		sentry_scope_attach_filew(scope, *attachment->GetPath());
 
 	if (!attachment->GetFilename().IsEmpty())
 		sentry_attachment_set_filenamew(nativeAttachment, *attachment->GetFilename());
@@ -23,7 +23,7 @@ void FMicrosoftSentryScope::AddByteAttachment(TSharedPtr<FGenericPlatformSentryA
 	const TArray<uint8>& byteBuf = attachment->GetData();
 
 	sentry_attachment_t* nativeAttachment =
-		sentry_scope_attach_bytesw(scope,  reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *attachment->GetFilename());
+		sentry_scope_attach_bytesw(scope, reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *attachment->GetFilename());
 
 	if (!attachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryScope.cpp
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
+#include "MicrosoftSentryScope.h"
+
+#include "GenericPlatform/GenericPlatformSentryAttachment.h"
+
+void FMicrosoftSentryScope::AddFileAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
+{
+	sentry_attachment_t* nativeAttachment =
+	sentry_scope_attach_filew(scope, *attachment->GetPath());
+
+	if (!attachment->GetFilename().IsEmpty())
+		sentry_attachment_set_filenamew(nativeAttachment, *attachment->GetFilename());
+
+	if (!attachment->GetContentType().IsEmpty())
+		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
+
+	attachment->SetNativeObject(nativeAttachment);
+}
+
+void FMicrosoftSentryScope::AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
+{
+	const TArray<uint8>& byteBuf = attachment->GetData();
+
+	sentry_attachment_t* nativeAttachment =
+		sentry_scope_attach_bytesw(scope,  reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *attachment->GetFilename());
+
+	if (!attachment->GetContentType().IsEmpty())
+		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
+
+	attachment->SetNativeObject(nativeAttachment);
+}

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryScope.h
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryScope.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
+#pragma once
+
+#if USE_SENTRY_NATIVE
+
+#include "GenericPlatform/GenericPlatformSentryScope.h"
+
+class FMicrosoftSentryScope : public FGenericPlatformSentryScope
+{
+public:
+	virtual ~FMicrosoftSentryScope() override = default;
+
+protected:
+	virtual void AddFileAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope) override;
+	virtual void AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope) override;
+};
+
+typedef FMicrosoftSentryScope FPlatformSentryScope;
+
+#endif

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -89,7 +89,7 @@ void FMicrosoftSentrySubsystem::AddByteAttachment(TSharedPtr<ISentryAttachment> 
 {
 	TSharedPtr<FGenericPlatformSentryAttachment> platformAttachment = StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment);
 
-	const TArray<uint8>& byteBuf = platformAttachment->GetData();
+	const TArray<uint8>& byteBuf = platformAttachment->GetDataByRef();
 
 	sentry_attachment_t* nativeAttachment =
 		sentry_attach_bytesw(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *platformAttachment->GetFilename());

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -74,7 +74,7 @@ void FMicrosoftSentrySubsystem::AddFileAttachment(TSharedPtr<ISentryAttachment> 
 	TSharedPtr<FGenericPlatformSentryAttachment> platformAttachment = StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment);
 
 	sentry_attachment_t* nativeAttachment =
-	sentry_attach_filew(*platformAttachment->GetPath());
+		sentry_attach_filew(*platformAttachment->GetPath());
 
 	if (!platformAttachment->GetFilename().IsEmpty())
 		sentry_attachment_set_filenamew(nativeAttachment, *platformAttachment->GetFilename());

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -10,6 +10,8 @@
 #include "SentryModule.h"
 #include "SentrySettings.h"
 
+#include "GenericPlatform/GenericPlatformSentryAttachment.h"
+
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
 #include "Misc/EngineVersionComparison.h"
 
@@ -65,6 +67,37 @@ void FMicrosoftSentrySubsystem::ConfigureLogFileAttachment(sentry_options_t* Opt
 void FMicrosoftSentrySubsystem::ConfigureScreenshotAttachment(sentry_options_t* Options)
 {
 	sentry_options_add_attachmentw(Options, *GetScreenshotPath());
+}
+
+void FMicrosoftSentrySubsystem::AddFileAttachment(TSharedPtr<ISentryAttachment> attachment)
+{
+	TSharedPtr<FGenericPlatformSentryAttachment> platformAttachment = StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment);
+
+	sentry_attachment_t* nativeAttachment =
+	sentry_attach_filew(*platformAttachment->GetPath());
+
+	if (!platformAttachment->GetFilename().IsEmpty())
+		sentry_attachment_set_filenamew(nativeAttachment, *platformAttachment->GetFilename());
+
+	if (!platformAttachment->GetContentType().IsEmpty())
+		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetContentType()));
+
+	platformAttachment->SetNativeObject(nativeAttachment);
+}
+
+void FMicrosoftSentrySubsystem::AddByteAttachment(TSharedPtr<ISentryAttachment> attachment)
+{
+	TSharedPtr<FGenericPlatformSentryAttachment> platformAttachment = StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment);
+
+	const TArray<uint8>& byteBuf = platformAttachment->GetData();
+
+	sentry_attachment_t* nativeAttachment =
+		sentry_attach_bytesw(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *platformAttachment->GetFilename());
+
+	if (!platformAttachment->GetContentType().IsEmpty())
+		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetContentType()));
+
+	platformAttachment->SetNativeObject(nativeAttachment);
 }
 
 #endif // USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -83,6 +83,8 @@ void FMicrosoftSentrySubsystem::AddFileAttachment(TSharedPtr<ISentryAttachment> 
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetContentType()));
 
 	platformAttachment->SetNativeObject(nativeAttachment);
+
+	attachments.Add(platformAttachment);
 }
 
 void FMicrosoftSentrySubsystem::AddByteAttachment(TSharedPtr<ISentryAttachment> attachment)
@@ -98,6 +100,8 @@ void FMicrosoftSentrySubsystem::AddByteAttachment(TSharedPtr<ISentryAttachment> 
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetContentType()));
 
 	platformAttachment->SetNativeObject(nativeAttachment);
+
+	attachments.Add(platformAttachment);
 }
 
 #endif // USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
@@ -18,6 +18,9 @@ protected:
 	virtual void ConfigureDatabasePath(sentry_options_t* Options) override;
 	virtual void ConfigureLogFileAttachment(sentry_options_t* Options) override;
 	virtual void ConfigureScreenshotAttachment(sentry_options_t* Options) override;
+
+	virtual void AddFileAttachment(TSharedPtr<ISentryAttachment> attachment) override;
+	virtual void AddByteAttachment(TSharedPtr<ISentryAttachment> attachment) override;
 };
 
 #endif // USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -18,6 +18,7 @@
 #include "SentryUserFeedback.h"
 
 #include "CoreGlobals.h"
+#include "SentryAttachment.h"
 #include "Engine/World.h"
 #include "GenericPlatform/GenericPlatformDriver.h"
 #include "GenericPlatform/GenericPlatformMisc.h"
@@ -244,6 +245,30 @@ void USentrySubsystem::ClearBreadcrumbs()
 	}
 
 	SubsystemNativeImpl->ClearBreadcrumbs();
+}
+
+void USentrySubsystem::AddAttachment(USentryAttachment* Attachment)
+{
+	check(SubsystemNativeImpl);
+
+	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
+	{
+		return;
+	}
+
+	SubsystemNativeImpl->AddAttachment(Attachment->GetNativeObject());
+}
+
+void USentrySubsystem::RemoveAttachment(USentryAttachment* Attachment)
+{
+	check(SubsystemNativeImpl);
+
+	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
+	{
+		return;
+	}
+
+	SubsystemNativeImpl->RemoveAttachment(Attachment->GetNativeObject());
 }
 
 FString USentrySubsystem::CaptureMessage(const FString& Message, ESentryLevel Level)

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -18,7 +18,6 @@
 #include "SentryUserFeedback.h"
 
 #include "CoreGlobals.h"
-#include "SentryAttachment.h"
 #include "Engine/World.h"
 #include "GenericPlatform/GenericPlatformDriver.h"
 #include "GenericPlatform/GenericPlatformMisc.h"
@@ -26,6 +25,7 @@
 #include "Misc/AssertionMacros.h"
 #include "Misc/CoreDelegates.h"
 #include "Misc/EngineVersion.h"
+#include "SentryAttachment.h"
 
 #include "Interface/SentrySubsystemInterface.h"
 

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -259,7 +259,7 @@ void USentrySubsystem::AddAttachment(USentryAttachment* Attachment)
 	SubsystemNativeImpl->AddAttachment(Attachment->GetNativeObject());
 }
 
-void USentrySubsystem::RemoveAttachment(USentryAttachment* Attachment)
+void USentrySubsystem::ClearAttachments()
 {
 	check(SubsystemNativeImpl);
 
@@ -268,7 +268,7 @@ void USentrySubsystem::RemoveAttachment(USentryAttachment* Attachment)
 		return;
 	}
 
-	SubsystemNativeImpl->RemoveAttachment(Attachment->GetNativeObject());
+	SubsystemNativeImpl->ClearAttachments();
 }
 
 FString USentrySubsystem::CaptureMessage(const FString& Message, ESentryLevel Level)

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -112,13 +112,9 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
 	void AddAttachment(USentryAttachment* Attachment);
 
-	/**
-	 * Removes an attachment from the current Scope.
-	 *
-	 * @param Attachment The attachment that will be removed.
-	 */
+	/** Clears all previously added attachments from the current scope. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	void RemoveAttachment(USentryAttachment* Attachment);
+	void ClearAttachments();
 
 	/**
 	 * Captures the message.

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -105,6 +105,22 @@ public:
 	void ClearBreadcrumbs();
 
 	/**
+	 * Adds an attachment to the current Scope.
+	 *
+	 * @param Attachment The attachment that will be added to every event.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	void AddAttachment(USentryAttachment* Attachment);
+
+	/**
+	 * Removes an attachment from the current Scope.
+	 *
+	 * @param Attachment The attachment that will be removed.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	void RemoveAttachment(USentryAttachment* Attachment);
+
+	/**
 	 * Captures the message.
 	 *
 	 * @param Message The message to send.

--- a/scripts/packaging/package-github.snapshot
+++ b/scripts/packaging/package-github.snapshot
@@ -80,6 +80,8 @@ Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashCo
 Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.h
 Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.cpp
 Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.h
+Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
+Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.h
 Source/Sentry/Private/GenericPlatform/GenericPlatformSentryBreadcrumb.cpp
 Source/Sentry/Private/GenericPlatform/GenericPlatformSentryBreadcrumb.h
 Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.cpp
@@ -138,6 +140,8 @@ Source/Sentry/Private/Linux/LinuxSentryUser.h
 Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
 Source/Sentry/Private/Mac/MacSentrySubsystem.h
 Source/Sentry/Private/Mac/MacSentryUser.h
+Source/Sentry/Private/Microsoft/MicrosoftSentryScope.cpp
+Source/Sentry/Private/Microsoft/MicrosoftSentryScope.h
 Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
 Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
 Source/Sentry/Private/Null/NullSentryAttachment.h

--- a/scripts/packaging/package-marketplace.snapshot
+++ b/scripts/packaging/package-marketplace.snapshot
@@ -79,6 +79,8 @@ Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashCo
 Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.h
 Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.cpp
 Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.h
+Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
+Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.h
 Source/Sentry/Private/GenericPlatform/GenericPlatformSentryBreadcrumb.cpp
 Source/Sentry/Private/GenericPlatform/GenericPlatformSentryBreadcrumb.h
 Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.cpp
@@ -137,6 +139,8 @@ Source/Sentry/Private/Linux/LinuxSentryUser.h
 Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
 Source/Sentry/Private/Mac/MacSentrySubsystem.h
 Source/Sentry/Private/Mac/MacSentryUser.h
+Source/Sentry/Private/Microsoft/MicrosoftSentryScope.cpp
+Source/Sentry/Private/Microsoft/MicrosoftSentryScope.h
 Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
 Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
 Source/Sentry/Private/Null/NullSentryAttachment.h


### PR DESCRIPTION
This PR adopts changes introduced in Native SDK version [0.9.1](https://github.com/getsentry/sentry-native/releases/tag/0.9.1) to enable runtime attachments on Windows and Linux.

Attachments can now be added to all outgoing events by setting them via `USentrySubsystem` on the global scope or to individual events by adding them to a local scope, i.e. when capturing with `CaptureEventWithScope`.

On Apple/Android, removing individual attachments from the global scope currently is not supported. However, on these platforms the corresponding SDKs provide `clearAttachments` which is not available in `sentry-native` at the moment.

Closes #430
Closes #946