### PR TITLE
Add pre-build step to grant symbol upload script execute permission on Mac

### DIFF
--- a/plugin-dev/Sentry.uplugin
+++ b/plugin-dev/Sentry.uplugin
@@ -28,6 +28,12 @@
 			"WhitelistPlatforms": [ "Win64", "Mac", "Android", "IOS", "Linux", "LinuxArm64" ]
 		}
 	],
+	"PreBuildSteps":
+	{
+		"Mac": [
+			"if [ -f \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" ]; then\n chmod +x \"$(PluginDir)/Scripts/upload-debug-symbols.sh\" \nfi"
+		]
+	},
 	"PostBuildSteps":
 	{
 		"Mac": [


### PR DESCRIPTION
This fixes a missing `execute` permission on the symbol upload script for Mac which caused issues when submitting the plugin package to FAB. It appears that Epic alters file permissions during processing the package

A somewhat similar problem was addressed in [#834](https://github.com/getsentry/sentry-unreal/pull/834) (`download-artifact` action doesn't preserve file permissions).

Closes:
- https://github.com/getsentry/sentry-unreal/issues/998

#skip-changelog