### PR TITLE
Add UE version guard for automatic UObject count metric

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Performance/SentryPerfGameStatsMonitor.cpp
+++ b/plugin-dev/Source/Sentry/Private/Performance/SentryPerfGameStatsMonitor.cpp
@@ -56,8 +56,10 @@ bool FSentryPerfGameStatsMonitor::OnTick(float DeltaTime)
 	const FPlatformMemoryStats MemStats = FPlatformMemory::GetStats();
 	Sentry->AddGaugeWithAttributes(TEXT("game.perf.used_memory"), static_cast<float>(MemStats.UsedPhysical), FSentryUnit(ESentryUnit::Byte), Attributes);
 
+#if !UE_VERSION_OLDER_THAN(5, 3, 0)
 	const int32 UObjectCount = GUObjectArray.GetObjectArrayNumMinusAvailable();
 	Sentry->AddGaugeWithAttributes(TEXT("game.perf.uobject_count"), static_cast<float>(UObjectCount), FSentryUnit(ESentryUnit::None), Attributes);
+#endif
 
 	return true;
 }

--- a/plugin-dev/Source/Sentry/Private/Performance/SentryPerfGameStatsMonitor.h
+++ b/plugin-dev/Source/Sentry/Private/Performance/SentryPerfGameStatsMonitor.h
@@ -15,7 +15,7 @@ class FSentryPerfMetricAttributes;
  *
  * Emits:
  * - game.perf.used_memory (gauge, bytes) — process physical memory usage
- * - game.perf.uobject_count (gauge) — number of active UObjects
+ * - game.perf.uobject_count (gauge) — number of active UObjects (UE 5.3+)
  */
 class FSentryPerfGameStatsMonitor
 {


### PR DESCRIPTION
This PR fixes build errors in older engine versions (UE 4.27–5.2) caused by the use of `GUObjectArray.GetObjectArrayNumMinusAvailable()` which is required to track the number of active UObjects (`game.perf.uobject_count`). This API is unavailable or has limited support across target configurations in those versions, so for now the corresponding metric will only be tracked in UE 5.3 and newer.

Documentation:
- https://github.com/getsentry/sentry-docs/pull/17112

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1305

#skip-changelog