### PR TITLE
Add runtime safety checks for subsystem inputs and returned data

### DIFF
--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -265,9 +265,9 @@ void USentrySubsystem::ClearBreadcrumbs()
 void USentrySubsystem::AddAttachment(USentryAttachment* Attachment)
 {
 	check(SubsystemNativeImpl);
-	check(Attachment)
+	check(Attachment);
 
-		if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
+	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
 	{
 		return;
 	}


### PR DESCRIPTION
This PR introduces the following changes:
- Add extra checks in `USentrySubsystem` methods to ensure `nullptr` inputs are handled gracefully
- Add validation for `EventId` and `Transaction` return values
- Remove unnecessary `UObject` creation when capturing feedback with parameters

Supersedes #956

#skip-changelog