### PR TITLE
Add support for automatic event linking with spans/transactions

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.cpp
@@ -23,16 +23,16 @@ void FAndroidSentrySpan::SetupClassMethods()
 	ToSentryTraceMethod = GetMethod("toSentryTrace", "()Lio/sentry/SentryTraceHeader;");
 }
 
-TSharedPtr<ISentrySpan> FAndroidSentrySpan::StartChild(const FString& operation, const FString& desctiption)
+TSharedPtr<ISentrySpan> FAndroidSentrySpan::StartChild(const FString& operation, const FString& desctiption, bool bindToScope)
 {
 	auto span = CallObjectMethod<jobject>(StartChildMethod, *GetJString(operation), *GetJString(desctiption));
 	return MakeShareable(new FAndroidSentrySpan(*span));
 }
 
-TSharedPtr<ISentrySpan> FAndroidSentrySpan::StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp)
+TSharedPtr<ISentrySpan> FAndroidSentrySpan::StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope)
 {
 	UE_LOG(LogSentrySdk, Log, TEXT("Starting child span with explicit timestamp not supported on Android."));
-	return StartChild(operation, desctiption);
+	return StartChild(operation, desctiption, bindToScope);
 }
 
 void FAndroidSentrySpan::Finish()

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySpan.h
@@ -13,8 +13,8 @@ public:
 
 	void SetupClassMethods();
 
-	virtual TSharedPtr<ISentrySpan> StartChild(const FString& operation, const FString& desctiption) override;
-	virtual TSharedPtr<ISentrySpan> StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp) override;
+	virtual TSharedPtr<ISentrySpan> StartChild(const FString& operation, const FString& desctiption, bool bindToScope) override;
+	virtual TSharedPtr<ISentrySpan> StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope) override;
 	virtual void Finish() override;
 	virtual void FinishWithTimestamp(int64 timestamp) override;
 	virtual bool IsFinished() const override;

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -303,6 +303,7 @@ TSharedPtr<ISentryTransaction> FAndroidSentrySubsystem::StartTransactionWithCont
 
 	TSharedPtr<FAndroidSentryTransactionOptions> transactionOptionsAndroid = MakeShareable(new FAndroidSentryTransactionOptions());
 	transactionOptionsAndroid->SetCustomSamplingContext(options.CustomSamplingContext);
+	transactionOptionsAndroid->SetBindToScope(options.BindToScope);
 
 	auto transaction = FSentryJavaObjectWrapper::CallStaticObjectMethod<jobject>(SentryJavaClasses::Sentry, "startTransaction", "(Lio/sentry/TransactionContext;Lio/sentry/TransactionOptions;)Lio/sentry/ITransaction;",
 		transactionContextAndroid->GetJObject(), transactionOptionsAndroid->GetJObject());

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
@@ -34,9 +34,9 @@ public:
 	virtual void GiveUserConsent() override;
 	virtual void RevokeUserConsent() override;
 	virtual EUserConsent GetUserConsent() const override;
-	virtual TSharedPtr<ISentryTransaction> StartTransaction(const FString& name, const FString& operation) override;
-	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context) override;
-	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp) override;
+	virtual TSharedPtr<ISentryTransaction> StartTransaction(const FString& name, const FString& operation, bool bindToScope) override;
+	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context, bool bindToScope) override;
+	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp, bool bindToScope) override;
 	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndOptions(TSharedPtr<ISentryTransactionContext> context, const FSentryTransactionOptions& options) override;
 	virtual TSharedPtr<ISentryTransactionContext> ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders) override;
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.cpp
@@ -25,16 +25,16 @@ void FAndroidSentryTransaction::SetupClassMethods()
 	ToSentryTraceMethod = GetMethod("toSentryTrace", "()Lio/sentry/SentryTraceHeader;");
 }
 
-TSharedPtr<ISentrySpan> FAndroidSentryTransaction::StartChildSpan(const FString& operation, const FString& desctiption)
+TSharedPtr<ISentrySpan> FAndroidSentryTransaction::StartChildSpan(const FString& operation, const FString& desctiption, bool bindToScope)
 {
 	auto span = CallObjectMethod<jobject>(StartChildMethod, *GetJString(operation), *GetJString(desctiption));
 	return MakeShareable(new FAndroidSentrySpan(*span));
 }
 
-TSharedPtr<ISentrySpan> FAndroidSentryTransaction::StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp)
+TSharedPtr<ISentrySpan> FAndroidSentryTransaction::StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope)
 {
 	UE_LOG(LogSentrySdk, Log, TEXT("Starting child span with explicit timestamp not supported on Android."));
-	return StartChildSpan(operation, desctiption);
+	return StartChildSpan(operation, desctiption, bindToScope);
 }
 
 void FAndroidSentryTransaction::Finish()

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransaction.h
@@ -13,8 +13,8 @@ public:
 
 	void SetupClassMethods();
 
