### PR TITLE
Fix screenshot capture after Sentry disabled on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add screenshot capturing for ensure/assert events on Android ([#1097](https://github.com/getsentry/sentry-unreal/pull/1097))
 
+### Fixes
+
+- Fix screenshot capture after Sentry disabled on Mac ([#1101](https://github.com/getsentry/sentry-unreal/pull/1101))
+
 ### Dependencies
 
 - Bump Java SDK (Android) from v8.22.0 to v8.23.0 ([#1098](https://github.com/getsentry/sentry-unreal/pull/1098))

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
@@ -20,11 +20,22 @@ void FMacSentrySubsystem::InitWithSettings(const USentrySettings* settings, USen
 
 	if (IsEnabled() && isScreenshotAttachmentEnabled)
 	{
-		FCoreDelegates::OnHandleSystemError.AddLambda([this]()
+		OnHandleSystemErrorDelegateHandle = FCoreDelegates::OnHandleSystemError.AddLambda([this]()
 		{
 			TryCaptureScreenshot();
 		});
 	}
+}
+
+void FMacSentrySubsystem::Close()
+{
+	if (OnHandleSystemErrorDelegateHandle.IsValid())
+	{
+		FCoreDelegates::OnHandleSystemError.Remove(OnHandleSystemErrorDelegateHandle);
+		OnHandleSystemErrorDelegateHandle.Reset();
+	}
+
+	FAppleSentrySubsystem::Close();
 }
 
 TSharedPtr<ISentryId> FMacSentrySubsystem::CaptureEnsure(const FString& type, const FString& message)

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
@@ -8,6 +8,7 @@ class FMacSentrySubsystem : public FAppleSentrySubsystem
 {
 public:
 	virtual void InitWithSettings(const USentrySettings* settings, USentryBeforeSendHandler* beforeSendHandler, USentryBeforeBreadcrumbHandler* beforeBreadcrumbHandler, USentryBeforeLogHandler* beforeLogHandler, USentryTraceSampler* traceSampler) override;
+	virtual void Close() override;
 
 	virtual TSharedPtr<ISentryId> CaptureEnsure(const FString& type, const FString& message) override;
 
@@ -16,6 +17,9 @@ public:
 protected:
 	virtual FString GetGameLogPath() const override;
 	virtual FString GetLatestGameLog() const override;
+
+private:
+	FDelegateHandle OnHandleSystemErrorDelegateHandle;
 };
 
 typedef FMacSentrySubsystem FPlatformSentrySubsystem;


### PR DESCRIPTION
This PR fixes an issue where the SDK would still attempt to capture a screenshot during an assert or crash even after Sentry was disabled at runtime.