### PR TITLE
Fix crashpad handler path configuration in FAB pluging version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- The FAB plugin version no longer opts out of Crashpad handler configuration ([#1028](https://github.com/getsentry/sentry-unreal/pull/1028))
+
 ## 1.0.0-beta.6
 
 ### Fixes

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -38,21 +38,6 @@ void FMicrosoftSentrySubsystem::InitWithSettings(const USentrySettings* Settings
 #endif
 }
 
-void FMicrosoftSentrySubsystem::ConfigureHandlerPath(sentry_options_t* Options)
-{
-	if (!FSentryModule::Get().IsMarketplaceVersion())
-	{
-		const FString HandlerPath = GetHandlerPath();
-
-		if (!FPaths::FileExists(HandlerPath))
-		{
-			UE_LOG(LogSentrySdk, Log, TEXT("Crashpad executable couldn't be found so Breakpad will be used instead. Please make sure that the plugin was rebuilt to avoid initialization failure."));
-		}
-
-		sentry_options_set_handler_pathw(Options, *HandlerPath);
-	}
-}
-
 void FMicrosoftSentrySubsystem::ConfigureDatabasePath(sentry_options_t* Options)
 {
 	sentry_options_set_database_pathw(Options, *GetDatabasePath());

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.h
@@ -14,7 +14,6 @@ public:
 	virtual void InitWithSettings(const USentrySettings* settings, USentryBeforeSendHandler* beforeSendHandler, USentryBeforeBreadcrumbHandler* beforeBreadcrumbHandler, USentryTraceSampler* traceSampler) override;
 
 protected:
-	virtual void ConfigureHandlerPath(sentry_options_t* Options) override;
 	virtual void ConfigureDatabasePath(sentry_options_t* Options) override;
 	virtual void ConfigureLogFileAttachment(sentry_options_t* Options) override;
 

--- a/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
@@ -7,6 +7,7 @@
 #include "SentryDefines.h"
 
 #include "Misc/OutputDeviceRedirector.h"
+#include "Misc/Paths.h"
 #include "Windows/Infrastructure/WindowsSentryConverters.h"
 #include "Windows/WindowsPlatformStackWalk.h"
 
@@ -55,6 +56,19 @@ static void PrintCrashLog(const sentry_ucontext_t* uctx)
 #endif // !UE_VERSION_OLDER_THAN(5, 6, 0)
 
 #endif // !UE_VERSION_OLDER_THAN(5, 0, 0)
+}
+
+void FWindowsSentrySubsystem::ConfigureHandlerPath(sentry_options_t* Options)
+{
+	const FString HandlerPath = GetHandlerPath();
+
+	if (!FPaths::FileExists(HandlerPath))
+	{
+		UE_LOG(LogSentrySdk, Log, TEXT("Crashpad executable couldn't be found so Breakpad will be used instead. Please make sure that the plugin was rebuilt to avoid initialization failure."));
+		return;
+	}
+
+	sentry_options_set_handler_pathw(Options, *HandlerPath);
 }
 
 sentry_value_t FWindowsSentrySubsystem::OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure)

--- a/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.h
@@ -9,6 +9,8 @@
 class FWindowsSentrySubsystem : public FMicrosoftSentrySubsystem
 {
 protected:
+	virtual void ConfigureHandlerPath(sentry_options_t* Options) override;
+
 	virtual FString GetHandlerExecutableName() const override { return TEXT("crashpad_handler.exe"); }
 
 	virtual sentry_value_t OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure) override;


### PR DESCRIPTION
Since `Crashpad` is now included in the FAB plugin package we no longer need to forcefully opt out of it when `IsMarketplaceVersion()` returns `true`.