-	virtual TSharedPtr<ISentrySpan> StartChildSpan(const FString& operation, const FString& desctiption) override;
-	virtual TSharedPtr<ISentrySpan> StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp) override;
+	virtual TSharedPtr<ISentrySpan> StartChildSpan(const FString& operation, const FString& desctiption, bool bindToScope) override;
+	virtual TSharedPtr<ISentrySpan> StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope) override;
 	virtual void Finish() override;
 	virtual void FinishWithTimestamp(int64 timestamp) override;
 	virtual bool IsFinished() const override;

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionOptions.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionOptions.cpp
@@ -14,6 +14,7 @@ FAndroidSentryTransactionOptions::FAndroidSentryTransactionOptions()
 void FAndroidSentryTransactionOptions::SetupClassMethods()
 {
 	SetCustomSamplingContextMethod = GetMethod("setCustomSamplingContext", "(Lio/sentry/CustomSamplingContext;)V");
+	SetBindToScopeMethod = GetMethod("setBindToScope", "(Z)V");
 }
 
 void FAndroidSentryTransactionOptions::SetCustomSamplingContext(const TMap<FString, FSentryVariant>& data)
@@ -27,4 +28,9 @@ void FAndroidSentryTransactionOptions::SetCustomSamplingContext(const TMap<FStri
 	}
 
 	CallMethod<void>(SetCustomSamplingContextMethod, NativeCustomSamplingContext.GetJObject());
+}
+
+void FAndroidSentryTransactionOptions::SetBindToScope(bool bindToScope)
+{
+	CallMethod<void>(SetBindToScopeMethod, bindToScope);
 }

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionOptions.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryTransactionOptions.h
@@ -14,9 +14,11 @@ public:
 	void SetupClassMethods();
 
 	void SetCustomSamplingContext(const TMap<FString, FSentryVariant>& data);
+	void SetBindToScope(bool bindToScope);
 
 private:
 	FSentryJavaMethod SetCustomSamplingContextMethod;
+	FSentryJavaMethod SetBindToScopeMethod;
 };
 
 typedef FAndroidSentryTransactionOptions FPlatformSentryTransactionOptions;

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.cpp
@@ -6,8 +6,8 @@
 
 #include "Infrastructure/AppleSentryConverters.h"
 
-#include "Convenience/AppleSentryMacro.h"
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 FAppleSentrySpan::FAppleSentrySpan(id<SentrySpan> span)
 {

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.cpp
@@ -6,6 +6,7 @@
 
 #include "Infrastructure/AppleSentryConverters.h"
 
+#include "Convenience/AppleSentryMacro.h"
 #include "Convenience/AppleSentryInclude.h"
 
 FAppleSentrySpan::FAppleSentrySpan(id<SentrySpan> span)
@@ -27,13 +28,21 @@ id<SentrySpan> FAppleSentrySpan::GetNativeObject()
 TSharedPtr<ISentrySpan> FAppleSentrySpan::StartChild(const FString& operation, const FString& desctiption, bool bindToScope)
 {
 	id<SentrySpan> span = [SpanApple startChildWithOperation:operation.GetNSString() description:desctiption.GetNSString()];
+
+	if (bindToScope)
+	{
+		[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
+			scope.span = span;
+		}];
+	}
+
 	return MakeShareable(new FAppleSentrySpan(span));
 }
 
 TSharedPtr<ISentrySpan> FAppleSentrySpan::StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope)
 {
 	UE_LOG(LogSentrySdk, Log, TEXT("Starting child span with explicit timestamp not supported on Mac/iOS."));
-	return StartChild(operation, desctiption, TODO);
+	return StartChild(operation, desctiption, bindToScope);
 }
 
 void FAppleSentrySpan::Finish()

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.cpp
@@ -24,16 +24,16 @@ id<SentrySpan> FAppleSentrySpan::GetNativeObject()
 	return SpanApple;
 }
 
-TSharedPtr<ISentrySpan> FAppleSentrySpan::StartChild(const FString& operation, const FString& desctiption)
+TSharedPtr<ISentrySpan> FAppleSentrySpan::StartChild(const FString& operation, const FString& desctiption, bool bindToScope)
 {
 	id<SentrySpan> span = [SpanApple startChildWithOperation:operation.GetNSString() description:desctiption.GetNSString()];
 	return MakeShareable(new FAppleSentrySpan(span));
 }
 
-TSharedPtr<ISentrySpan> FAppleSentrySpan::StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp)
+TSharedPtr<ISentrySpan> FAppleSentrySpan::StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope)
 {
 	UE_LOG(LogSentrySdk, Log, TEXT("Starting child span with explicit timestamp not supported on Mac/iOS."));
-	return StartChild(operation, desctiption);
+	return StartChild(operation, desctiption, TODO);
 }
 
 void FAppleSentrySpan::Finish()

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySpan.h
@@ -14,8 +14,8 @@ public:
 
 	id<SentrySpan> GetNativeObject();
 
-	virtual TSharedPtr<ISentrySpan> StartChild(const FString& operation, const FString& desctiption) override;
-	virtual TSharedPtr<ISentrySpan> StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp) override;
+	virtual TSharedPtr<ISentrySpan> StartChild(const FString& operation, const FString& desctiption, bool bindToScope) override;
+	virtual TSharedPtr<ISentrySpan> StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope) override;
 	virtual void Finish() override;
 	virtual void FinishWithTimestamp(int64 timestamp) override;
 	virtual bool IsFinished() const override;

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -12,7 +12,6 @@
 #include "AppleSentryTransaction.h"
 #include "AppleSentryTransactionContext.h"
 #include "AppleSentryUser.h"
-#include "Convenience/AppleSentryMacro.h"
 
 #include "SentryBeforeBreadcrumbHandler.h"
 #include "SentryBeforeSendHandler.h"
@@ -25,6 +24,7 @@
 
 #include "Infrastructure/AppleSentryConverters.h"
 
