### PR TITLE
Add support for unreal's additional crash context scopes

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.cpp
@@ -9,7 +9,7 @@
 
 #include "GenericPlatform/GenericPlatformSentryScope.h"
 
-#if WITH_ADDITIONAL_CRASH_CONTEXTS
+#if UE_VERSION_NEWER_THAN(5, 7, 0) && WITH_ADDITIONAL_CRASH_CONTEXTS
 struct FSentryCrashContextExtendedWriter : public FCrashContextExtendedWriter
 {
 public:


### PR DESCRIPTION
Requires Epic to accept https://github.com/EpicGames/UnrealEngine/pull/13686 first as one required method is not exported from `Core`.

Unreal has a little-known macro `UE_ADD_CRASH_CONTEXT_SCOPE` which allows running code to add additional information to a crash if the crash happens within the scope the macro is in. This adds support to sentry to retrieve this information and add it as an additional scope. Some other systems may also add data into this via `OnAdditionalCrashContextDelegate()`.