### PR TITLE
Add missing `SWIFT_PACKAGE` define for Apple platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Packaging errors in Unreal Engine 5.4 and 5.5 caused by a missing `SWIFT_PACKAGE` define when targeting Mac and iOS
+
 ## 1.0.0
 
 After several months of work we're finally shipping the Sentry SDK for Unreal Engine version 1.0.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Packaging errors in Unreal Engine 5.4 and 5.5 caused by a missing `SWIFT_PACKAGE` define when targeting Mac and iOS
+- Packaging errors in Unreal Engine 5.4 and 5.5 caused by a missing `SWIFT_PACKAGE` define when targeting Mac and iOS ([#1063](https://github.com/getsentry/sentry-unreal/pull/1063))
 
 ## 1.0.0
 

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -61,6 +61,7 @@ public class Sentry : ModuleRules
 			PublicDefinitions.Add("SENTRY_NO_UIKIT=0");
 			PublicDefinitions.Add("APPLICATION_EXTENSION_API_ONLY_NO=0");
 			PublicDefinitions.Add("SDK_V9=0");
+			PublicDefinitions.Add("SWIFT_PACKAGE=0");
 		}
 		else if (Target.Platform == UnrealTargetPlatform.Mac)
 		{
@@ -75,6 +76,7 @@ public class Sentry : ModuleRules
 			PublicDefinitions.Add("SENTRY_NO_UIKIT=1");
 			PublicDefinitions.Add("APPLICATION_EXTENSION_API_ONLY_NO=0");
 			PublicDefinitions.Add("SDK_V9=0");
+			PublicDefinitions.Add("SWIFT_PACKAGE=0");
 		}
 		else if (Target.Platform == UnrealTargetPlatform.Android)
 		{


### PR DESCRIPTION
This PR resolves packaging errors in UE 5.4 and 5.5 due to a missing `SWIFT_PACKAGE` define when targeting Apple platforms. The problem was discovered after submitting version `1.0.0` to FAB.