+#include "Convenience/AppleSentryMacro.h"
 #include "Convenience/AppleSentryInclude.h"
 
 #include "Utils/SentryFileUtils.h"

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -392,6 +392,7 @@ TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransactionWithContex
 	TSharedPtr<FAppleSentryTransactionContext> transactionContextIOS = StaticCastSharedPtr<FAppleSentryTransactionContext>(context);
 
 	id<SentrySpan> transaction = [SENTRY_APPLE_CLASS(SentrySDK) startTransactionWithContext:transactionContextIOS->GetNativeObject()
+																	  bindToScope:options.BindToScope
 																	  customSamplingContext:FAppleSentryConverters::VariantMapToNative(options.CustomSamplingContext)];
 
 	return MakeShareable(new FAppleSentryTransaction(transaction));

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -365,26 +365,26 @@ EUserConsent FAppleSentrySubsystem::GetUserConsent() const
 	return EUserConsent::Unknown;
 }
 
-TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransaction(const FString& name, const FString& operation)
+TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransaction(const FString& name, const FString& operation, bool bindToScope)
 {
-	id<SentrySpan> transaction = [SENTRY_APPLE_CLASS(SentrySDK) startTransactionWithName:name.GetNSString() operation:operation.GetNSString()];
+	id<SentrySpan> transaction = [SENTRY_APPLE_CLASS(SentrySDK) startTransactionWithName:name.GetNSString() operation:operation.GetNSString() bindToScope:bindToScope];
 
 	return MakeShareable(new FAppleSentryTransaction(transaction));
 }
 
-TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context)
+TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context, bool bindToScope)
 {
 	TSharedPtr<FAppleSentryTransactionContext> transactionContextIOS = StaticCastSharedPtr<FAppleSentryTransactionContext>(context);
 
-	id<SentrySpan> transaction = [SENTRY_APPLE_CLASS(SentrySDK) startTransactionWithContext:transactionContextIOS->GetNativeObject()];
+	id<SentrySpan> transaction = [SENTRY_APPLE_CLASS(SentrySDK) startTransactionWithContext:transactionContextIOS->GetNativeObject() bindToScope:bindToScope];
 
 	return MakeShareable(new FAppleSentryTransaction(transaction));
 }
 
-TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp)
+TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp, bool bindToScope)
 {
 	UE_LOG(LogSentrySdk, Log, TEXT("Setting transaction timestamp explicitly not supported on Mac/iOS."));
-	return StartTransactionWithContext(context);
+	return StartTransactionWithContext(context, bindToScope);
 }
 
 TSharedPtr<ISentryTransaction> FAppleSentrySubsystem::StartTransactionWithContextAndOptions(TSharedPtr<ISentryTransactionContext> context, const FSentryTransactionOptions& options)

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -24,8 +24,8 @@
 
 #include "Infrastructure/AppleSentryConverters.h"
 
-#include "Convenience/AppleSentryMacro.h"
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 #include "Utils/SentryFileUtils.h"
 #include "Utils/SentryLogUtils.h"

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -34,9 +34,9 @@ public:
 	virtual void GiveUserConsent() override;
 	virtual void RevokeUserConsent() override;
 	virtual EUserConsent GetUserConsent() const override;
-	virtual TSharedPtr<ISentryTransaction> StartTransaction(const FString& name, const FString& operation) override;
-	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context) override;
-	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp) override;
+	virtual TSharedPtr<ISentryTransaction> StartTransaction(const FString& name, const FString& operation, bool bindToScope) override;
+	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context, bool bindToScope) override;
+	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp, bool bindToScope) override;
 	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndOptions(TSharedPtr<ISentryTransactionContext> context, const FSentryTransactionOptions& options) override;
 	virtual TSharedPtr<ISentryTransactionContext> ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders) override;
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.cpp
@@ -5,8 +5,8 @@
 
 #include "Infrastructure/AppleSentryConverters.h"
 
-#include "Convenience/AppleSentryMacro.h"
 #include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
 
 #include "SentryDefines.h"
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.cpp
@@ -25,16 +25,16 @@ id<SentrySpan> FAppleSentryTransaction::GetNativeObject()
 	return TransactionApple;
 }
 
-TSharedPtr<ISentrySpan> FAppleSentryTransaction::StartChildSpan(const FString& operation, const FString& desctiption)
+TSharedPtr<ISentrySpan> FAppleSentryTransaction::StartChildSpan(const FString& operation, const FString& desctiption, bool bindToScope)
 {
 	id<SentrySpan> span = [TransactionApple startChildWithOperation:operation.GetNSString() description:desctiption.GetNSString()];
 	return MakeShareable(new FAppleSentrySpan(span));
 }
 
-TSharedPtr<ISentrySpan> FAppleSentryTransaction::StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp)
+TSharedPtr<ISentrySpan> FAppleSentryTransaction::StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope)
 {
 	UE_LOG(LogSentrySdk, Log, TEXT("Starting child span with explicit timestamp not supported on Mac/iOS."));
-	return StartChildSpan(operation, desctiption);
+	return StartChildSpan(operation, desctiption, TODO);
 }
 
 void FAppleSentryTransaction::Finish()

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.cpp
@@ -5,6 +5,7 @@
 
 #include "Infrastructure/AppleSentryConverters.h"
 
+#include "Convenience/AppleSentryMacro.h"
 #include "Convenience/AppleSentryInclude.h"
 
 #include "SentryDefines.h"
