### PR TITLE
fix: Prevent usage of internal UE logger during crash handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Prevent usage of internal UE logger during crash handling ([#1081](https://github.com/getsentry/sentry-unreal/pull/1081))
+
 ### Dependencies
 
 - Bump Android Gradle Plugin from v5.10.0 to v5.11.0 ([#1078](https://github.com/getsentry/sentry-unreal/pull/1078))

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -47,7 +47,7 @@ extern CORE_API bool GIsGPUCrashed;
 
 #if USE_SENTRY_NATIVE
 
-void PrintVerboseLog(sentry_level_t level, const char* message, va_list args, void* userdata)
+static void PrintVerboseLog(sentry_level_t level, const char* message, va_list args, void* closure)
 {
 	char buffer[512];
 	vsnprintf(buffer, 512, message, args);
@@ -364,6 +364,7 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 	sentry_options_set_on_crash(options, HandleOnCrash, this);
 	sentry_options_set_shutdown_timeout(options, 3000);
 	sentry_options_set_crashpad_wait_for_upload(options, settings->CrashpadWaitForUpload);
+	sentry_options_set_logger_enabled_when_crashed(options, false);
 
 	if (settings->bRequireUserConsent)
 	{

--- a/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
@@ -11,53 +11,6 @@
 #include "Windows/Infrastructure/WindowsSentryConverters.h"
 #include "Windows/WindowsPlatformStackWalk.h"
 
-static void PrintCrashLog(const sentry_ucontext_t* uctx)
-{
-#if !UE_VERSION_OLDER_THAN(5, 0, 0)
-	FWindowsSentryConverters::SentryCrashContextToString(uctx, GErrorExceptionDescription, UE_ARRAY_COUNT(GErrorExceptionDescription));
-
-	const SIZE_T StackTraceSize = 65535;
-
-#if !UE_VERSION_OLDER_THAN(5, 6, 0)
-	ANSICHAR* StackTrace = (ANSICHAR*)FMemory::Malloc(StackTraceSize);
-#else
-	ANSICHAR* StackTrace = (ANSICHAR*)GMalloc->Malloc(StackTraceSize);
-#endif // !UE_VERSION_OLDER_THAN(5, 6, 0)
-
-	StackTrace[0] = 0;
-
-	// Currently raw crash data stored in `uctx` can be utilized for stalk walking on Windows only
-	void* ProgramCounter = uctx->exception_ptrs.ExceptionRecord->ExceptionAddress;
-
-	FPlatformStackWalk::StackWalkAndDump(StackTrace, StackTraceSize, ProgramCounter);
-
-#if !UE_VERSION_OLDER_THAN(5, 6, 0)
-	FCString::StrncatTruncateDest(GErrorHist, UE_ARRAY_COUNT(GErrorHist), GErrorExceptionDescription);
-	FCString::StrncatTruncateDest(GErrorHist, UE_ARRAY_COUNT(GErrorHist), TEXT("\r\n\r\n"));
-	FCString::StrncatTruncateDest(GErrorHist, UE_ARRAY_COUNT(GErrorHist), ANSI_TO_TCHAR(StackTrace));
-#else
-	FCString::Strncat(GErrorHist, GErrorExceptionDescription, UE_ARRAY_COUNT(GErrorHist));
-	FCString::Strncat(GErrorHist, TEXT("\r\n\r\n"), UE_ARRAY_COUNT(GErrorHist));
-	FCString::Strncat(GErrorHist, ANSI_TO_TCHAR(StackTrace), UE_ARRAY_COUNT(GErrorHist));
-#endif // !UE_VERSION_OLDER_THAN(5, 6, 0)
-
-#if !NO_LOGGING
-	FDebug::LogFormattedMessageWithCallstack(LogSentrySdk.GetCategoryName(), __FILE__, __LINE__, TEXT("=== Critical error: ==="), GErrorHist, ELogVerbosity::Error);
-#endif // !NO_LOGGING
-
-#if !UE_VERSION_OLDER_THAN(5, 1, 0)
-	GLog->Panic();
-#endif // !UE_VERSION_OLDER_THAN(5, 1, 0)
-
-#if !UE_VERSION_OLDER_THAN(5, 6, 0)
-	FMemory::Free(StackTrace);
-#else
-	GMalloc->Free(StackTrace);
-#endif // !UE_VERSION_OLDER_THAN(5, 6, 0)
-
-#endif // !UE_VERSION_OLDER_THAN(5, 0, 0)
-}
-
 void FWindowsSentrySubsystem::ConfigureHandlerPath(sentry_options_t* Options)
 {
 	const FString HandlerPath = GetHandlerPath();
@@ -73,10 +26,6 @@ void FWindowsSentrySubsystem::ConfigureHandlerPath(sentry_options_t* Options)
 
 sentry_value_t FWindowsSentrySubsystem::OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure)
 {
-	// Ensures that error message and corresponding callstack flushed to a log file (if available)
-	// before it's attached to the captured crash event and uploaded to Sentry.
-	PrintCrashLog(uctx);
-
 	return FMicrosoftSentrySubsystem::OnCrash(uctx, event, closure);
 }
 


### PR DESCRIPTION
* Prevent usage of internal UE logger during crash handling
* Disable console logging for Windows crashes