### PR TITLE
Fix crash when obtaining `jclass` references on Android

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -29,6 +29,16 @@
 #include "Misc/OutputDeviceError.h"
 #include "Serialization/JsonSerializer.h"
 
+FAndroidSentrySubsystem::FAndroidSentrySubsystem()
+{
+	SentryJavaClasses::InitJavaClassRefsCache();
+}
+
+FAndroidSentrySubsystem::~FAndroidSentrySubsystem()
+{
+	SentryJavaClasses::ClearJavaClassRefsCache();
+}
+
 void FAndroidSentrySubsystem::InitWithSettings(const USentrySettings* settings, USentryBeforeSendHandler* beforeSendHandler, USentryBeforeBreadcrumbHandler* beforeBreadcrumbHandler, USentryTraceSampler* traceSampler)
 {
 	TSharedPtr<FJsonObject> SettingsJson = MakeShareable(new FJsonObject);

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
@@ -7,6 +7,9 @@
 class FAndroidSentrySubsystem : public ISentrySubsystem
 {
 public:
+	FAndroidSentrySubsystem();
+	~FAndroidSentrySubsystem();
+
 	virtual void InitWithSettings(const USentrySettings* settings, USentryBeforeSendHandler* beforeSendHandler, USentryBeforeBreadcrumbHandler* beforeBreadcrumbHandler, USentryTraceSampler* traceSampler) override;
 	virtual void Close() override;
 	virtual bool IsEnabled() override;

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryDataTypes.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryDataTypes.h
@@ -2,6 +2,8 @@
 
 #pragma once
 
+#include "CoreMinimal.h"
+
 #include "Android/AndroidJNI.h"
 
 enum class ESentryJavaClassType : uint8

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaClasses.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaClasses.h
@@ -41,4 +41,14 @@ struct SentryJavaClasses
 	const static FSentryJavaClass Float;
 	const static FSentryJavaClass Boolean;
 	const static FSentryJavaClass String;
+
+	// Java class references cache
+	static void InitJavaClassRefsCache();
+	static void ClearJavaClassRefsCache();
+
+	static jclass GetCachedJavaClassRef(const FSentryJavaClass& ClassData);
+	static jclass FindJavaClassRef(const FSentryJavaClass& ClassData);
+
+private:
+	static TMap<FName, jclass> JavaClassRefsCache;
 };


### PR DESCRIPTION
Closes #848 