@@ -28,13 +29,21 @@ id<SentrySpan> FAppleSentryTransaction::GetNativeObject()
 TSharedPtr<ISentrySpan> FAppleSentryTransaction::StartChildSpan(const FString& operation, const FString& desctiption, bool bindToScope)
 {
 	id<SentrySpan> span = [TransactionApple startChildWithOperation:operation.GetNSString() description:desctiption.GetNSString()];
+
+	if (bindToScope)
+	{
+		[SENTRY_APPLE_CLASS(SentrySDK) configureScope:^(SentryScope* scope) {
+			scope.span = span;
+		}];
+	}
+
 	return MakeShareable(new FAppleSentrySpan(span));
 }
 
 TSharedPtr<ISentrySpan> FAppleSentryTransaction::StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope)
 {
 	UE_LOG(LogSentrySdk, Log, TEXT("Starting child span with explicit timestamp not supported on Mac/iOS."));
-	return StartChildSpan(operation, desctiption, TODO);
+	return StartChildSpan(operation, desctiption, bindToScope);
 }
 
 void FAppleSentryTransaction::Finish()

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryTransaction.h
@@ -14,8 +14,8 @@ public:
 
 	id<SentrySpan> GetNativeObject();
 
-	virtual TSharedPtr<ISentrySpan> StartChildSpan(const FString& operation, const FString& desctiption) override;
-	virtual TSharedPtr<ISentrySpan> StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp) override;
+	virtual TSharedPtr<ISentrySpan> StartChildSpan(const FString& operation, const FString& desctiption, bool bindToScope) override;
+	virtual TSharedPtr<ISentrySpan> StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope) override;
 	virtual void Finish() override;
 	virtual void FinishWithTimestamp(int64 timestamp) override;
 	virtual bool IsFinished() const override;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySpan.cpp
@@ -23,10 +23,15 @@ sentry_span_t* FGenericPlatformSentrySpan::GetNativeObject()
 	return Span;
 }
 
-TSharedPtr<ISentrySpan> FGenericPlatformSentrySpan::StartChild(const FString& operation, const FString& description)
+TSharedPtr<ISentrySpan> FGenericPlatformSentrySpan::StartChild(const FString& operation, const FString& description, bool bindToScope)
 {
 	if (sentry_span_t* nativeSpan = sentry_span_start_child(Span, TCHAR_TO_ANSI(*operation), TCHAR_TO_ANSI(*description)))
 	{
+		if (bindToScope)
+		{
+			sentry_set_span(nativeSpan);
+		}
+
 		return MakeShareable(new FGenericPlatformSentrySpan(nativeSpan));
 	}
 	else
@@ -35,10 +40,15 @@ TSharedPtr<ISentrySpan> FGenericPlatformSentrySpan::StartChild(const FString& op
 	}
 }
 
-TSharedPtr<ISentrySpan> FGenericPlatformSentrySpan::StartChildWithTimestamp(const FString& operation, const FString& description, int64 timestamp)
+TSharedPtr<ISentrySpan> FGenericPlatformSentrySpan::StartChildWithTimestamp(const FString& operation, const FString& description, int64 timestamp, bool bindToScope)
 {
 	if (sentry_span_t* nativeSpan = sentry_span_start_child_ts(Span, TCHAR_TO_ANSI(*operation), TCHAR_TO_ANSI(*description), timestamp))
 	{
+		if (bindToScope)
+		{
+			sentry_set_span(nativeSpan);
+		}
+
 		return MakeShareable(new FGenericPlatformSentrySpan(nativeSpan));
 	}
 	else

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySpan.h
@@ -18,8 +18,8 @@ public:
 
 	sentry_span_t* GetNativeObject();
 
-	virtual TSharedPtr<ISentrySpan> StartChild(const FString& operation, const FString& description) override;
-	virtual TSharedPtr<ISentrySpan> StartChildWithTimestamp(const FString& operation, const FString& description, int64 timestamp) override;
+	virtual TSharedPtr<ISentrySpan> StartChild(const FString& operation, const FString& description, bool bindToScope) override;
+	virtual TSharedPtr<ISentrySpan> StartChildWithTimestamp(const FString& operation, const FString& description, int64 timestamp, bool bindToScope) override;
 	virtual void Finish() override;
 	virtual void FinishWithTimestamp(int64 timestamp) override;
 	virtual bool IsFinished() const override;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -737,6 +737,11 @@ TSharedPtr<ISentryTransaction> FGenericPlatformSentrySubsystem::StartTransaction
 	{
 		if (sentry_transaction_t* nativeTransaction = sentry_transaction_start(platformTransactionContext->GetNativeObject(), FGenericPlatformSentryConverters::VariantMapToNative(options.CustomSamplingContext)))
 		{
+			if (options.BindToScope)
+			{
+				sentry_set_transaction_object(nativeTransaction);
+			}
+
 			return MakeShareable(new FGenericPlatformSentryTransaction(nativeTransaction));
 		}
 	}

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -698,19 +698,24 @@ EUserConsent FGenericPlatformSentrySubsystem::GetUserConsent() const
 	}
 }
 
-TSharedPtr<ISentryTransaction> FGenericPlatformSentrySubsystem::StartTransaction(const FString& name, const FString& operation)
+TSharedPtr<ISentryTransaction> FGenericPlatformSentrySubsystem::StartTransaction(const FString& name, const FString& operation, bool bindToScope)
 {
 	TSharedPtr<ISentryTransactionContext> transactionContext = MakeShareable(new FGenericPlatformSentryTransactionContext(name, operation));
 
-	return StartTransactionWithContext(transactionContext);
+	return StartTransactionWithContext(transactionContext, bindToScope);
 }
 
