### PR TITLE
Fix `jstring` lifetime issue for log file path on Android

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Android/Jni/AndroidSentryJni.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Jni/AndroidSentryJni.cpp
@@ -125,8 +125,8 @@ JNI_METHOD jstring Java_io_sentry_unreal_SentryBridgeJava_getLogFilePath(JNIEnv*
 	IFileManager& FileManager = IFileManager::Get();
 	if (!FileManager.FileExists(*LogFilePath))
 	{
-		return *FSentryJavaObjectWrapper::GetJString(FString(""));
+		return env->NewStringUTF("");
 	}
 
-	return *FSentryJavaObjectWrapper::GetJString(LogFilePath);
+	return env->NewStringUTF(TCHAR_TO_UTF8(*LogFilePath));
 }


### PR DESCRIPTION
This PR fixes a crash on Android caused by returning an invalid `jstring` from the JNI bridge when resolving game log path required to create file attachment.

Previously, the corresponding utility method used `FScopedJavaObject<jstring>` which deletes the local reference as soon as the temporary goes out of scope. This left Java with a dangling `jstring` reference leading to a `SIGSEGV` when accessing the value in beforeSend handler.