### PR TITLE
chore: Add automatic Crash Reporter updates tracking in CI

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -1,4 +1,4 @@
-name: update-dependencies
+name: Update dependencies
 
 on:
   # Run every day.
@@ -33,6 +33,14 @@ jobs:
     with:
       path: modules/sentry-cocoa.properties
       name: Cocoa SDK
+    secrets:
+      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+
+  crash-reporter:
+    uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2
+    with:
+      path: modules/sentry-crash-reporter.properties
+      name: Crash Reporter
     secrets:
       api-token: ${{ secrets.CI_DEPLOY_KEY }}
 


### PR DESCRIPTION
This PR adds Sentry Crash Reporter to the list of Unreal plugin dependencies for which CI tracks updates automatically.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1342


#skip-changelog