### PR TITLE
Fix binaries copying for FAB version of the plugin

### DIFF
--- a/plugin-dev/Scripts/post-build-steps-win.bat
+++ b/plugin-dev/Scripts/post-build-steps-win.bat
@@ -10,23 +10,28 @@ set "PROJECT_FILE=%~5"
 set "PLUGIN_DIR=%~6"
 set "ENGINE_DIR=%~7"
 
-REM Copy crashpad handler executable to plugin's Binaries\Linux dir if it doesn't exist there
-REM This enables cross-compilation for Linux on Windows with FAB version of the plugin
-set "CRASHPAD_HANDLER_LINUX=%PLUGIN_DIR%\Binaries\Linux\crashpad_handler"
+set "LINUX_BIN_DIR=%PLUGIN_DIR%\Binaries\Linux"
+set "LINUX_SOURCE_DIR=%PLUGIN_DIR%\Source\ThirdParty\Linux\bin"
+
+REM Copy crashpad handler to plugin's Binaries\Linux for cross-compilation on Windows
 if "%TARGET_PLATFORM%"=="Linux" (
-  if not exist "%CRASHPAD_HANDLER_LINUX%" (
-    if not exist "%PLUGIN_DIR%\Binaries\Linux\" (mkdir "%PLUGIN_DIR%\Binaries\Linux")
-    xcopy "%PLUGIN_DIR%\Source\ThirdParty\Linux\bin\*" "%PLUGIN_DIR%\Binaries\Linux\" /F /R /Y /I
+  if not exist "%LINUX_BIN_DIR%" (mkdir "%LINUX_BIN_DIR%")
+  if not exist "%LINUX_BIN_DIR%\crashpad_handler" (
+    copy /Y "%LINUX_SOURCE_DIR%\crashpad_handler" "%LINUX_BIN_DIR%\"
   )
 )
 
-REM Copy crashpad handler executable to plugin's Binaries\Win64 dir if it doesn't exist there
-REM Epic obfuscates any extra binaries when pre-building the plugin for FAB
-set "CRASHPAD_HANDLER_WIN=%PLUGIN_DIR%\Binaries\Win64\crashpad_handler.exe"
+set "WIN64_BIN_DIR=%PLUGIN_DIR%\Binaries\Win64"
+set "WIN64_SOURCE_DIR=%PLUGIN_DIR%\Source\ThirdParty\Win64\bin"
+
+REM Copy crashpad binaries to plugin's Binaries\Win64 (FAB compatibility)
 if "%TARGET_PLATFORM%"=="Win64" (
-  if not exist "%CRASHPAD_HANDLER_WIN%" (
-    if not exist "%PLUGIN_DIR%\Binaries\Win64\" (mkdir "%PLUGIN_DIR%\Binaries\Win64")
-    xcopy "%PLUGIN_DIR%\Source\ThirdParty\Win64\bin\*" "%PLUGIN_DIR%\Binaries\Win64\" /F /R /Y /I
+  if not exist "%WIN64_BIN_DIR%" (mkdir "%WIN64_BIN_DIR%")
+  if not exist "%WIN64_BIN_DIR%\crashpad_handler.exe" (
+    copy /Y "%WIN64_SOURCE_DIR%\crashpad_handler.exe" "%WIN64_BIN_DIR%\"
+  )
+  if not exist "%WIN64_BIN_DIR%\crashpad_wer.dll" (
+    copy /Y "%WIN64_SOURCE_DIR%\crashpad_wer.dll" "%WIN64_BIN_DIR%\"
   )
 )
 


### PR DESCRIPTION
This PR address the issue with missing Crashpad/WER module binaries in FAB version of the plugin (some changes made in #1108 were accidentally overwritten #1114).

#skip-changelog