### PR TITLE
chore: Update .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,8 +21,7 @@ plugin-dev/Intermediate/*
 .DS_Store
 
 # Ignore package release
-package-release-github/
-package-release-marketplace/
+package-release/
 sentry-unreal-*.zip
 
 # Prebuilt libraries & artifacts are collected in CI.


### PR DESCRIPTION
This PR updates `.gitignore` to exclude temporary files generated during the preparation of release artifacts. Related to https://github.com/getsentry/sentry-unreal/pull/1030.

#skip-changelog