### PR TITLE
fix(ci): Update validate-pr action to remove draft enforcement

### DIFF
--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: getsentry/github-workflows/validate-pr@4ff40ada546d4a31b852a4279828b989a6193497
+      - uses: getsentry/github-workflows/validate-pr@0b52fc6a867b744dcbdf5d25c18bc8d1c95710e1
         with:
           app-id: ${{ vars.SDK_MAINTAINER_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_MAINTAINER_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
The validate-pr action's draft enforcement step was failing with:

```
API call failed: GraphQL: Resource not accessible by integration (convertPullRequestToDraft)
```

Draft enforcement has been removed from the shared action in getsentry/github-workflows#159. This bumps the pinned SHA.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>