### PR TITLE
Fix irrelevant screenshot being attached to captured crash event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - On mobile platforms, the default traces sampler will no longer be created automatically if one is not explicitly configured in the plugin settings (`General -> Performance Monitoring`).
 - If upgrading from a version prior to 0.9.0 legacy settings `DsnUrl`, `EnableVerboseLogging` and `EnableStackTrace` will no longer be read from the project configuration file automatically. Instead, you must re-set them in plugin settings to adopt the new format.
 
+### Fixes
+
+- Avoid irrelevant screenshot being attached to captured crash event ([#1019](https://github.com/getsentry/sentry-unreal/pull/1019))
+
 ### Dependencies
 
 - Bump CLI from v2.46.0 to v2.50.0 ([#989](https://github.com/getsentry/sentry-unreal/pull/989), [#1001](https://github.com/getsentry/sentry-unreal/pull/1001), [#1015](https://github.com/getsentry/sentry-unreal/pull/1015), [#1016](https://github.com/getsentry/sentry-unreal/pull/1016))

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -54,7 +54,7 @@ public:
 	USentryBeforeSendHandler* GetBeforeSendHandler();
 	USentryBeforeBreadcrumbHandler* GetBeforeBreadcrumbHandler();
 
-	void TryCaptureScreenshot() const;
+	void TryCaptureScreenshot();
 
 	FString GetGpuDumpBackupPath() const;
 
@@ -63,7 +63,6 @@ protected:
 	virtual void ConfigureDatabasePath(sentry_options_t* Options) {}
 	virtual void ConfigureCertsPath(sentry_options_t* Options) {}
 	virtual void ConfigureLogFileAttachment(sentry_options_t* Options) {}
-	virtual void ConfigureScreenshotAttachment(sentry_options_t* Options) {}
 	virtual void ConfigureGpuDumpAttachment(sentry_options_t* Options) {}
 	virtual void ConfigureNetworkConnectFunc(sentry_options_t* Options) {}
 

--- a/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.cpp
@@ -60,11 +60,6 @@ void FLinuxSentrySubsystem::ConfigureLogFileAttachment(sentry_options_t* Options
 	sentry_options_add_attachment(Options, TCHAR_TO_UTF8(*FPaths::ConvertRelativePathToFull(LogFilePath)));
 }
 
-void FLinuxSentrySubsystem::ConfigureScreenshotAttachment(sentry_options_t* Options)
-{
-	sentry_options_add_attachment(Options, TCHAR_TO_UTF8(*GetScreenshotPath()));
-}
-
 void FLinuxSentrySubsystem::ConfigureGpuDumpAttachment(sentry_options_t* Options)
 {
 	sentry_options_add_attachment(Options, TCHAR_TO_UTF8(*GetGpuDumpBackupPath()));

--- a/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Linux/LinuxSentrySubsystem.h
@@ -16,7 +16,6 @@ protected:
 	virtual void ConfigureDatabasePath(sentry_options_t* Options) override;
 	virtual void ConfigureCertsPath(sentry_options_t* Options) override;
 	virtual void ConfigureLogFileAttachment(sentry_options_t* Options) override;
-	virtual void ConfigureScreenshotAttachment(sentry_options_t* Options) override;
 	virtual void ConfigureGpuDumpAttachment(sentry_options_t* Options) override;
 
 	virtual FString GetHandlerExecutableName() const override { return TEXT("crashpad_handler"); }

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -64,11 +64,6 @@ void FMicrosoftSentrySubsystem::ConfigureLogFileAttachment(sentry_options_t* Opt
 	sentry_options_add_attachmentw(Options, *FPaths::ConvertRelativePathToFull(LogFilePath));
 }
 
-void FMicrosoftSentrySubsystem::ConfigureScreenshotAttachment(sentry_options_t* Options)
-{
-	sentry_options_add_attachmentw(Options, *GetScreenshotPath());
-}
-
 void FMicrosoftSentrySubsystem::AddFileAttachment(TSharedPtr<ISentryAttachment> attachment)
 {
 	TSharedPtr<FGenericPlatformSentryAttachment> platformAttachment = StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment);

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
@@ -17,7 +17,6 @@ protected:
 	virtual void ConfigureHandlerPath(sentry_options_t* Options) override;
 	virtual void ConfigureDatabasePath(sentry_options_t* Options) override;
 	virtual void ConfigureLogFileAttachment(sentry_options_t* Options) override;
-	virtual void ConfigureScreenshotAttachment(sentry_options_t* Options) override;
 
 	virtual void AddFileAttachment(TSharedPtr<ISentryAttachment> attachment) override;
 	virtual void AddByteAttachment(TSharedPtr<ISentryAttachment> attachment) override;


### PR DESCRIPTION
This PR fixes an issue where a screenshot from a previous app session could be incorrectly attached to a crash event in the current session. This occurred when screenshot capturing failed during the current session, leaving the old screenshot file in place.

Key changes:
- Screenshot attachments are now added during the `on_crash` hook handling instead of at initialization
- Cached screenshots are now cleared from disk at app startup to prevent stale data

Fixes https://github.com/getsentry/sentry-unreal/issues/1010