### PR TITLE
Use `sentry-cocoa` as dynamic lib on Mac

### DIFF
--- a/plugin-dev/Sentry.uplugin
+++ b/plugin-dev/Sentry.uplugin
@@ -31,6 +31,7 @@
 	"PostBuildSteps":
 	{
 		"Mac": [
+			"if [ $(TargetPlatform) = \"Mac\" ] && [ ! -f \"$(PluginDir)/Binaries/Mac/sentry.dylib\" ]; then\n cp \"$(PluginDir)/Source/ThirdParty/Mac/bin/sentry.dylib\" \"$(PluginDir)/Binaries/Mac/sentry.dylib\"\nfi",
 			"if [ -f \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" ]; then\n \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" $(TargetPlatform) $(TargetName) $(TargetType) $(TargetConfiguration) \"$(ProjectDir)\" \"$(PluginDir)\"\nelse\n echo \"Sentry: Symbol upload script is missing. Skipping post build step.\"\nfi"
 		],
 		"Linux": [

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryAttachment.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryAttachment.cpp
@@ -5,17 +5,18 @@
 #include "Infrastructure/AppleSentryConverters.h"
 
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 FAppleSentryAttachment::FAppleSentryAttachment(const TArray<uint8>& data, const FString& filename, const FString& contentType)
 {
-	AttachmentApple = [[SentryAttachment alloc] initWithData:FAppleSentryConverters::ByteDataToNative(data)
+	AttachmentApple = [[SENTRY_APPLE_CLASS(SentryAttachment) alloc] initWithData:FAppleSentryConverters::ByteDataToNative(data)
 													filename:filename.GetNSString()
 												 contentType:contentType.GetNSString()];
 }
 
 FAppleSentryAttachment::FAppleSentryAttachment(const FString& path, const FString& filename, const FString& contentType)
 {
-	AttachmentApple = [[SentryAttachment alloc] initWithPath:path.GetNSString()
+	AttachmentApple = [[SENTRY_APPLE_CLASS(SentryAttachment) alloc] initWithPath:path.GetNSString()
 													filename:filename.GetNSString()
 												 contentType:contentType.GetNSString()];
 }

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryAttachment.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryAttachment.cpp
@@ -10,15 +10,15 @@
 FAppleSentryAttachment::FAppleSentryAttachment(const TArray<uint8>& data, const FString& filename, const FString& contentType)
 {
 	AttachmentApple = [[SENTRY_APPLE_CLASS(SentryAttachment) alloc] initWithData:FAppleSentryConverters::ByteDataToNative(data)
-													filename:filename.GetNSString()
-												 contentType:contentType.GetNSString()];
+																		filename:filename.GetNSString()
+																	 contentType:contentType.GetNSString()];
 }
 
 FAppleSentryAttachment::FAppleSentryAttachment(const FString& path, const FString& filename, const FString& contentType)
 {
 	AttachmentApple = [[SENTRY_APPLE_CLASS(SentryAttachment) alloc] initWithPath:path.GetNSString()
-													filename:filename.GetNSString()
-												 contentType:contentType.GetNSString()];
+																		filename:filename.GetNSString()
+																	 contentType:contentType.GetNSString()];
 }
 
 FAppleSentryAttachment::~FAppleSentryAttachment()

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryBreadcrumb.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryBreadcrumb.cpp
@@ -5,10 +5,11 @@
 #include "Infrastructure/AppleSentryConverters.h"
 
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 FAppleSentryBreadcrumb::FAppleSentryBreadcrumb()
 {
-	BreadcrumbApple = [[SentryBreadcrumb alloc] init];
+	BreadcrumbApple = [[SENTRY_APPLE_CLASS(SentryBreadcrumb) alloc] init];
 }
 
 FAppleSentryBreadcrumb::FAppleSentryBreadcrumb(SentryBreadcrumb* breadcrumb)

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
@@ -36,7 +36,7 @@ TSharedPtr<ISentryId> FAppleSentryEvent::GetId() const
 
 void FAppleSentryEvent::SetMessage(const FString& message)
 {
-	SentryMessage* msg = [SentryMessage alloc];
+	SentryMessage* msg = [SENTRY_APPLE_CLASS(SentryMessage) alloc];
 	msg.message = message.GetNSString();
 	EventApple.message = msg;
 }

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
@@ -6,10 +6,11 @@
 #include "Infrastructure/AppleSentryConverters.h"
 
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 FAppleSentryEvent::FAppleSentryEvent()
 {
-	EventApple = [[SentryEvent alloc] init];
+	EventApple = [[SENTRY_APPLE_CLASS(SentryEvent) alloc] init];
 }
 
 FAppleSentryEvent::FAppleSentryEvent(SentryEvent* event)

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryId.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryId.cpp
@@ -3,15 +3,24 @@
 #include "AppleSentryId.h"
 
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 FAppleSentryId::FAppleSentryId()
 {
-	IdApple = [[SentryId alloc] init];
+#if PLATFORM_MAC
+	IdApple = [[SENTRY_APPLE_CLASS(_TtC6Sentry8SentryId) alloc] init];
+#elif PLATFORM_IOS
+	IdApple = [[SENTRY_APPLE_CLASS(SentryId) alloc] init];
+#endif
 }
 
 FAppleSentryId::FAppleSentryId(const FString& id)
 {
-	IdApple = [[SentryId alloc] initWithUUIDString:id.GetNSString()];
+#if PLATFORM_MAC
+	IdApple = [[SENTRY_APPLE_CLASS(_TtC6Sentry8SentryId) alloc] initWithUUIDString:id.GetNSString()];
+#elif PLATFORM_IOS
+	IdApple = [[SENTRY_APPLE_CLASS(SentryId) alloc] initWithUUIDString:id.GetNSString()];
+#endif
 }
 
 FAppleSentryId::FAppleSentryId(SentryId* id)

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryScope.cpp
@@ -8,10 +8,11 @@
 #include "Infrastructure/AppleSentryConverters.h"
 
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 FAppleSentryScope::FAppleSentryScope()
 {
-	ScopeApple = [[SentryScope alloc] init];
+	ScopeApple = [[SENTRY_APPLE_CLASS(SentryScope) alloc] init];
 }
 
 FAppleSentryScope::FAppleSentryScope(SentryScope* scope)

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -44,12 +44,12 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, US
 	isScreenshotAttachmentEnabled = settings->AttachScreenshot;
 	isGameLogAttachmentEnabled = settings->EnableAutoLogAttachment;
 
-	[PrivateSentrySDKOnly setSdkName:@"sentry.cocoa.unreal"];
+	[SENTRY_APPLE_CLASS(PrivateSentrySDKOnly) setSdkName:@"sentry.cocoa.unreal"];
 
 	dispatch_group_t sentryDispatchGroup = dispatch_group_create();
 	dispatch_group_enter(sentryDispatchGroup);
 	dispatch_async(dispatch_get_main_queue(), ^{
-		[SentrySDK startWithConfigureOptions:^(SentryOptions* options) {
+		[SENTRY_APPLE_CLASS(SentrySDK) startWithConfigureOptions:^(SentryOptions* options) {
 			options.dsn = settings->GetEffectiveDsn().GetNSString();
 			options.environment = settings->Environment.GetNSString();
 			options.dist = settings->Dist.GetNSString();
@@ -162,24 +162,24 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, US
 
 void FAppleSentrySubsystem::Close()
 {
-	[SentrySDK close];
+	[SENTRY_APPLE_CLASS(SentrySDK) close];
 }
 
 bool FAppleSentrySubsystem::IsEnabled()
 {
-	return [SentrySDK isEnabled];
+	return [SENTRY_APPLE_CLASS(SentrySDK) isEnabled];
 }
 
 ESentryCrashedLastRun FAppleSentrySubsystem::IsCrashedLastRun()
 {
-	return [SentrySDK crashedLastRun] ? ESentryCrashedLastRun::Crashed : ESentryCrashedLastRun::NotCrashed;
+	return [SENTRY_APPLE_CLASS(SentrySDK) crashedLastRun] ? ESentryCrashedLastRun::Crashed : ESentryCrashedLastRun::NotCrashed;
 }
 
 void FAppleSentrySubsystem::AddBreadcrumb(TSharedPtr<ISentryBreadcrumb> breadcrumb)
 {
 	TSharedPtr<FAppleSentryBreadcrumb> breadcrumbIOS = StaticCastSharedPtr<FAppleSentryBreadcrumb>(breadcrumb);
 
-	[SentrySDK addBreadcrumb:breadcrumbIOS->GetNativeObject()];
+	[SENTRY_APPLE_CLASS(SentrySDK) addBreadcrumb:breadcrumbIOS->GetNativeObject()];
 }
 
 void FAppleSentrySubsystem::AddBreadcrumbWithParams(const FString& Message, const FString& Category, const FString& Type, const TMap<FString, FSentryVariant>& Data, ESentryLevel Level)
@@ -191,12 +191,12 @@ void FAppleSentrySubsystem::AddBreadcrumbWithParams(const FString& Message, cons
 	breadcrumbIOS->SetData(Data);
 	breadcrumbIOS->SetLevel(Level);
 
-	[SentrySDK addBreadcrumb:breadcrumbIOS->GetNativeObject()];
+	[SENTRY_APPLE_CLASS(SentrySDK) addBreadcrumb:breadcrumbIOS->GetNativeObject()];
 }
 
 void FAppleSentrySubsystem::ClearBreadcrumbs()
 {
-	[SentrySDK configureScope:^(SentryScope* scope) {
+	[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
 		[scope clearBreadcrumbs];
 	}];
 }
@@ -205,7 +205,7 @@ void FAppleSentrySubsystem::AddAttachment(TSharedPtr<ISentryAttachment> attachme
 {
 	TSharedPtr<FAppleSentryAttachment> attachmentApple = StaticCastSharedPtr<FAppleSentryAttachment>(attachment);
 
-	[SentrySDK configureScope:^(SentryScope* scope) {
+	[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
 		[scope addAttachment:attachmentApple->GetNativeObject()];
 	}];
 }
@@ -217,7 +217,7 @@ void FAppleSentrySubsystem::RemoveAttachment(TSharedPtr<ISentryAttachment> attac
 
 void FAppleSentrySubsystem::ClearAttachments()
 {
-	[SentrySDK configureScope:^(SentryScope* scope) {
+	[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
 		[scope clearAttachments];
 	}];
 }
@@ -230,7 +230,7 @@ TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureMessage(const FString& messa
 
 TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureMessageWithScope(const FString& message, ESentryLevel level, const FSentryScopeDelegate& onConfigureScope)
 {
-	SentryId* nativeId = [SentrySDK captureMessage:message.GetNSString() withScopeBlock:^(SentryScope* scope) {
+	SentryId* nativeId = [SENTRY_APPLE_CLASS(SentrySDK) captureMessage:message.GetNSString() withScopeBlock:^(SentryScope* scope) {
 		[scope setLevel:FAppleSentryConverters::SentryLevelToNative(level)];
 		onConfigureScope.ExecuteIfBound(MakeShareable(new FAppleSentryScope(scope)));
 	}];
@@ -255,7 +255,7 @@ TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureEventWithScope(TSharedPtr<IS
 {
 	TSharedPtr<FAppleSentryEvent> eventApple = StaticCastSharedPtr<FAppleSentryEvent>(event);
 
-	SentryId* nativeId = [SentrySDK captureEvent:eventApple->GetNativeObject() withScopeBlock:^(SentryScope* scope) {
+	SentryId* nativeId = [SENTRY_APPLE_CLASS(SentrySDK) captureEvent:eventApple->GetNativeObject() withScopeBlock:^(SentryScope* scope) {
 		onConfigureScope.ExecuteIfBound(MakeShareable(new FAppleSentryScope(scope)));
 	}];
 
@@ -278,7 +278,7 @@ TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureEnsure(const FString& type, 
 	SentryEvent* exceptionEvent = [[SENTRY_APPLE_CLASS(SentryEvent) alloc] init];
 	exceptionEvent.exceptions = nativeExceptionArray;
 
-	SentryId* nativeId = [SentrySDK captureEvent:exceptionEvent];
+	SentryId* nativeId = [SENTRY_APPLE_CLASS(SentrySDK) captureEvent:exceptionEvent];
 
 	TSharedPtr<ISentryId> id = MakeShareable(new FAppleSentryId(nativeId));
 
@@ -294,62 +294,62 @@ void FAppleSentrySubsystem::CaptureUserFeedback(TSharedPtr<ISentryUserFeedback> 
 {
 	TSharedPtr<FAppleSentryUserFeedback> userFeedbackIOS = StaticCastSharedPtr<FAppleSentryUserFeedback>(userFeedback);
 
-	[SentrySDK captureFeedback:userFeedbackIOS->GetNativeObject()];
+	[SENTRY_APPLE_CLASS(SentrySDK) captureFeedback:userFeedbackIOS->GetNativeObject()];
 }
 
 void FAppleSentrySubsystem::SetUser(TSharedPtr<ISentryUser> user)
 {
 	TSharedPtr<FAppleSentryUser> userIOS = StaticCastSharedPtr<FAppleSentryUser>(user);
 
-	[SentrySDK setUser:userIOS->GetNativeObject()];
+	[SENTRY_APPLE_CLASS(SentrySDK) setUser:userIOS->GetNativeObject()];
 }
 
 void FAppleSentrySubsystem::RemoveUser()
 {
-	[SentrySDK setUser:nil];
+	[SENTRY_APPLE_CLASS(SentrySDK) setUser:nil];
 }
 
 void FAppleSentrySubsystem::SetContext(const FString& key, const TMap<FString, FSentryVariant>& values)
 {
-	[SentrySDK configureScope:^(SentryScope* scope) {
+	[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
 		[scope setContextValue:FAppleSentryConverters::VariantMapToNative(values) forKey:key.GetNSString()];
 	}];
 }
 
 void FAppleSentrySubsystem::SetTag(const FString& key, const FString& value)
 {
-	[SentrySDK configureScope:^(SentryScope* scope) {
+	[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
 		[scope setTagValue:value.GetNSString() forKey:key.GetNSString()];
 	}];
 }
 
 void FAppleSentrySubsystem::RemoveTag(const FString& key)
 {
-	[SentrySDK configureScope:^(SentryScope* scope) {
+	[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
 		[scope removeTagForKey:key.GetNSString()];
 	}];
 }
 
 void FAppleSentrySubsystem::SetLevel(ESentryLevel level)
 {
-	[SentrySDK configureScope:^(SentryScope* scope) {
+	[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
 		[scope setLevel:FAppleSentryConverters::SentryLevelToNative(level)];
 	}];
 }
 
 void FAppleSentrySubsystem::StartSession()
 {
-	[SentrySDK startSession];
+	[SENTRY_APPLE_CLASS(SentrySDK) startSession];
 }
 
 void FAppleSentrySubsystem::EndSession()
 {
-	[SentrySDK endSession];
+	[SENTRY_APPLE_CLASS(SentrySDK) endSession];
 }
 
 TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransaction(const FString& name, const FString& operation)
 {
-	id<SentrySpan> transaction = [SentrySDK startTransactionWithName:name.GetNSString() operation:operation.GetNSString()];
+	id<SentrySpan> transaction = [SENTRY_APPLE_CLASS(SentrySDK) startTransactionWithName:name.GetNSString() operation:operation.GetNSString()];
 
 	return MakeShareable(new FAppleSentryTransaction(transaction));
 }
@@ -358,7 +358,7 @@ TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransactionWithContex
 {
 	TSharedPtr<FAppleSentryTransactionContext> transactionContextIOS = StaticCastSharedPtr<FAppleSentryTransactionContext>(context);
 
-	id<SentrySpan> transaction = [SentrySDK startTransactionWithContext:transactionContextIOS->GetNativeObject()];
+	id<SentrySpan> transaction = [SENTRY_APPLE_CLASS(SentrySDK) startTransactionWithContext:transactionContextIOS->GetNativeObject()];
 
 	return MakeShareable(new FAppleSentryTransaction(transaction));
 }
@@ -373,7 +373,7 @@ TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransactionWithContex
 {
 	TSharedPtr<FAppleSentryTransactionContext> transactionContextIOS = StaticCastSharedPtr<FAppleSentryTransactionContext>(context);
 
-	id<SentrySpan> transaction = [SentrySDK startTransactionWithContext:transactionContextIOS->GetNativeObject()
+	id<SentrySpan> transaction = [SENTRY_APPLE_CLASS(SentrySDK) startTransactionWithContext:transactionContextIOS->GetNativeObject()
 												  customSamplingContext:FAppleSentryConverters::StringMapToNative(options)];
 
 	return MakeShareable(new FAppleSentryTransaction(transaction));
@@ -427,7 +427,7 @@ void FAppleSentrySubsystem::UploadAttachmentForEvent(TSharedPtr<ISentryId> event
 
 	SentryAttachment* attachment = [[SENTRY_APPLE_CLASS(SentryAttachment) alloc] initWithPath:filePathExt.GetNSString() filename:name.GetNSString()];
 
-	SentryOptions* options = [PrivateSentrySDKOnly options];
+	SentryOptions* options = [SENTRY_APPLE_CLASS(PrivateSentrySDKOnly) options];
 	int32 size = options.maxAttachmentSize;
 
 	SentryEnvelopeItem* envelopeItem = [[SENTRY_APPLE_CLASS(SentryEnvelopeItem) alloc] initWithAttachment:attachment maxAttachmentSize:size];
@@ -436,7 +436,7 @@ void FAppleSentrySubsystem::UploadAttachmentForEvent(TSharedPtr<ISentryId> event
 
 	SentryEnvelope* envelope = [[SENTRY_APPLE_CLASS(SentryEnvelope) alloc] initWithId:id singleItem:envelopeItem];
 
-	[PrivateSentrySDKOnly captureEnvelope:envelope];
+	[SENTRY_APPLE_CLASS(PrivateSentrySDKOnly) captureEnvelope:envelope];
 
 	if (deleteAfterUpload)
 	{

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -374,7 +374,7 @@ TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransactionWithContex
 	TSharedPtr<FAppleSentryTransactionContext> transactionContextIOS = StaticCastSharedPtr<FAppleSentryTransactionContext>(context);
 
 	id<SentrySpan> transaction = [SENTRY_APPLE_CLASS(SentrySDK) startTransactionWithContext:transactionContextIOS->GetNativeObject()
-												  customSamplingContext:FAppleSentryConverters::StringMapToNative(options)];
+																	  customSamplingContext:FAppleSentryConverters::StringMapToNative(options)];
 
 	return MakeShareable(new FAppleSentryTransaction(transaction));
 }

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -8,11 +8,11 @@
 #include "AppleSentryId.h"
 #include "AppleSentrySamplingContext.h"
 #include "AppleSentryScope.h"
-#include "Convenience/AppleSentryMacro.h"
 #include "AppleSentryTransaction.h"
 #include "AppleSentryTransactionContext.h"
 #include "AppleSentryUser.h"
 #include "AppleSentryUserFeedback.h"
+#include "Convenience/AppleSentryMacro.h"
 
 #include "SentryBeforeBreadcrumbHandler.h"
 #include "SentryBeforeSendHandler.h"
@@ -402,12 +402,12 @@ TSharedPtr<ISentryTransactionContext> FAppleSentrySubsystem::ContinueTrace(const
 #endif
 
 	SentryTransactionContext* transactionContext = [[SENTRY_APPLE_CLASS(SentryTransactionContext) alloc] initWithName:@"<unlabeled transaction>" operation:@"default"
-																						  traceId:traceId
-																						   spanId:[[SENTRY_APPLE_CLASS(SentrySpanId) alloc] init]
-																					 parentSpanId:[[SENTRY_APPLE_CLASS(SentrySpanId) alloc] initWithValue:traceParts[1].GetNSString()]
-																					parentSampled:sampleDecision
-																				 parentSampleRate:nil
-																				 parentSampleRand:nil];
+																											  traceId:traceId
+																											   spanId:[[SENTRY_APPLE_CLASS(SentrySpanId) alloc] init]
+																										 parentSpanId:[[SENTRY_APPLE_CLASS(SentrySpanId) alloc] initWithValue:traceParts[1].GetNSString()]
+																										parentSampled:sampleDecision
+																									 parentSampleRate:nil
+																									 parentSampleRand:nil];
 
 	// currently `sentry-cocoa` doesn't have API for `SentryTransactionContext` to set `baggageHeaders`
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransactionContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransactionContext.cpp
@@ -3,10 +3,11 @@
 #include "AppleSentryTransactionContext.h"
 
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 FAppleSentryTransactionContext::FAppleSentryTransactionContext(const FString& name, const FString& operation)
 {
-	TransactionContext = [[SentryTransactionContext alloc] initWithName:name.GetNSString() operation:operation.GetNSString()];
+	TransactionContext = [[SENTRY_APPLE_CLASS(SentryTransactionContext) alloc] initWithName:name.GetNSString() operation:operation.GetNSString()];
 }
 
 FAppleSentryTransactionContext::FAppleSentryTransactionContext(SentryTransactionContext* context)

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUser.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUser.cpp
@@ -5,10 +5,11 @@
 #include "Infrastructure/AppleSentryConverters.h"
 
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 FAppleSentryUser::FAppleSentryUser()
 {
-	UserApple = [[SentryUser alloc] init];
+	UserApple = [[SENTRY_APPLE_CLASS(SentryUser) alloc] init];
 }
 
 FAppleSentryUser::FAppleSentryUser(SentryUser* user)

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUserFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUserFeedback.cpp
@@ -14,18 +14,18 @@ FAppleSentryUserFeedback::FAppleSentryUserFeedback(TSharedPtr<ISentryId> eventId
 
 #if PLATFORM_MAC
 	UserFeedbackApple = [[SENTRY_APPLE_CLASS(_TtC6Sentry12SentryFeedback) alloc] initWithMessage:@""
-														   name:nil
-														  email:nil
-														 source:SentryFeedbackSourceCustom
-											  associatedEventId:id
-													attachments:nil];
+																							name:nil
+																						   email:nil
+																						  source:SentryFeedbackSourceCustom
+																			   associatedEventId:id
+																					 attachments:nil];
 #elif PLATFORM_IOS
 	UserFeedbackApple = [[SENTRY_APPLE_CLASS(SentryFeedback) alloc] initWithMessage:@""
-														   name:nil
-														  email:nil
-														 source:SentryFeedbackSourceCustom
-											  associatedEventId:id
-													attachments:nil];
+																			   name:nil
+																			  email:nil
+																			 source:SentryFeedbackSourceCustom
+																  associatedEventId:id
+																		attachments:nil];
 #endif
 }
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUserFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUserFeedback.cpp
@@ -13,7 +13,7 @@ FAppleSentryUserFeedback::FAppleSentryUserFeedback(TSharedPtr<ISentryId> eventId
 	SentryId* id = idIOS->GetNativeObject();
 
 #if PLATFORM_MAC
-	UserFeedbackApple = [[SENTRY_APPLE_CLASS(_TtC6Sentry12SentryFeedback) alloc] initWithMessage:@""
+	UserFeedbackApple = [[SENTRY_APPLE_CLASS(_TtC6Sentry14SentryFeedback) alloc] initWithMessage:@""
 																							name:nil
 																						   email:nil
 																						  source:SentryFeedbackSourceCustom

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUserFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryUserFeedback.cpp
@@ -5,18 +5,28 @@
 #include "AppleSentryId.h"
 
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 FAppleSentryUserFeedback::FAppleSentryUserFeedback(TSharedPtr<ISentryId> eventId)
 {
 	TSharedPtr<FAppleSentryId> idIOS = StaticCastSharedPtr<FAppleSentryId>(eventId);
 	SentryId* id = idIOS->GetNativeObject();
 
-	UserFeedbackApple = [[SentryFeedback alloc] initWithMessage:@""
+#if PLATFORM_MAC
+	UserFeedbackApple = [[SENTRY_APPLE_CLASS(_TtC6Sentry12SentryFeedback) alloc] initWithMessage:@""
 														   name:nil
 														  email:nil
 														 source:SentryFeedbackSourceCustom
 											  associatedEventId:id
 													attachments:nil];
+#elif PLATFORM_IOS
+	UserFeedbackApple = [[SENTRY_APPLE_CLASS(SentryFeedback) alloc] initWithMessage:@""
+														   name:nil
+														  email:nil
+														 source:SentryFeedbackSourceCustom
+											  associatedEventId:id
+													attachments:nil];
+#endif
 }
 
 FAppleSentryUserFeedback::~FAppleSentryUserFeedback()

--- a/plugin-dev/Source/Sentry/Private/Apple/Convenience/AppleSentryMacro.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/Convenience/AppleSentryMacro.h
@@ -1,0 +1,13 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
+#pragma once
+
+#include "SentryModule.h"
+
+#if PLATFORM_MAC
+	#define SENTRY_APPLE_CLASS(Name) \
+		(__bridge Class)dlsym(FSentryModule::Get().GetSentryLibHandle(), "OBJC_CLASS_$_" #Name)
+#elif PLATFORM_IOS
+	#define SENTRY_APPLE_CLASS(Name) \
+		Name
+#endif

--- a/plugin-dev/Source/Sentry/Private/Apple/Convenience/AppleSentryMacro.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/Convenience/AppleSentryMacro.h
@@ -4,10 +4,14 @@
 
 #include "SentryModule.h"
 
+// clang-format off
+
 #if PLATFORM_MAC
 	#define SENTRY_APPLE_CLASS(Name) \
-		(__bridge Class)dlsym(FSentryModule::Get().GetSentryLibHandle(), "OBJC_CLASS_$_" #Name)
+		(__bridge Class) dlsym(FSentryModule::Get().GetSentryLibHandle(), "OBJC_CLASS_$_" #Name)
 #elif PLATFORM_IOS
 	#define SENTRY_APPLE_CLASS(Name) \
 		Name
 #endif
+
+// clang-format on

--- a/plugin-dev/Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.cpp
@@ -5,6 +5,7 @@
 #include "SentryDefines.h"
 
 #include "Apple/AppleSentryScope.h"
+#include "Apple/Convenience/AppleSentryMacro.h"
 
 SentryLevel FAppleSentryConverters::SentryLevelToNative(ESentryLevel level)
 {
@@ -116,12 +117,12 @@ SentryStacktrace* FAppleSentryConverters::CallstackToNative(const TArray<FProgra
 
 	for (int i = 0; i < framesCount; ++i)
 	{
-		SentryFrame* frame = [[SentryFrame alloc] init];
+		SentryFrame* frame = [[SENTRY_APPLE_CLASS(SentryFrame) alloc] init];
 		frame.instructionAddress = FString::Printf(TEXT("0x%llx"), callstack[framesCount - i - 1].ProgramCounter).GetNSString();
 		[arr addObject:frame];
 	}
 
-	SentryStacktrace* trace = [[SentryStacktrace alloc] initWithFrames:arr registers:@{}];
+	SentryStacktrace* trace = [[SENTRY_APPLE_CLASS(SentryStacktrace) alloc] initWithFrames:arr registers:@{}];
 
 	return trace;
 }

--- a/plugin-dev/Source/Sentry/Private/SentryModule.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryModule.cpp
@@ -10,6 +10,7 @@
 #include "Modules/ModuleManager.h"
 #include "UObject/Package.h"
 #include "UObject/UObjectGlobals.h"
+#include "HAL/PlatformProcess.h"
 
 #define LOCTEXT_NAMESPACE "FSentryModule"
 
@@ -22,6 +23,17 @@ void FSentryModule::StartupModule()
 	// This code will execute after your module is loaded into memory; the exact timing is specified in the .uplugin file per-module
 	SentrySettings = NewObject<USentrySettings>(GetTransientPackage(), "SentrySettings", RF_Standalone);
 	SentrySettings->AddToRoot();
+
+#if PLATFORM_MAC
+	// Load Sentry Cocoa dynamic library
+	FString LibraryPath = FPaths::Combine(GetBinariesPath(), TEXT("sentry.dylib"));
+	mDllHandleSentry = FPlatformProcess::GetDllHandle(*LibraryPath);
+
+	if (!mDllHandleSentry)
+	{
+		UE_LOG(LogSentrySdk, Error, TEXT("Failed to load sentry.dylib from %s"), *LibraryPath);
+	}
+#endif
 
 	if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
 	{
@@ -36,6 +48,15 @@ void FSentryModule::ShutdownModule()
 {
 	// This function may be called during shutdown to clean up your module.  For modules that support dynamic reloading,
 	// we call this function before unloading the module.
+
+#if PLATFORM_MAC
+	// Free sentry dynamic library
+	if (mDllHandleSentry)
+	{
+		FPlatformProcess::FreeDllHandle(mDllHandleSentry);
+		mDllHandleSentry = nullptr;
+	}
+#endif
 
 	if (ISettingsModule* SettingsModule = FModuleManager::GetModulePtr<ISettingsModule>("Settings"))
 	{
@@ -98,6 +119,13 @@ bool FSentryModule::IsMarketplaceVersion()
 {
 	return IsMarketplace;
 }
+
+#if PLATFORM_MAC
+void* FSentryModule::GetSentryLibHandle() const
+{
+	return mDllHandleSentry;
+}
+#endif
 
 #undef LOCTEXT_NAMESPACE
 

--- a/plugin-dev/Source/Sentry/Private/SentryModule.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryModule.cpp
@@ -5,12 +5,12 @@
 #include "SentrySettings.h"
 
 #include "Developer/Settings/Public/ISettingsModule.h"
+#include "HAL/PlatformProcess.h"
 #include "Interfaces/IPluginManager.h"
 #include "Misc/Paths.h"
 #include "Modules/ModuleManager.h"
 #include "UObject/Package.h"
 #include "UObject/UObjectGlobals.h"
-#include "HAL/PlatformProcess.h"
 
 #define LOCTEXT_NAMESPACE "FSentryModule"
 

--- a/plugin-dev/Source/Sentry/Public/SentryModule.h
+++ b/plugin-dev/Source/Sentry/Public/SentryModule.h
@@ -44,10 +44,19 @@ public:
 	/** Gets flag indicating whether plugin was downloaded from UE Marketplace. */
 	static bool IsMarketplaceVersion();
 
+#if PLATFORM_MAC
+	/** Gets handle to dynamically loaded sentry library. */
+	void* GetSentryLibHandle() const;
+#endif
+
 	static const FName ModuleName;
 
 	static const bool IsMarketplace;
 
 private:
 	USentrySettings* SentrySettings = nullptr;
+
+#if PLATFORM_MAC
+	void* mDllHandleSentry = nullptr;
+#endif
 };

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -67,17 +67,7 @@ public class Sentry : ModuleRules
 
 			PublicIncludePaths.Add(Path.Combine(PlatformThirdPartyPath, "include"));
 
-			PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, "lib", "libsentry.a"));
-
-			string XcodeRoot = Utils.RunLocalProcessAndReturnStdOut("/usr/bin/xcode-select", "--print-path");
-			string SwiftStandardLibrariesPath = Path.Combine(XcodeRoot, "Toolchains", "XcodeDefault.xctoolchain", "usr", "lib", "swift", "macosx");
-
-			PublicSystemLibraries.Add(Path.Combine(SwiftStandardLibrariesPath, "libswiftCompatibility50.a"));
-			PublicSystemLibraries.Add(Path.Combine(SwiftStandardLibrariesPath, "libswiftCompatibility51.a"));
-			PublicSystemLibraries.Add(Path.Combine(SwiftStandardLibrariesPath, "libswiftCompatibility56.a"));
-			PublicSystemLibraries.Add(Path.Combine(SwiftStandardLibrariesPath, "libswiftCompatibilityConcurrency.a"));
-			PublicSystemLibraries.Add(Path.Combine(SwiftStandardLibrariesPath, "libswiftCompatibilityDynamicReplacements.a"));
-			PublicSystemLibraries.Add(Path.Combine(SwiftStandardLibrariesPath, "libswiftCompatibilityPacks.a"));
+			RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "sentry.dylib"), Path.Combine(PlatformThirdPartyPath, "bin", "sentry.dylib"));
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=0");
 			PublicDefinitions.Add("COCOAPODS=0");

--- a/scripts/download-cocoa.sh
+++ b/scripts/download-cocoa.sh
@@ -15,14 +15,13 @@ fi
 cocoaRepo=$(getProperty 'repo')
 cocoaVersion=$(getProperty 'version')
 
-# Prepare iOS artifacts
-
 cocoaDynamicFrameworkUrl="${cocoaRepo}/releases/download/${cocoaVersion}/Sentry-Dynamic.xcframework.zip"
 
 curl -L "${cocoaDynamicFrameworkUrl}" -o "${sentryCocoaCache}/Sentry-Dynamic.xcframework.zip"
 
 unzip -o "${sentryCocoaCache}/Sentry-Dynamic.xcframework.zip" -d "${sentryCocoaCache}/"
 
+# Prepare iOS artifacts
 if ! [ -d "$(dirname $sentryArtifactsDestination)/IOS" ]; then
     mkdir "$(dirname $sentryArtifactsDestination)/IOS"
 else
@@ -41,23 +40,16 @@ rm -rf "Sentry.embeddedframework"
 rm "Sentry.embeddedframework.zip"
 
 # Prepare Mac artifacts
-
-cocoaStaticFrameworkUrl="${cocoaRepo}/releases/download/${cocoaVersion}/Sentry.xcframework.zip"
-
-curl -L "${cocoaStaticFrameworkUrl}" -o "${sentryCocoaCache}/Sentry.xcframework.zip"
-
-unzip -o "${sentryCocoaCache}/Sentry.xcframework.zip" -d "${sentryCocoaCache}/"
-
 if ! [ -d "$(dirname $sentryArtifactsDestination)/Mac" ]; then
     mkdir "$(dirname $sentryArtifactsDestination)/Mac"
 else
     rm -rf "$(dirname $sentryArtifactsDestination)/Mac/"*
 fi
 
-mkdir "$(dirname $sentryArtifactsDestination)/Mac/lib"
+mkdir "$(dirname $sentryArtifactsDestination)/Mac/bin"
 mkdir "$(dirname $sentryArtifactsDestination)/Mac/include"
 
-cp "${sentryCocoaCache}/Sentry.xcframework/macos-arm64_arm64e_x86_64/Sentry.framework/Sentry" "$(dirname $sentryArtifactsDestination)/Mac/lib/libsentry.a"
+cp "${sentryCocoaCache}/Sentry-Dynamic.xcframework/macos-arm64_arm64e_x86_64/Sentry.framework/Sentry" "$(dirname $sentryArtifactsDestination)/Mac/bin/sentry.dylib"
 
-cp -rL "${sentryCocoaCache}/Sentry.xcframework/macos-arm64_arm64e_x86_64/Sentry.framework/Headers" "$(dirname $sentryArtifactsDestination)/Mac/include/Sentry"
-cp -rL "${sentryCocoaCache}/Sentry.xcframework/macos-arm64_arm64e_x86_64/Sentry.framework/PrivateHeaders/." "$(dirname $sentryArtifactsDestination)/Mac/include/Sentry"
+cp -rL "${sentryCocoaCache}/Sentry-Dynamic.xcframework/macos-arm64_arm64e_x86_64/Sentry.framework/Headers" "$(dirname $sentryArtifactsDestination)/Mac/include/Sentry"
+cp -rL "${sentryCocoaCache}/Sentry-Dynamic.xcframework/macos-arm64_arm64e_x86_64/Sentry.framework/PrivateHeaders/." "$(dirname $sentryArtifactsDestination)/Mac/include/Sentry"

--- a/scripts/packaging/package-github.snapshot
+++ b/scripts/packaging/package-github.snapshot
@@ -73,6 +73,7 @@ Source/Sentry/Private/Apple/AppleSentryUser.h
 Source/Sentry/Private/Apple/AppleSentryUserFeedback.cpp
 Source/Sentry/Private/Apple/AppleSentryUserFeedback.h
 Source/Sentry/Private/Apple/Convenience/AppleSentryInclude.h
+Source/Sentry/Private/Apple/Convenience/AppleSentryMacro.h
 Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.cpp
 Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.h
 Source/Sentry/Private/GenericPlatform/Convenience/GenericPlatformSentryInclude.h

--- a/scripts/packaging/package-github.snapshot
+++ b/scripts/packaging/package-github.snapshot
@@ -349,6 +349,7 @@ Source/ThirdParty/LinuxArm64/lib/libcrashpad_tools.a
 Source/ThirdParty/LinuxArm64/lib/libcrashpad_util.a
 Source/ThirdParty/LinuxArm64/lib/libmini_chromium.a
 Source/ThirdParty/LinuxArm64/lib/libsentry.a
+Source/ThirdParty/Mac/bin/sentry.dylib
 Source/ThirdParty/Mac/include/Sentry/PrivateSentrySDKOnly.h
 Source/ThirdParty/Mac/include/Sentry/PrivatesHeader.h
 Source/ThirdParty/Mac/include/Sentry/Sentry-Swift.h
@@ -428,7 +429,6 @@ Source/ThirdParty/Mac/include/Sentry/SentryTransactionContext.h
 Source/ThirdParty/Mac/include/Sentry/SentryUser.h
 Source/ThirdParty/Mac/include/Sentry/SentryUser+Private.h
 Source/ThirdParty/Mac/include/Sentry/SentryWithoutUIKit.h
-Source/ThirdParty/Mac/lib/libsentry.a
 Source/ThirdParty/Win64/Breakpad/include/sentry.h
 Source/ThirdParty/Win64/Breakpad/lib/breakpad_client.lib
 Source/ThirdParty/Win64/Breakpad/lib/sentry.lib

--- a/scripts/packaging/package-marketplace.snapshot
+++ b/scripts/packaging/package-marketplace.snapshot
@@ -72,6 +72,7 @@ Source/Sentry/Private/Apple/AppleSentryUser.h
 Source/Sentry/Private/Apple/AppleSentryUserFeedback.cpp
 Source/Sentry/Private/Apple/AppleSentryUserFeedback.h
 Source/Sentry/Private/Apple/Convenience/AppleSentryInclude.h
+Source/Sentry/Private/Apple/Convenience/AppleSentryMacro.h
 Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.cpp
 Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.h
 Source/Sentry/Private/GenericPlatform/Convenience/GenericPlatformSentryInclude.h

--- a/scripts/packaging/package-marketplace.snapshot
+++ b/scripts/packaging/package-marketplace.snapshot
@@ -347,6 +347,7 @@ Source/ThirdParty/LinuxArm64/lib/libcrashpad_tools.a
 Source/ThirdParty/LinuxArm64/lib/libcrashpad_util.a
 Source/ThirdParty/LinuxArm64/lib/libmini_chromium.a
 Source/ThirdParty/LinuxArm64/lib/libsentry.a
+Source/ThirdParty/Mac/bin/sentry.dylib
 Source/ThirdParty/Mac/include/Sentry/PrivateSentrySDKOnly.h
 Source/ThirdParty/Mac/include/Sentry/PrivatesHeader.h
 Source/ThirdParty/Mac/include/Sentry/Sentry-Swift.h
@@ -426,7 +427,6 @@ Source/ThirdParty/Mac/include/Sentry/SentryTransactionContext.h
 Source/ThirdParty/Mac/include/Sentry/SentryUser.h
 Source/ThirdParty/Mac/include/Sentry/SentryUser+Private.h
 Source/ThirdParty/Mac/include/Sentry/SentryWithoutUIKit.h
-Source/ThirdParty/Mac/lib/libsentry.a
 Source/ThirdParty/Win64/Breakpad/include/sentry.h
 Source/ThirdParty/Win64/Breakpad/lib/breakpad_client.lib
 Source/ThirdParty/Win64/Breakpad/lib/sentry.lib


### PR DESCRIPTION
This effectively reverts the changes made in #902 to resolve issues with publishing the plugin to FAB.

Linking Cocoa as a static library introduces dependencies on Xcode-provided Swift libraries the availability of which can vary between Xcode versions. Since Epic builds the plugin for the three latest Unreal Engine versions (each using a different version of Xcode) it becomes difficult to maintain compatibility across the binaries we ship with the SDK.

Cocoa SDK itself appears to require a newer Xcode making it problematic to pre-build the corresponding library in CI using its older versions (e.g. UE 5.4 needs Xcode 14.2).

Related to #998

#skip-changelog