### PR TITLE
Remove unused envelope item conversion utility

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
@@ -325,18 +325,6 @@ FString FGenericPlatformSentryConverters::SentryLevelToString(ESentryLevel level
 	return Result;
 }
 
-TArray<uint8> FGenericPlatformSentryConverters::SentryEnvelopeToByteArray(sentry_envelope_t* envelope)
-{
-	size_t size;
-	ANSICHAR* serializedEnvelopeStr = sentry_envelope_serialize(envelope, &size);
-
-	TArray<uint8> envelopeData = TArray<uint8>(reinterpret_cast<uint8*>(serializedEnvelopeStr), size);
-
-	sentry_string_free(serializedEnvelopeStr);
-
-	return envelopeData;
-}
-
 ELogVerbosity::Type FGenericPlatformSentryConverters::SentryLevelToLogVerbosity(sentry_level_t level)
 {
 	ELogVerbosity::Type LogVerbosity = ELogVerbosity::Error;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.h
@@ -36,7 +36,6 @@ public:
 
 	/** Other conversions */
 	static FString SentryLevelToString(ESentryLevel level);
-	static TArray<uint8> SentryEnvelopeToByteArray(sentry_envelope_t* envelope);
 	static ELogVerbosity::Type SentryLevelToLogVerbosity(sentry_level_t level);
 	static TSharedPtr<FJsonValue> VariantToJsonValue(const FSentryVariant& variant);
 	static TSharedPtr<FJsonValue> VariantArrayToJsonValue(const TArray<FSentryVariant>& array);


### PR DESCRIPTION
This PR removes unused `FGenericPlatformSentryConverters::SentryEnvelopeToByteArray` conversion method (no longer needed after custom transport implementation for Native SDK was removed https://github.com/getsentry/sentry-unreal/pull/748).

#skip-changelog