-TSharedPtr<ISentryTransaction> FGenericPlatformSentrySubsystem::StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context)
+TSharedPtr<ISentryTransaction> FGenericPlatformSentrySubsystem::StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context, bool bindToScope)
 {
 	if (TSharedPtr<FGenericPlatformSentryTransactionContext> platformTransactionContext = StaticCastSharedPtr<FGenericPlatformSentryTransactionContext>(context))
 	{
 		if (sentry_transaction_t* nativeTransaction = sentry_transaction_start(platformTransactionContext->GetNativeObject(), sentry_value_new_null()))
 		{
+			if (bindToScope)
+			{
+				sentry_set_transaction_object(nativeTransaction);
+			}
+
 			return MakeShareable(new FGenericPlatformSentryTransaction(nativeTransaction));
 		}
 	}
@@ -718,12 +723,17 @@ TSharedPtr<ISentryTransaction> FGenericPlatformSentrySubsystem::StartTransaction
 	return nullptr;
 }
 
-TSharedPtr<ISentryTransaction> FGenericPlatformSentrySubsystem::StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp)
+TSharedPtr<ISentryTransaction> FGenericPlatformSentrySubsystem::StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp, bool bindToScope)
 {
 	if (TSharedPtr<FGenericPlatformSentryTransactionContext> platformTransactionContext = StaticCastSharedPtr<FGenericPlatformSentryTransactionContext>(context))
 	{
 		if (sentry_transaction_t* nativeTransaction = sentry_transaction_start_ts(platformTransactionContext->GetNativeObject(), sentry_value_new_null(), timestamp))
 		{
+			if (bindToScope)
+			{
+				sentry_set_transaction_object(nativeTransaction);
+			}
+
 			return MakeShareable(new FGenericPlatformSentryTransaction(nativeTransaction));
 		}
 	}

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -46,9 +46,9 @@ public:
 	virtual void GiveUserConsent() override;
 	virtual void RevokeUserConsent() override;
 	virtual EUserConsent GetUserConsent() const override;
-	virtual TSharedPtr<ISentryTransaction> StartTransaction(const FString& name, const FString& operation) override;
-	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context) override;
-	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp) override;
+	virtual TSharedPtr<ISentryTransaction> StartTransaction(const FString& name, const FString& operation, bool bindToScope) override;
+	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context, bool bindToScope) override;
+	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp, bool bindToScope) override;
 	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndOptions(TSharedPtr<ISentryTransactionContext> context, const FSentryTransactionOptions& options) override;
 	virtual TSharedPtr<ISentryTransactionContext> ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders) override;
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransaction.cpp
@@ -24,10 +24,15 @@ sentry_transaction_t* FGenericPlatformSentryTransaction::GetNativeObject()
 	return Transaction;
 }
 
-TSharedPtr<ISentrySpan> FGenericPlatformSentryTransaction::StartChildSpan(const FString& operation, const FString& description)
+TSharedPtr<ISentrySpan> FGenericPlatformSentryTransaction::StartChildSpan(const FString& operation, const FString& description, bool bindToScope)
 {
 	if (sentry_span_t* nativeSpan = sentry_transaction_start_child(Transaction, TCHAR_TO_ANSI(*operation), TCHAR_TO_ANSI(*description)))
 	{
+		if (bindToScope)
+		{
+			sentry_set_span(nativeSpan);
+		}
+
 		return MakeShareable(new FGenericPlatformSentrySpan(nativeSpan));
 	}
 	else
@@ -36,10 +41,15 @@ TSharedPtr<ISentrySpan> FGenericPlatformSentryTransaction::StartChildSpan(const 
 	}
 }
 
-TSharedPtr<ISentrySpan> FGenericPlatformSentryTransaction::StartChildSpanWithTimestamp(const FString& operation, const FString& description, int64 timestamp)
+TSharedPtr<ISentrySpan> FGenericPlatformSentryTransaction::StartChildSpanWithTimestamp(const FString& operation, const FString& description, int64 timestamp, bool bindToScope)
 {
 	if (sentry_span_t* nativeSpan = sentry_transaction_start_child_ts(Transaction, TCHAR_TO_ANSI(*operation), TCHAR_TO_ANSI(*description), timestamp))
 	{
+		if (bindToScope)
+		{
+			sentry_set_span(nativeSpan);
+		}
+
 		return MakeShareable(new FGenericPlatformSentrySpan(nativeSpan));
 	}
 	else

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryTransaction.h
@@ -18,8 +18,8 @@ public:
 
 	sentry_transaction_t* GetNativeObject();
 
-	virtual TSharedPtr<ISentrySpan> StartChildSpan(const FString& operation, const FString& description) override;
-	virtual TSharedPtr<ISentrySpan> StartChildSpanWithTimestamp(const FString& operation, const FString& description, int64 timestamp) override;
+	virtual TSharedPtr<ISentrySpan> StartChildSpan(const FString& operation, const FString& description, bool bindToScope) override;
+	virtual TSharedPtr<ISentrySpan> StartChildSpanWithTimestamp(const FString& operation, const FString& description, int64 timestamp, bool bindToScope) override;
 	virtual void Finish() override;
 	virtual void FinishWithTimestamp(int64 timestamp) override;
 	virtual bool IsFinished() const override;

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySpanInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySpanInterface.h
@@ -10,8 +10,8 @@ class ISentrySpan
 public:
 	virtual ~ISentrySpan() = default;
 
-	virtual TSharedPtr<ISentrySpan> StartChild(const FString& operation, const FString& desctiption) = 0;
-	virtual TSharedPtr<ISentrySpan> StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp) = 0;
+	virtual TSharedPtr<ISentrySpan> StartChild(const FString& operation, const FString& desctiption, bool bindToScope) = 0;
+	virtual TSharedPtr<ISentrySpan> StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope) = 0;
 	virtual void Finish() = 0;
 	virtual void FinishWithTimestamp(int64 timestamp) = 0;
 	virtual bool IsFinished() const = 0;

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
@@ -58,9 +58,9 @@ public:
 	virtual void GiveUserConsent() = 0;
 	virtual void RevokeUserConsent() = 0;
 	virtual EUserConsent GetUserConsent() const = 0;
