### PR TITLE
Fix build errors for Android target

### DIFF
--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -34,13 +34,13 @@
             <true>
                 <copyFile src="$S(ProjectDir)/sentry.properties" dst="$S(BuildDir)/gradle/sentry.properties" />
                 <copyFile src="$S(ProjectDir)/sentry.properties" dst="$S(BuildDir)/gradle/AFSProject/app/sentry.properties" />
-                <if condition="bUseLegacyGradlePlugin">
-                    <false>
-                        <log text="Modifying engine's Gradle version used by replacing gradle-wrapper.properties"/>
-                        <copyFile src="$S(PluginDir)/../../Gradle/gradle-wrapper.properties" dst="$S(BuildDir)/gradle/gradle/wrapper/gradle-wrapper.properties" />
-                    </false>
-                </if>
             </true>
+        </if>
+        <if condition="bUseLegacyGradlePlugin">
+            <false>
+                <log text="Modifying engine's Gradle version used by replacing gradle-wrapper.properties"/>
+                <copyFile src="$S(PluginDir)/../../Gradle/gradle-wrapper.properties" dst="$S(BuildDir)/gradle/gradle/wrapper/gradle-wrapper.properties" />
+            </false>
         </if>
     </prebuildCopies>
 
@@ -170,7 +170,7 @@
             <false>
                 <insert>
                     dependencies {
-                        classpath 'com.android.tools.build:gradle:8.5.2'
+                        classpath 'com.android.tools.build:gradle:7.4.2'
                     }
                 </insert>
             </false>


### PR DESCRIPTION
Android SDK 8.35.0 added `TombstoneParser` that references the optional `epitaph` library for parsing tombstones which should now be used instead of `protobuf-javalite` (https://github.com/getsentry/sentry-java/pull/5157).

#skip-changelog