### PR TITLE
chore: Use `ubuntu-latest-4-cores` for running Linux CI checks

### DIFF
--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-4-cores
 
     steps:
       - name: Free disk space


### PR DESCRIPTION
The `test-linux.yml` workflow started failing for UE 5.6 and UE 5.7 with `System.IO.IOException: No space left on device`. Running disk cleanup before pulling the Unreal Engine Docker images is no longer sufficient for these newer engine versions.

To address this, the workflow is switched to the larger `ubuntu-latest-4-cores` runner, matching the setup already used for Android builds where disk requirements are higher due to additional platform files included in the engine distribution.

#skip-changelog