-	virtual TSharedPtr<ISentryTransaction> StartTransaction(const FString& name, const FString& operation) = 0;
-	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context) = 0;
-	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp) = 0;
+	virtual TSharedPtr<ISentryTransaction> StartTransaction(const FString& name, const FString& operation, bool bindToScope) = 0;
+	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context, bool bindToScope) = 0;
+	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp, bool bindToScope) = 0;
 	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndOptions(TSharedPtr<ISentryTransactionContext> context, const FSentryTransactionOptions& options) = 0;
 	virtual TSharedPtr<ISentryTransactionContext> ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders) = 0;
 

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryTransactionInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryTransactionInterface.h
@@ -12,8 +12,8 @@ class ISentryTransaction
 public:
 	virtual ~ISentryTransaction() = default;
 
-	virtual TSharedPtr<ISentrySpan> StartChildSpan(const FString& operation, const FString& desctiption) = 0;
-	virtual TSharedPtr<ISentrySpan> StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp) = 0;
+	virtual TSharedPtr<ISentrySpan> StartChildSpan(const FString& operation, const FString& desctiption, bool bindToScope) = 0;
+	virtual TSharedPtr<ISentrySpan> StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope) = 0;
 	virtual void Finish() = 0;
 	virtual void FinishWithTimestamp(int64 timestamp) = 0;
 	virtual bool IsFinished() const = 0;

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentrySpan.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentrySpan.h
@@ -9,8 +9,8 @@ class FNullSentrySpan final : public ISentrySpan
 public:
 	virtual ~FNullSentrySpan() override = default;
 
-	virtual TSharedPtr<ISentrySpan> StartChild(const FString& operation, const FString& desctiption) override { return nullptr; }
-	virtual TSharedPtr<ISentrySpan> StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp) override { return nullptr; }
+	virtual TSharedPtr<ISentrySpan> StartChild(const FString& operation, const FString& desctiption, bool bindToScope) override { return nullptr; }
+	virtual TSharedPtr<ISentrySpan> StartChildWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope) override { return nullptr; }
 	virtual void Finish() override {}
 	virtual void FinishWithTimestamp(int64 timestamp) override {}
 	virtual bool IsFinished() const override { return false; }

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentrySubsystem.h
@@ -36,9 +36,9 @@ public:
 	virtual void GiveUserConsent() override {}
 	virtual void RevokeUserConsent() override {}
 	virtual EUserConsent GetUserConsent() const override { return EUserConsent::Unknown; }
-	virtual TSharedPtr<ISentryTransaction> StartTransaction(const FString& name, const FString& operation) override { return nullptr; }
-	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context) override { return nullptr; }
-	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp) override { return nullptr; }
+	virtual TSharedPtr<ISentryTransaction> StartTransaction(const FString& name, const FString& operation, bool bindToScope) override { return nullptr; }
+	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContext(TSharedPtr<ISentryTransactionContext> context, bool bindToScope) override { return nullptr; }
+	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndTimestamp(TSharedPtr<ISentryTransactionContext> context, int64 timestamp, bool bindToScope) override { return nullptr; }
 	virtual TSharedPtr<ISentryTransaction> StartTransactionWithContextAndOptions(TSharedPtr<ISentryTransactionContext> context, const FSentryTransactionOptions& options) override { return nullptr; }
 	virtual TSharedPtr<ISentryTransactionContext> ContinueTrace(const FString& sentryTrace, const TArray<FString>& baggageHeaders) override { return nullptr; }
 

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryTransaction.h
@@ -9,8 +9,8 @@ class FNullSentryTransaction final : public ISentryTransaction
 public:
 	virtual ~FNullSentryTransaction() override = default;
 
-	virtual TSharedPtr<ISentrySpan> StartChildSpan(const FString& operation, const FString& desctiption) override { return nullptr; }
-	virtual TSharedPtr<ISentrySpan> StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp) override { return nullptr; }
+	virtual TSharedPtr<ISentrySpan> StartChildSpan(const FString& operation, const FString& desctiption, bool bindToScope) override { return nullptr; }
+	virtual TSharedPtr<ISentrySpan> StartChildSpanWithTimestamp(const FString& operation, const FString& desctiption, int64 timestamp, bool bindToScope) override { return nullptr; }
 	virtual void Finish() override {}
 	virtual void FinishWithTimestamp(int64 timestamp) override {}
 	virtual bool IsFinished() const override { return false; }

