### PR TITLE
chore: Add PR validation workflow

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -16,14 +16,14 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v2
         with:
           app-id: ${{ vars.SDK_MAINTAINER_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_MAINTAINER_BOT_PRIVATE_KEY }}
 
       - name: Validate PR
         id: validate
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
@@ -270,7 +270,7 @@ jobs:
     steps:
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859  # v2
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v2
         with:
           app-id: ${{ vars.SDK_MAINTAINER_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_MAINTAINER_BOT_PRIVATE_KEY }}
@@ -283,7 +283,7 @@ jobs:
           gh pr ready "$PR_URL" --undo
 
       - name: Label and comment
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea  # v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |


### PR DESCRIPTION
## Summary
- Adds a `validate-pr.yml` workflow to automatically validate non-maintainer PRs
- Checks that PRs reference a GitHub issue with prior discussion between the author and a maintainer
- Closes PRs that don't meet contribution guidelines (no issue reference, no maintainer discussion, or issue assigned to someone else)
- Enforces that all PRs start as drafts

Rollout of getsentry/sentry-python#4233 across all SDK repos.

## Test plan
- [ ] Verify workflow file is valid YAML
- [ ] Confirm `SDK_MAINTAINER_BOT_APP_ID` var and `SDK_MAINTAINER_BOT_PRIVATE_KEY` secret are available to this repo
- [ ] Test with a non-maintainer PR that has no issue reference (should be closed)
- [ ] Test with a maintainer PR (should be skipped)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>