### PR TITLE
Fix build errors in FAB version of the plugin on Android/iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- The FAB version of the plugin builds successfully on Android and iOS ([#1027](https://github.com/getsentry/sentry-unreal/pull/1027))
+
 ## 1.0.0-beta.6
 
 ### Fixes

--- a/plugin-dev/Source/Sentry/Private/Android/Callbacks/AndroidSentryScopeCallback.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Callbacks/AndroidSentryScopeCallback.cpp
@@ -2,12 +2,9 @@
 
 #include "AndroidSentryScopeCallback.h"
 
-#include "HAL/CriticalSection.h"
-
 int64 AndroidSentryScopeCallback::NextDelegateID;
 TMap<int64, FSentryScopeDelegate> AndroidSentryScopeCallback::ScopeDelegates;
-
-FCriticalSection CriticalSection;
+FCriticalSection AndroidSentryScopeCallback::CriticalSection;
 
 int64 AndroidSentryScopeCallback::SaveDelegate(const FSentryScopeDelegate& onConfigure)
 {

--- a/plugin-dev/Source/Sentry/Private/Android/Callbacks/AndroidSentryScopeCallback.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Callbacks/AndroidSentryScopeCallback.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "HAL/CriticalSection.h"
 
 #include "Android/AndroidSentrySubsystem.h"
 
@@ -16,4 +17,5 @@ public:
 private:
 	static int64 NextDelegateID;
 	static TMap<int64, FSentryScopeDelegate> ScopeDelegates;
+	static FCriticalSection CriticalSection;
 };

--- a/plugin-dev/Source/Sentry/Private/IOS/IOSSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/IOS/IOSSentrySubsystem.cpp
@@ -2,8 +2,6 @@
 
 #include "IOS/IOSSentrySubsystem.h"
 
-#include "IOS/IOSAppDelegate.h"
-
 #include "SentryDefines.h"
 #include "SentrySettings.h"
 
@@ -14,6 +12,17 @@
 #include "Misc/CoreDelegates.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
+
+// In UE 5.5 and newer, PLATFORM_VISIONOS may be incorrectly set to true during iOS packaging
+// causing build errors due to engine's IOSAppDelegate.h including visionOS-specific headers.
+#pragma push_macro("PLATFORM_VISIONOS")
+
+#undef PLATFORM_VISIONOS
+#define PLATFORM_VISIONOS 0
+
+#include "IOS/IOSAppDelegate.h"
+
+#pragma pop_macro("PLATFORM_VISIONOS")
 
 static FIOSSentrySubsystem* GIOSSentrySubsystem = nullptr;
 


### PR DESCRIPTION
This PR addresses plugin packaging errors that were reported after FAB processed `1.0.0-beta.6` update.

Note: It looks that UE 5.5-5.6 incorrectly define `PLATFORM_VISIONOS` when packaging game/plugin for iOS causing build errors due to engine's [IOSAppDelegate.h](https://github.com/EpicGames/UnrealEngine/blob/2d6debb7180b196d7f36cd9f8fc4f787de9bab2c/Engine/Source/Runtime/ApplicationCore/Public/IOS/IOSAppDelegate.h) including visionOS-specific headers.

Closes #1026