--- a/plugin-dev/Source/Sentry/Private/SentrySpan.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySpan.cpp
@@ -5,12 +5,12 @@
 
 #include "HAL/PlatformSentrySpan.h"
 
-USentrySpan* USentrySpan::StartChild(const FString& Operation, const FString& Description)
+USentrySpan* USentrySpan::StartChild(const FString& Operation, const FString& Description, bool BindToScope)
 {
 	if (!NativeImpl || NativeImpl->IsFinished())
 		return nullptr;
 
-	if (TSharedPtr<ISentrySpan> ChildSpan = NativeImpl->StartChild(Operation, Description))
+	if (TSharedPtr<ISentrySpan> ChildSpan = NativeImpl->StartChild(Operation, Description, BindToScope))
 	{
 		return USentrySpan::Create(ChildSpan);
 	}
@@ -21,12 +21,12 @@ USentrySpan* USentrySpan::StartChild(const FString& Operation, const FString& De
 	}
 }
 
-USentrySpan* USentrySpan::StartChildWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp)
+USentrySpan* USentrySpan::StartChildWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp, bool BindToScope)
 {
 	if (!NativeImpl || NativeImpl->IsFinished())
 		return nullptr;
 
-	if (TSharedPtr<ISentrySpan> ChildSpan = NativeImpl->StartChildWithTimestamp(Operation, Description, Timestamp))
+	if (TSharedPtr<ISentrySpan> ChildSpan = NativeImpl->StartChildWithTimestamp(Operation, Description, Timestamp, BindToScope))
 	{
 		return USentrySpan::Create(ChildSpan);
 	}

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -503,7 +503,7 @@ EUserConsent USentrySubsystem::GetUserConsent() const
 	return SubsystemNativeImpl->GetUserConsent();
 }
 
-USentryTransaction* USentrySubsystem::StartTransaction(const FString& Name, const FString& Operation)
+USentryTransaction* USentrySubsystem::StartTransaction(const FString& Name, const FString& Operation, bool BindToScope)
 {
 	check(SubsystemNativeImpl);
 
@@ -512,13 +512,13 @@ USentryTransaction* USentrySubsystem::StartTransaction(const FString& Name, cons
 		return nullptr;
 	}
 
-	TSharedPtr<ISentryTransaction> SentryTransaction = SubsystemNativeImpl->StartTransaction(Name, Operation);
+	TSharedPtr<ISentryTransaction> SentryTransaction = SubsystemNativeImpl->StartTransaction(Name, Operation, BindToScope);
 	check(SentryTransaction);
 
 	return USentryTransaction::Create(SentryTransaction);
 }
 
-USentryTransaction* USentrySubsystem::StartTransactionWithContext(USentryTransactionContext* Context)
+USentryTransaction* USentrySubsystem::StartTransactionWithContext(USentryTransactionContext* Context, bool BindToScope)
 {
 	check(SubsystemNativeImpl);
 	check(Context);
@@ -528,13 +528,13 @@ USentryTransaction* USentrySubsystem::StartTransactionWithContext(USentryTransac
 		return nullptr;
 	}
 
-	TSharedPtr<ISentryTransaction> SentryTransaction = SubsystemNativeImpl->StartTransactionWithContext(Context->GetNativeObject());
+	TSharedPtr<ISentryTransaction> SentryTransaction = SubsystemNativeImpl->StartTransactionWithContext(Context->GetNativeObject(), BindToScope);
 	check(SentryTransaction);
 
 	return USentryTransaction::Create(SentryTransaction);
 }
 
