### PR TITLE
Fix Crash Reporter documentation links in plugin settings menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Fix Crash Reporter documentation links in plugin settings menu ([#1373](https://github.com/getsentry/sentry-unreal/pull/1373))
+
 ## 1.11.0
 
 > [!IMPORTANT]

--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -246,7 +246,7 @@ void FSentrySettingsCustomization::DrawUnrealCrashReporterNotice(IDetailLayoutBu
 			.VAlign(VAlign_Top)
 			[
 				SNew(SRichTextBlock)
-				.Text(FText::FromString(TEXT("<a id=\"browser\" href=\"https://docs.sentry.io/platforms/unreal/configuration/crash-reporter/crash-reporter-client//\">View the Unreal Crash Reporter setup documentation -></>")))
+				.Text(FText::FromString(TEXT("<a id=\"browser\" href=\"https://docs.sentry.io/platforms/unreal/configuration/crash-reporter/crash-reporter-client/\">View the Unreal Crash Reporter setup documentation -></>")))
 				.AutoWrapText(true)
 				.DecoratorStyleSet(&FCoreStyle::Get())
 				+ SRichTextBlock::HyperlinkDecorator(TEXT("browser"), FSlateHyperlinkRun::FOnClick::CreateStatic(&OnDocumentationLinkClicked))

--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -192,7 +192,7 @@ void FSentrySettingsCustomization::DrawSentryCrashReporterSection(IDetailLayoutB
 			.VAlign(VAlign_Top)
 			[
 				SNew(SRichTextBlock)
-				.Text(FText::FromString(TEXT("<a id=\"browser\" href=\"https://docs.sentry.io/platforms/unreal/configuration/setup-crashreporter/#sentry-crash-reporter\">View the Sentry Crash Reporter setup documentation -></>")))
+				.Text(FText::FromString(TEXT("<a id=\"browser\" href=\"https://docs.sentry.io/platforms/unreal/configuration/crash-reporter/sentry-crash-reporter/#sentry-crash-reporter\">View the Sentry Crash Reporter setup documentation -></>")))
 				.AutoWrapText(true)
 				.DecoratorStyleSet(&FCoreStyle::Get())
 				+ SRichTextBlock::HyperlinkDecorator(TEXT("browser"), FSlateHyperlinkRun::FOnClick::CreateStatic(&OnDocumentationLinkClicked))
@@ -246,7 +246,7 @@ void FSentrySettingsCustomization::DrawUnrealCrashReporterNotice(IDetailLayoutBu
 			.VAlign(VAlign_Top)
 			[
 				SNew(SRichTextBlock)
-				.Text(FText::FromString(TEXT("<a id=\"browser\" href=\"https://docs.sentry.io/platforms/unreal/setup-crashreporter/\">View the Unreal Crash Reporter setup documentation -></>")))
+				.Text(FText::FromString(TEXT("<a id=\"browser\" href=\"https://docs.sentry.io/platforms/unreal/configuration/crash-reporter/crash-reporter-client//\">View the Unreal Crash Reporter setup documentation -></>")))
 				.AutoWrapText(true)
 				.DecoratorStyleSet(&FCoreStyle::Get())
 				+ SRichTextBlock::HyperlinkDecorator(TEXT("browser"), FSlateHyperlinkRun::FOnClick::CreateStatic(&OnDocumentationLinkClicked))


### PR DESCRIPTION
This PR fixes invalid documentation links opened from the plugin settings menu for both Sentry/Unreal Crash Reporters. The issue appeared after a recent Unreal SDK documentation update where the Crash Reporter instructions were split into separate pages.

Related items:
- https://github.com/getsentry/sentry-docs/pull/17394