### PR TITLE
Move Sentry Crash Reporter settings to a dedicated section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add WinGDK platform support ([#1337](https://github.com/getsentry/sentry-unreal/pull/1337))
 - Add out-of-process screenshot capturing on Windows ([#1325](https://github.com/getsentry/sentry-unreal/pull/1325))
 - Add native backend support for Mac ([#1333](https://github.com/getsentry/sentry-unreal/pull/1333))
+- Add a dedicated plugin settings section for Sentry Crash Reporter([#1350](https://github.com/getsentry/sentry-unreal/pull/1350))
 
 ### Fixes
 

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -472,13 +472,13 @@ class SENTRY_API USentrySettings : public UObject
 		Meta = (DisplayName = "Enable logging during crash handling", ToolTip = "Flag indicating whether the SDK should log additional crash information (such as stack traces and error messages). This is intended for debug builds only and is not safe for production use."))
 	bool EnableOnCrashLogging;
 
-	UPROPERTY(Config, EditAnywhere, Category = "General|Native",
-		Meta = (DisplayName = "Enable external crash reporter",
-			ToolTip = "When enabled, a crash reporter dialog is shown to the user after a crash, allowing them to provide feedback before submitting the crash report. Supported on Windows and Linux only."))
+	UPROPERTY(Config, EditAnywhere, Category = "Sentry Crash Reporter",
+		Meta = (DisplayName = "Enable Sentry Crash Reporter",
+			ToolTip = "When enabled, the Sentry Crash Reporter dialog is shown to the user after a crash, allowing them to review crash details and provide feedback before the report is submitted."))
 	bool EnableExternalCrashReporter;
 
-	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "General|Native",
-		Meta = (DisplayName = "External crash reporter appearance", ToolTip = "Customize the appearance of the external crash reporter dialog.",
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "Sentry Crash Reporter",
+		Meta = (DisplayName = "Sentry Crash Reporter appearance", ToolTip = "Customize the appearance of the Sentry Crash Reporter dialog.",
 			EditCondition = "EnableExternalCrashReporter"))
 	FSentryCrashReporterAppearance CrashReporterAppearance;
 
@@ -594,12 +594,12 @@ class SENTRY_API USentrySettings : public UObject
 			EditCondition = "UploadSymbolsAutomatically"))
 	bool UseLegacyGradlePlugin;
 
-	UPROPERTY(Config, EditAnywhere, Category = "Crash Reporter",
-		Meta = (DisplayName = "Crash Reporter Endpoint", ToolTip = "Endpoint that Unreal Engine Crah Reporter should use in order to upload crash data to Sentry."))
+	UPROPERTY(Config, EditAnywhere, Category = "Unreal Crash Reporter",
+		Meta = (DisplayName = "Crash Reporter Endpoint", ToolTip = "Endpoint that Unreal Crash Reporter should use in order to upload crash data to Sentry."))
 	FString CrashReporterUrl;
 
-	UPROPERTY(Config, EditAnywhere, Category = "Crash Reporter",
-		Meta = (DisplayName = "Allow Crash Reporter context propagation", ToolTip = "Flag indicating whether to automatically propagate additional data (e.g., tags, context) set via Sentry SDK interface to Crash Reporter."))
+	UPROPERTY(Config, EditAnywhere, Category = "Unreal Crash Reporter",
+		Meta = (DisplayName = "Allow Unreal Crash Reporter context propagation", ToolTip = "Flag indicating whether to automatically propagate additional data (e.g., tags, context) set via Sentry SDK interface to Unreal Crash Reporter."))
 	bool EnableCrashReporterContextPropagation;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Consent",

--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -65,7 +65,8 @@ void FSentrySettingsCustomization::CustomizeDetails(IDetailLayoutBuilder& Detail
 {
 	DrawGeneralNotice(DetailBuilder);
 	DrawDebugSymbolsNotice(DetailBuilder);
-	DrawCrashReporterNotice(DetailBuilder);
+	DrawSentryCrashReporterSection(DetailBuilder);
+	DrawUnrealCrashReporterNotice(DetailBuilder);
 
 	SetPropertiesUpdateHandler(DetailBuilder);
 }
@@ -148,9 +149,61 @@ void FSentrySettingsCustomization::DrawGeneralNotice(IDetailLayoutBuilder& Detai
 #endif
 }
 
-void FSentrySettingsCustomization::DrawCrashReporterNotice(IDetailLayoutBuilder& DetailBuilder)
+void FSentrySettingsCustomization::DrawSentryCrashReporterSection(IDetailLayoutBuilder& DetailBuilder)
 {
-	IDetailCategoryBuilder& CrashReporterCategory = DetailBuilder.EditCategory(TEXT("Crash Reporter"));
+	IDetailCategoryBuilder& SentryCrashReporterCategory = DetailBuilder.EditCategory(TEXT("Sentry Crash Reporter"));
+
+#if UE_VERSION_OLDER_THAN(5, 0, 0)
+	const ISlateStyle& Style = FEditorStyle::Get();
+#else
+	const ISlateStyle& Style = FAppStyle::Get();
+#endif
+
+	// clang-format off
+	SentryCrashReporterCategory.AddCustomRow(FText::FromString(TEXT("SentryCrashReporter")), false)
+		.WholeRowWidget
+		[
+			SNew(SVerticalBox)
+			+ SVerticalBox::Slot()
+			.Padding(1)
+			.AutoHeight()
+			[
+				SNew(SBorder)
+				.Padding(1)
+				[
+					SNew(SHorizontalBox)
+					+ SHorizontalBox::Slot()
+					.Padding(FMargin(10, 10, 10, 10))
+					.FillWidth(1.0f)
+					[
+						SNew(SRichTextBlock)
+							.Text(FText::FromString(TEXT("Sentry Crash Reporter is a standalone application that can be used instead of the default Unreal Crash Reporter. "
+								"It lets users review crash details (tags, context, stacktrace) and submit feedback before the report is sent to Sentry. "
+								"Supported on all desktop platforms (on macOS the <RichTextBlock.TextHighlight>native crash backend</> must be enabled). "
+								"For symbolicated stacktraces in Shipping builds, enable \"Include Debug Files in Shipping Builds\" in packaging settings.")))
+							.TextStyle(Style, "MessageLog")
+							.DecoratorStyleSet(&Style)
+							.AutoWrapText(true)
+					]
+				]
+			]
+			+ SVerticalBox::Slot()
+			.Padding(FMargin(0, 10, 0, 10))
+			.VAlign(VAlign_Top)
+			[
+				SNew(SRichTextBlock)
+				.Text(FText::FromString(TEXT("<a id=\"browser\" href=\"https://docs.sentry.io/platforms/unreal/configuration/setup-crashreporter/#sentry-crash-reporter\">View the Sentry Crash Reporter setup documentation -></>")))
+				.AutoWrapText(true)
+				.DecoratorStyleSet(&FCoreStyle::Get())
+				+ SRichTextBlock::HyperlinkDecorator(TEXT("browser"), FSlateHyperlinkRun::FOnClick::CreateStatic(&OnDocumentationLinkClicked))
+			]
+		];
+	// clang-format on
+}
+
+void FSentrySettingsCustomization::DrawUnrealCrashReporterNotice(IDetailLayoutBuilder& DetailBuilder)
+{
+	IDetailCategoryBuilder& CrashReporterCategory = DetailBuilder.EditCategory(TEXT("Unreal Crash Reporter"));
 
 	TSharedPtr<IPropertyHandle> CrashReporterUrlHandle = DetailBuilder.GetProperty(GET_MEMBER_NAME_CHECKED(USentrySettings, CrashReporterUrl));
 
@@ -178,7 +231,7 @@ void FSentrySettingsCustomization::DrawCrashReporterNotice(IDetailLayoutBuilder&
 					.FillWidth(1.0f)
 					[
 						SNew(SRichTextBlock)
-							.Text(FText::FromString(TEXT("In order to configure Crash Reporter use Sentry's Unreal Engine Endpoint from the Client Keys settings page. "
+							.Text(FText::FromString(TEXT("In order to configure Unreal Crash Reporter use Sentry's Unreal Engine Endpoint from the Client Keys settings page. "
 								"This will include which project within Sentry you want to see the crashes arriving in real time. "
 								"Note that it's accomplished by modifying the `CrashReportClient` section in the global <RichTextBlock.TextHighlight>DefaultEngine.ini</> file. "
 								"Changing the engine is necessary for this to work!")))
@@ -193,7 +246,7 @@ void FSentrySettingsCustomization::DrawCrashReporterNotice(IDetailLayoutBuilder&
 			.VAlign(VAlign_Top)
 			[
 				SNew(SRichTextBlock)
-				.Text(FText::FromString(TEXT("<a id=\"browser\" href=\"https://docs.sentry.io/platforms/unreal/setup-crashreporter/\">View the Crash Reporter setup documentation -></>")))
+				.Text(FText::FromString(TEXT("<a id=\"browser\" href=\"https://docs.sentry.io/platforms/unreal/setup-crashreporter/\">View the Unreal Crash Reporter setup documentation -></>")))
 				.AutoWrapText(true)
 				.DecoratorStyleSet(&FCoreStyle::Get())
 				+ SRichTextBlock::HyperlinkDecorator(TEXT("browser"), FSlateHyperlinkRun::FOnClick::CreateStatic(&OnDocumentationLinkClicked))

--- a/plugin-dev/Source/SentryEditor/Public/SentrySettingsCustomization.h
+++ b/plugin-dev/Source/SentryEditor/Public/SentrySettingsCustomization.h
@@ -36,7 +36,8 @@ public:
 
 private:
 	void DrawGeneralNotice(IDetailLayoutBuilder& DetailBuilder);
-	void DrawCrashReporterNotice(IDetailLayoutBuilder& DetailBuilder);
+	void DrawSentryCrashReporterSection(IDetailLayoutBuilder& DetailBuilder);
+	void DrawUnrealCrashReporterNotice(IDetailLayoutBuilder& DetailBuilder);
 	void DrawDebugSymbolsNotice(IDetailLayoutBuilder& DetailBuilder);
 
 	void SetPropertiesUpdateHandler(IDetailLayoutBuilder& DetailBuilder);


### PR DESCRIPTION
This PR reorganizes the plugin settings to clearly distinguish Sentry’s Crash Reporter from Unreal Engine’s built-in Crash Reporter, now that the former has matured into a full desktop feature supported on Windows, Linux, and macOS (with the native backend).

- Promotes `EnableExternalCrashReporter` and `CrashReporterAppearance` from `General | Native` into a new top-level **Sentry Crash Reporter** section.
- Renames the existing top-level **Crash Reporter** section (which configures Epic’s CrashReportClient endpoint) to **Unreal Crash Reporter** to remove ambiguity.
- Adds a notice box at the top of the **Sentry Crash Reporter** section describing the feature, platform support (including the macOS native-backend caveat), the Shipping-build symbolication requirement, and a link to the docs.
- Updates user-facing `DisplayName` and `ToolTip` strings to use the clarified product names instead of generic “Crash Reporter” or “external crash reporter.” Code, `.ini` keys, and C++/Blueprint APIs remain unchanged.

## Documentation
- https://github.com/getsentry/sentry-docs/pull/17394