-USentryTransaction* USentrySubsystem::StartTransactionWithContextAndTimestamp(USentryTransactionContext* Context, int64 Timestamp)
+USentryTransaction* USentrySubsystem::StartTransactionWithContextAndTimestamp(USentryTransactionContext* Context, int64 Timestamp, bool BindToScope)
 {
 	check(SubsystemNativeImpl);
 	check(Context);
@@ -544,7 +544,7 @@ USentryTransaction* USentrySubsystem::StartTransactionWithContextAndTimestamp(US
 		return nullptr;
 	}
 
-	TSharedPtr<ISentryTransaction> SentryTransaction = SubsystemNativeImpl->StartTransactionWithContextAndTimestamp(Context->GetNativeObject(), Timestamp);
+	TSharedPtr<ISentryTransaction> SentryTransaction = SubsystemNativeImpl->StartTransactionWithContextAndTimestamp(Context->GetNativeObject(), Timestamp, BindToScope);
 	check(SentryTransaction);
 
 	return USentryTransaction::Create(SentryTransaction);

--- a/plugin-dev/Source/Sentry/Private/SentryTransaction.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryTransaction.cpp
@@ -6,12 +6,12 @@
 
 #include "HAL/PlatformSentryTransaction.h"
 
-USentrySpan* USentryTransaction::StartChildSpan(const FString& Operation, const FString& Description)
+USentrySpan* USentryTransaction::StartChildSpan(const FString& Operation, const FString& Description, bool BindToScope)
 {
 	if (!NativeImpl || NativeImpl->IsFinished())
 		return nullptr;
 
-	if (TSharedPtr<ISentrySpan> spanNativeImpl = NativeImpl->StartChildSpan(Operation, Description))
+	if (TSharedPtr<ISentrySpan> spanNativeImpl = NativeImpl->StartChildSpan(Operation, Description, BindToScope))
 	{
 		return USentrySpan::Create(spanNativeImpl);
 	}
@@ -22,12 +22,12 @@ USentrySpan* USentryTransaction::StartChildSpan(const FString& Operation, const 
 	}
 }
 
-USentrySpan* USentryTransaction::StartChildSpanWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp)
+USentrySpan* USentryTransaction::StartChildSpanWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp, bool BindToScope)
 {
 	if (!NativeImpl || NativeImpl->IsFinished())
 		return nullptr;
 
-	if (TSharedPtr<ISentrySpan> spanNativeImpl = NativeImpl->StartChildSpanWithTimestamp(Operation, Description, Timestamp))
+	if (TSharedPtr<ISentrySpan> spanNativeImpl = NativeImpl->StartChildSpanWithTimestamp(Operation, Description, Timestamp, BindToScope))
 	{
 		return USentrySpan::Create(spanNativeImpl);
 	}

--- a/plugin-dev/Source/Sentry/Public/SentrySpan.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySpan.h
@@ -24,13 +24,21 @@ class SENTRY_API USentrySpan : public UObject, public TSentryImplWrapper<ISentry
 	GENERATED_BODY()
 
 public:
-	/** Starts a new child span. */
+	/** Starts a new child span.
+	 *
+	 * @note: On Android, if the span is bound the scope
+	 * the SDK will put the new child span on the scope as well.
+	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentrySpan* StartChild(const FString& Operation, const FString& Description);
+	USentrySpan* StartChild(const FString& Operation, const FString& Description, bool BindToScope = false);
 
-	/** Starts a new child span with timestamp. */
+	/** Starts a new child span with timestamp.
+	 *
+	 * @note: On Android, if the span is bound the scope
+	 * the SDK will put the new child span on the scope as well.
+	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentrySpan* StartChildWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp);
+	USentrySpan* StartChildWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp, bool BindToScope = false);
 
 	/** Finishes and sends a span to Sentry. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -278,17 +278,19 @@ public:
 	 *
 	 * @param Name Transaction name.
 	 * @param Operation Short code identifying the type of operation the span is measuring.
+	 * @param BindToScope Flag indicating whether the SDK should bind the new transaction to the scope
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentryTransaction* StartTransaction(const FString& Name, const FString& Operation);
+	USentryTransaction* StartTransaction(const FString& Name, const FString& Operation, bool BindToScope = false);
 
 	/**
 	 * Starts a new transaction with given context.
 	 *
 	 * @param Context Transaction context.
+	 * @param BindToScope Flag indicating whether the SDK should bind the new transaction to the scope
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentryTransaction* StartTransactionWithContext(USentryTransactionContext* Context);
+	USentryTransaction* StartTransactionWithContext(USentryTransactionContext* Context, bool BindToScope = false);
 
 	/**
 	 * Starts a new transaction with given context and timestamp.
@@ -297,9 +299,10 @@ public:
 	 *
 	 * @param Context Transaction context.
 	 * @param Timestamp Transaction timestamp (microseconds since the Unix epoch).
+	 * @param BindToScope Flag indicating whether the SDK should bind the new transaction to the scope
 	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentryTransaction* StartTransactionWithContextAndTimestamp(USentryTransactionContext* Context, int64 Timestamp);
+	USentryTransaction* StartTransactionWithContextAndTimestamp(USentryTransactionContext* Context, int64 Timestamp, bool BindToScope = false);
 
 	/**
 	 * Starts a new transaction with given context and options.

--- a/plugin-dev/Source/Sentry/Public/SentryTransaction.h
+++ b/plugin-dev/Source/Sentry/Public/SentryTransaction.h
@@ -25,13 +25,21 @@ class SENTRY_API USentryTransaction : public UObject, public TSentryImplWrapper<
 	GENERATED_BODY()
 
 public:
-	/** Starts a new child span. */
+	/** Starts a new child span.
+	 *
+	 * @note: On Android, if the transaction is bound the scope
+	 * the SDK will put the new child span on the scope as well.
+	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentrySpan* StartChildSpan(const FString& Operation, const FString& Description);
+	USentrySpan* StartChildSpan(const FString& Operation, const FString& Description, bool BindToScope = false);
 
-	/** Starts a new child span with timestamp. */
+	/** Starts a new child span with timestamp.
+	 *
+	 * @note: On Android, if the transaction is bound the scope
+	 * the SDK will put the new child span on the scope as well.
+	 */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")
-	USentrySpan* StartChildSpanWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp);
+	USentrySpan* StartChildSpanWithTimestamp(const FString& Operation, const FString& Description, int64 Timestamp, bool BindToScope = false);
 
 	/** Finishes and sends a transaction to Sentry. */
 	UFUNCTION(BlueprintCallable, Category = "Sentry")

--- a/plugin-dev/Source/Sentry/Public/SentryTransactionOptions.h
+++ b/plugin-dev/Source/Sentry/Public/SentryTransactionOptions.h
@@ -17,5 +17,6 @@ struct SENTRY_API FSentryTransactionOptions
 	UPROPERTY(BlueprintReadWrite, Category = "Sentry")
 	TMap<FString, FSentryVariant> CustomSamplingContext;
 
-	// TODO: Add other options such as `BindToScope` flag
+	UPROPERTY(BlueprintReadWrite, Category = "Sentry")
+	bool BindToScope = false;
 };


### PR DESCRIPTION
This PR adds an optional `BindToScope` parameter to functions that start transactions or spans, allowing them to be automatically linked with captured event.