### PR TITLE
Add stub for configuring network connect function on Switch

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -295,6 +295,7 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 	ConfigureHandlerPath(options);
 	ConfigureDatabasePath(options);
 	ConfigureCertsPath(options);
+	ConfigureNetworkConnectFunc(options);
 
 	sentry_options_set_release(options, TCHAR_TO_ANSI(settings->OverrideReleaseName ? *settings->Release : *settings->GetFormattedReleaseName()));
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -65,6 +65,7 @@ protected:
 	virtual void ConfigureLogFileAttachment(sentry_options_t* Options) {}
 	virtual void ConfigureScreenshotAttachment(sentry_options_t* Options) {}
 	virtual void ConfigureGpuDumpAttachment(sentry_options_t* Options) {}
+	virtual void ConfigureNetworkConnectFunc(sentry_options_t* Options) {}
 
 	FString GetHandlerPath() const;
 	FString GetDatabasePath() const;


### PR DESCRIPTION
This PR adds `ConfigureNetworkConnectFunc` stub which is required for network access configuration in Switch plugin extension. 

#skip-changelog