### PR TITLE
chore: Fix path to Cocoa SDK binaries when building plugin dependencies locally

### DIFF
--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -133,7 +133,7 @@ function buildSentryCocoaIos()
 
     # Extract the built XCFramework
     $tempExtractDir = "$PSScriptRoot/../build/temp-xcframework-ios"
-    extractXCFramework "$CocoaPath/Carthage/Sentry-Dynamic.xcframework.zip" $tempExtractDir
+    extractXCFramework "$CocoaPath/XCFrameworkBuildPath/Sentry-Dynamic.xcframework.zip" $tempExtractDir
 
     # Prepare output directories
     $iosOutDir = "$outDir/IOS"
@@ -198,7 +198,7 @@ function buildSentryCocoaMac()
 
     # Extract the built XCFramework
     $tempExtractDir = "$PSScriptRoot/../build/temp-xcframework-mac"
-    extractXCFramework "$CocoaPath/Carthage/Sentry-Dynamic.xcframework.zip" $tempExtractDir
+    extractXCFramework "$CocoaPath/XCFrameworkBuildPath/Sentry-Dynamic.xcframework.zip" $tempExtractDir
 
     # Prepare output directories
     $macOutDir = "$outDir/Mac"


### PR DESCRIPTION
This PR fixes the path to the Cocoa SDK binaries allowing them to be copied into the plugin’s `ThirdParty` directory when building dependencies locally via `build-deps.ps1`.

#skip-changelog