### PR TITLE
Remove legacy settings check from `USentrySettings`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### Breaking Changes
 
-- On mobile platforms, the default traces sampler will no longer be created automatically if one is not explicitly configured in the plugin settings (`General -> Performance Monitoring`)
+- On mobile platforms, the default traces sampler will no longer be created automatically if one is not explicitly configured in the plugin settings (`General -> Performance Monitoring`).
+- If upgrading from a version prior to 0.9.0 legacy settings `DsnUrl`, `EnableVerboseLogging` and `EnableStackTrace` will no longer be read from the project configuration file automatically. Instead, you must re-set them in plugin settings to adopt the new format.
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySettings.cpp
@@ -51,8 +51,6 @@ USentrySettings::USentrySettings(const FObjectInitializer& ObjectInitializer)
 	{
 		LoadDebugSymbolsProperties();
 	}
-
-	CheckLegacySettings();
 }
 
 #if WITH_EDITOR
@@ -150,53 +148,5 @@ void USentrySettings::LoadDebugSymbolsProperties()
 		{
 			UE_LOG(LogSentrySdk, Warning, TEXT("Sentry plugin can't find sentry.properties file"));
 		}
-	}
-}
-
-void USentrySettings::CheckLegacySettings()
-{
-	bool IsSettingsDirty = false;
-
-	const FString SentrySection = TEXT("/Script/Sentry.SentrySettings");
-	const FString ConfigFilename = GetDefaultConfigFilename();
-
-	// Settings renamed in 0.9.0
-
-	const FString DsnLegacyKey = TEXT("DsnUrl");
-	FString DsnLegacyValue = TEXT("");
-	if (GConfig->GetString(*SentrySection, *DsnLegacyKey, DsnLegacyValue, *ConfigFilename))
-	{
-		Dsn = DsnLegacyValue;
-		GConfig->SetString(*SentrySection, TEXT("Dsn"), *Dsn, *ConfigFilename);
-		GConfig->RemoveKey(*SentrySection, *DsnLegacyKey, *ConfigFilename);
-		IsSettingsDirty = true;
-	}
-
-	const FString DebugLegacyKey = TEXT("EnableVerboseLogging");
-	bool DebugLegacyValue;
-	if (GConfig->GetBool(*SentrySection, *DebugLegacyKey, DebugLegacyValue, *ConfigFilename))
-	{
-		Debug = DebugLegacyValue;
-		GConfig->SetBool(*SentrySection, TEXT("Debug"), Debug, *ConfigFilename);
-		GConfig->RemoveKey(*SentrySection, *DebugLegacyKey, *ConfigFilename);
-		IsSettingsDirty = true;
-	}
-
-	const FString AttachStacktraceLegacyKey = TEXT("EnableStackTrace");
-	bool AttachStacktraceLegacyValue;
-	if (GConfig->GetBool(*SentrySection, *AttachStacktraceLegacyKey, AttachStacktraceLegacyValue, *ConfigFilename))
-	{
-		AttachStacktrace = AttachStacktraceLegacyValue;
-		GConfig->SetBool(*SentrySection, TEXT("AttachStacktrace"), AttachStacktrace, *ConfigFilename);
-		GConfig->RemoveKey(*SentrySection, *AttachStacktraceLegacyKey, *ConfigFilename);
-		IsSettingsDirty = true;
-	}
-
-	// Place newly renamed settings here specifying the release for which changes take place
-
-	if (IsSettingsDirty)
-	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Sentry settings were marked as dirty (if not checked out in Perforce these need to be updated manually)"));
-		GConfig->Flush(false, *ConfigFilename);
 	}
 }

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -388,7 +388,6 @@ private:
 	FString GetDefaultEnvironmentName();
 
 	void LoadDebugSymbolsProperties();
-	void CheckLegacySettings();
 
 	bool bIsDirty;
 };


### PR DESCRIPTION
Closes https://github.com/getsentry/sentry-unreal/issues/1006

#skip-changelog