### PR TITLE
Fix plugin init for sampling tests

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Tests/SentryTraceSampling.spec.cpp
+++ b/plugin-dev/Source/Sentry/Private/Tests/SentryTraceSampling.spec.cpp
@@ -52,7 +52,7 @@ void SentryTraceSamplingSpec::Define()
 				if (SamplingContext)
 				{
 					USentryTransactionContext* CustomContext = SamplingContext->GetTransactionContext();
-					TestNotNull("Transaction context should be available in sampling context", TransactionContext);
+					TestNotNull("Transaction context should be available in sampling context", CustomContext);
 					if (CustomContext)
 					{
 						TestEqual("Transaction name should match", CustomContext->GetName(), TEXT("Test transaction"));


### PR DESCRIPTION
Checking sampling context values after the callback invocation makes the tests flaky since the underlying native objects may already be invalidated.

#skip-changelog