### PR TITLE
Fix path resolution for platform-specific plugin binaries on WinGDK

### DIFF
--- a/plugin-dev/Source/Sentry/Private/SentryModule.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryModule.cpp
@@ -94,8 +94,14 @@ FString FSentryModule::GetPluginPath()
 
 FString FSentryModule::GetBinariesPath()
 {
-	// Windows ARM64 binaries are currently stored in Win64 dir so we need to set the right platform manually
-#if PLATFORM_WINDOWS && PLATFORM_CPU_ARM_FAMILY
+	// Unreal Engine currently stores Windows ARM64 binaries in the Win64 directory and does not distinguish by architecture,
+	// so when building the path to platform-specific plugin resources, the platform name must be set manually
+	// instead of relying on FPlatformProcess::GetBinariesSubdirectory().
+	// The same applies to WinGDK targets, which the engine treats as Win64 by default in this context.
+
+#if SENTRY_WINGDK
+	const FString PlatformDir = TEXT("WinGDK");
+#elif PLATFORM_WINDOWS && PLATFORM_CPU_ARM_FAMILY
 	const FString PlatformDir = TEXT("WinArm64");
 #else
 	const FString PlatformDir = FPlatformProcess::GetBinariesSubdirectory();
@@ -106,8 +112,14 @@ FString FSentryModule::GetBinariesPath()
 
 FString FSentryModule::GetThirdPartyPath()
 {
-	// Windows ARM64 binaries are still currently in Win64 dir so we need to set the right platform manually
-#if PLATFORM_WINDOWS && PLATFORM_CPU_ARM_FAMILY
+	// Unreal Engine currently stores Windows ARM64 binaries in the Win64 directory and does not distinguish by architecture,
+	// so when building the path to platform-specific plugin resources, the platform name must be set manually
+	// instead of relying on FPlatformProcess::GetBinariesSubdirectory().
+	// The same applies to WinGDK targets, which the engine treats as Win64 by default in this context.
+
+#if SENTRY_WINGDK
+	const FString PlatformDir = TEXT("WinGDK");
+#elif PLATFORM_WINDOWS && PLATFORM_CPU_ARM_FAMILY
 	const FString PlatformDir = TEXT("WinArm64");
 #else
 	const FString PlatformDir = FPlatformProcess::GetBinariesSubdirectory();

--- a/plugin-dev/Source/Sentry/Private/SentryModule.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryModule.cpp
@@ -12,6 +12,11 @@
 #include "UObject/Package.h"
 #include "UObject/UObjectGlobals.h"
 
+// SENTRY_WINGDK is explicitly defined only for Windows/WinGDK, so default it to 0 for other platforms to avoid -Wundef
+#ifndef SENTRY_WINGDK
+	#define SENTRY_WINGDK 0
+#endif
+
 #define LOCTEXT_NAMESPACE "FSentryModule"
 
 const FName FSentryModule::ModuleName = "Sentry";

--- a/plugin-dev/Source/Sentry/Private/SentryModule.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryModule.cpp
@@ -14,7 +14,7 @@
 
 // SENTRY_WINGDK is explicitly defined only for Windows/WinGDK, so default it to 0 for other platforms to avoid -Wundef
 #ifndef SENTRY_WINGDK
-	#define SENTRY_WINGDK 0
+#define SENTRY_WINGDK 0
 #endif
 
 #define LOCTEXT_NAMESPACE "FSentryModule"


### PR DESCRIPTION
This PR fixes `FSentryModule::GetBinariesPath()` utility that resolves the path to plugin’s platform-specific binaries dir for WinGDK target. This is required to enable experimental native backend support where the path to the crash handler executable (`sentry-crash.exe`) is set explicitly during Sentry initialization using `sentry_options_set_handler_pathw`.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1337
- https://github.com/getsentry/sentry-xbox/pull/128

#skip-changelog