### PR TITLE
Fix build issues when targeting Android Shipping configuration

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -169,24 +169,18 @@ jobs:
             -package \
             -archive
       
-      - name: Create sentry.properties for symbol upload
+      - name: Build Android package (Shipping)
+        id: build-android-shipping
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
           SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
         run: |
-          cat <<EOF > checkout/sample/sentry.properties
-          [Sentry]
-          defaults.org=$SENTRY_ORG
-          defaults.project=$SENTRY_PROJECT
-          auth.token=$SENTRY_AUTH_TOKEN
-          EOF
-
-      - name: Build Android package (Shipping)
-        id: build-android-shipping
-        run: |
           docker exec -w /workspace/checkout/sample \
             -e TMPDIR=/home/gh/.cache/tmp \
+            -e SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
+            -e SENTRY_ORG="$SENTRY_ORG" \
+            -e SENTRY_PROJECT="$SENTRY_PROJECT" \
             unreal /home/ue4/UnrealEngine/Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
             -project=/workspace/checkout/sample/SentryPlayground.uproject \
             -archivedirectory=/workspace/checkout/sample/Builds \


### PR DESCRIPTION
In Android SDK 8.32.0 ([#4999](https://github.com/getsentry/sentry-java/pull/4999)), a reference to the `ApplicationStartInfo` class (API 35) was introduced. When targeting Android SDK 34, this causes the build to fail with a `Missing class` error during `:app:minifyReleaseWithR8`.

Although the class presence is checked at runtime, the reference can still break the build in environments where only older Android build tools are available, such as the UE 5.5 Docker image used in CI.

Key change:
- Add R8 proguard rule `-dontwarn android.app.ApplicationStartInfo`

#skip-changelog