### PR TITLE
chore: Skip plugin build for UE 5.0-5.1 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,8 +142,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Note: these versions must match scripts/packaging/engine-versions.txt
-        # Note: Currently 5.0 is not supported due to ue4-docker issue https://github.com/adamrehn/ue4-docker/issues/373
         unreal: ['4.27', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7']
     uses: ./.github/workflows/test-linux.yml
     with:
@@ -156,7 +154,6 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Note: these versions must match scripts/packaging/engine-versions.txt
         unreal: ['4.27', '5.2', '5.3', '5.4', '5.5', '5.6', '5.7']
     uses: ./.github/workflows/test-windows.yml
     with:
@@ -193,7 +190,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Integration tests only for UE 5.2 and newer where CRC can be disabled
+        # Integration tests are supported only for UE 5.2 and newer where CRC can be disabled
         unreal: ['5.2', '5.3', '5.4', '5.5', '5.6', '5.7']
     uses: ./.github/workflows/integration-test-windows.yml
     with:


### PR DESCRIPTION
Since there are very few organizations still using the Unreal SDK with UE 5.0–5.1, these can be removed from the list of engine versions covered by CI checks.

This should also improve overall CI stability by reducing the number of Docker images that have to be pulled simultaneously from the GitHub Package Registry on each pipeline run, lowering the chance of hitting the “too many requests” error.

#skip-changelog