### PR TITLE
chore: Add UE 5.7 support for Windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
       fail-fast: false
       matrix:
         # Note: these versions must match scripts/packaging/engine-versions.txt
-        unreal: ['4.27', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6']
+        unreal: ['4.27', '5.0', '5.1', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7']
     uses: ./.github/workflows/test-windows.yml
     with:
       unreal-version: ${{ matrix.unreal }}
@@ -194,7 +194,7 @@ jobs:
       fail-fast: false
       matrix:
         # Integration tests only for UE 5.2 and newer where CRC can be disabled
-        unreal: ['5.2', '5.3', '5.4', '5.5', '5.6']
+        unreal: ['5.2', '5.3', '5.4', '5.5', '5.6', '5.7']
     uses: ./.github/workflows/integration-test-windows.yml
     with:
       unreal-version: ${{ matrix.unreal }}


### PR DESCRIPTION
This PR adds UE 5.7 CI checks support for Windows (see linked issue for details).

Closes #1153

#skip-changelog