### PR TITLE
Add experimental session replay capturing for Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Features
+
+- Add experimental session replay capturing for Android ([#1386](https://github.com/getsentry/sentry-unreal/pull/1386))
+
 ## 1.12.0
 
 ### Features

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -67,6 +67,7 @@ void FAndroidSentrySubsystem::InitWithSettings(const USentrySettings* settings, 
 	SettingsJson->SetNumberField(TEXT("sampleRate"), settings->SampleRate);
 	SettingsJson->SetNumberField(TEXT("maxBreadcrumbs"), settings->MaxBreadcrumbs);
 	SettingsJson->SetBoolField(TEXT("attachScreenshot"), settings->AttachScreenshot);
+	SettingsJson->SetBoolField(TEXT("attachSessionReplay"), settings->AttachSessionReplay);
 	SettingsJson->SetArrayField(TEXT("inAppInclude"), FAndroidSentryConverters::StrinArrayToJsonArray(settings->InAppInclude));
 	SettingsJson->SetArrayField(TEXT("inAppExclude"), FAndroidSentryConverters::StrinArrayToJsonArray(settings->InAppExclude));
 	SettingsJson->SetBoolField(TEXT("sendDefaultPii"), settings->SendDefaultPii);

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -73,7 +73,6 @@ public class SentryBridgeJava {
 					options.setSendDefaultPii(settingJson.getBoolean("sendDefaultPii"));
 					if(settingJson.getBoolean("attachSessionReplay")) {
 						options.getSessionReplay().setSessionSampleRate(1.0);
-						options.getSessionReplay().setOnErrorSampleRate(1.0);
 						options.getSessionReplay().setCaptureSurfaceViews(true);
 					}
 					JSONArray Includes = settingJson.getJSONArray("inAppInclude");

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -27,6 +27,7 @@ import io.sentry.Sentry;
 import io.sentry.SentryEvent;
 import io.sentry.SentryLevel;
 import io.sentry.SentryOptions;
+import io.sentry.SentryReplayOptions;
 import io.sentry.android.core.SentryAndroid;
 import io.sentry.android.core.SentryAndroidOptions;
 import io.sentry.exception.ExceptionMechanismException;
@@ -70,6 +71,11 @@ public class SentryBridgeJava {
 					options.setSampleRate(settingJson.getDouble("sampleRate"));
 					options.setMaxBreadcrumbs(settingJson.getInt("maxBreadcrumbs"));
 					options.setSendDefaultPii(settingJson.getBoolean("sendDefaultPii"));
+					if(settingJson.getBoolean("attachSessionReplay")) {
+						options.getSessionReplay().setSessionSampleRate(1.0);
+						options.getSessionReplay().setOnErrorSampleRate(1.0);
+						options.getSessionReplay().setCaptureSurfaceViews(true);
+					}
 					JSONArray Includes = settingJson.getJSONArray("inAppInclude");
 					for (int i = 0; i < Includes.length(); i++) {
 						options.addInAppInclude(Includes.getString(i));

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -340,11 +340,11 @@ class SENTRY_API USentrySettings : public UObject
 	bool EnableOutOfProcessScreenshots;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Attachments",
-		Meta = (DisplayName = "Attach session replay (for Xbox devkits only, experimental)", ToolTip = "When enabled, attaches a short retroactive video clip on crash, captured from the OS-managed game recording ring. Currently supported on Xbox development kits only."))
+		Meta = (DisplayName = "Attach session replay (experimental)", ToolTip = "Enables session replay capture. On Android, records a continuous video of the session and sends it with error events. On Xbox development kits, attaches a short retroactive video clip on crash, captured from the OS-managed game recording ring. Currently supported on Android and Xbox development kits only."))
 	bool AttachSessionReplay;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Attachments",
-		Meta = (DisplayName = "Session replay duration (ms)", ToolTip = "Requested duration of the retroactive session replay clip. The resulting clip can be shorter than the requested duration if it hasn't accumulated enough buffered frames yet.",
+		Meta = (DisplayName = "Session replay duration (ms, Xbox only)", ToolTip = "Requested duration of the retroactive session replay clip on Xbox. The resulting clip can be shorter than the requested duration if it hasn't accumulated enough buffered frames yet. This setting is ignored on Android, where the replay duration is determined by the Sentry SDK.",
 			EditCondition = "AttachSessionReplay", ClampMin = "1000", ClampMax = "15000"))
 	uint32 SessionReplayDurationMs;
 

--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -115,6 +115,7 @@
             dependencies {
                 implementation fileTree(dir: 'libs', include: ['*.aar', '*.jar'])
                 implementation "com.abovevacant:epitaph:0.1.1"
+                implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.24"
             }
 
             repositories {

--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -29,6 +29,7 @@
         <copyFile src="$S(PluginDir)/../ThirdParty/Android/sentry.jar" dst="$S(BuildDir)/gradle/app/libs/sentry.jar" />
         <copyFile src="$S(PluginDir)/../ThirdParty/Android/sentry-android-core-release.aar" dst="$S(BuildDir)/gradle/app/libs/sentry-android-core-release.aar" />
         <copyFile src="$S(PluginDir)/../ThirdParty/Android/sentry-android-ndk-release.aar" dst="$S(BuildDir)/gradle/app/libs/sentry-android-ndk-release.aar" />
+        <copyFile src="$S(PluginDir)/../ThirdParty/Android/sentry-android-replay-release.aar" dst="$S(BuildDir)/gradle/app/libs/sentry-android-replay-release.aar" />
         <copyFile src="$S(PluginDir)/../ThirdParty/Android/sentry-native-ndk-release.aar" dst="$S(BuildDir)/gradle/app/libs/sentry-native-ndk-release.aar" />
         <if condition="bUploadSymbols">
             <true>

--- a/scripts/build-android.sh
+++ b/scripts/build-android.sh
@@ -8,12 +8,13 @@ rm -rf "${sentryArtifactsDestination}/"*
 
 pushd ${sentryJavaRoot}
 ./gradlew -PsentryAndroidSdkName=sentry.native.android.unreal \
-    :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry:jar \
+    :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry-android-replay:assembleRelease :sentry:jar \
     --no-daemon --stacktrace --warning-mode none
 popd
 
 cp "${sentryJavaRoot}/sentry-android-ndk/build/outputs/aar/sentry-android-ndk-release.aar" "${sentryArtifactsDestination}/sentry-android-ndk-release.aar"
 cp "${sentryJavaRoot}/sentry-android-core/build/outputs/aar/sentry-android-core-release.aar" "${sentryArtifactsDestination}/sentry-android-core-release.aar"
+cp "${sentryJavaRoot}/sentry-android-replay/build/outputs/aar/sentry-android-replay-release.aar" "${sentryArtifactsDestination}/sentry-android-replay-release.aar"
 
 cp "${sentryJavaRoot}/sentry/build/libs/"sentry-*.jar "${sentryArtifactsDestination}/sentry.jar"
 

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -253,7 +253,7 @@ function buildSentryJava()
     try
     {
         ./gradlew -PsentryAndroidSdkName="sentry.native.android.unreal" `
-            :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry:jar --no-daemon --stacktrace --warning-mode none
+            :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry-android-replay:assembleRelease :sentry:jar --no-daemon --stacktrace --warning-mode none
 
         if ($LASTEXITCODE -ne 0)
         {
@@ -276,7 +276,41 @@ function buildSentryJava()
 
     Copy-Item "$JavaPath/sentry-android-ndk/build/outputs/aar/sentry-android-ndk-release.aar" -Destination "$androidOutDir/sentry-android-ndk-release.aar"
     Copy-Item "$JavaPath/sentry-android-core/build/outputs/aar/sentry-android-core-release.aar" -Destination "$androidOutDir/sentry-android-core-release.aar"
+    Copy-Item "$JavaPath/sentry-android-replay/build/outputs/aar/sentry-android-replay-release.aar" -Destination "$androidOutDir/sentry-android-replay-release.aar"
     Copy-Item "$JavaPath/sentry/build/libs/$("sentry-*.jar")" -Destination "$androidOutDir/sentry.jar"
+
+    # With version v8 of the sentry-java the Native SDK NDK has to be downloaded separately from the sentry-native repo release page
+    $configFile = "$JavaPath/gradle/libs.versions.toml"
+    if (-not (Test-Path $configFile))
+    {
+        throw "libs.versions.toml file not found at $configFile"
+    }
+
+    $tomlContent = Get-Content $configFile -Raw
+    if ($tomlContent -notmatch 'sentry-native-ndk[^\n]*version\s*=\s*"([^"]+)"')
+    {
+        throw "Failed to extract Native SDK NDK version from $configFile"
+    }
+    $nativeNdkVersion = $Matches[1]
+    Write-Host "Extracted Sentry Native NDK version: $nativeNdkVersion"
+
+    $nativeNdkCache = "$JavaPath/native-ndk-cache"
+    if (-not (Test-Path $nativeNdkCache))
+    {
+        New-Item $nativeNdkCache -ItemType Directory > $null
+    }
+
+    $nativeNdkZip = "$nativeNdkCache/sentry-native-ndk-$nativeNdkVersion.zip"
+    $nativeNdkUrl = "https://github.com/getsentry/sentry-native/releases/download/$nativeNdkVersion/sentry-native-ndk-$nativeNdkVersion.zip"
+
+    if (-not (Test-Path $nativeNdkZip))
+    {
+        Invoke-WebRequest -Uri $nativeNdkUrl -OutFile $nativeNdkZip
+    }
+
+    Expand-Archive -Path $nativeNdkZip -DestinationPath $nativeNdkCache -Force
+
+    Copy-Item "$nativeNdkCache/sentry-native-ndk-$nativeNdkVersion/sentry-native-ndk-release.aar" -Destination "$androidOutDir/sentry-native-ndk-release.aar"
 }
 
 function buildSentryNative()

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -464,8 +464,6 @@ Source/ThirdParty/Mac/Native/lib/libsentry.a
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/_CodeSignature/CodeResources
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/CodeResources
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/Info.plist
-Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/MacOS/._Sentry.CrashReporter.deps.json
-Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/MacOS/._Sentry.CrashReporter.runtimeconfig.json
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/MacOS/libclrgcexp.dylib
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/MacOS/libclrjit.dylib
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/MacOS/libcoreclr.dylib
@@ -748,6 +746,7 @@ Source/ThirdParty/Win64/Crashpad/lib/mini_chromium.lib
 Source/ThirdParty/Win64/Crashpad/lib/sentry.lib
 Source/ThirdParty/Win64/Native/bin/sentry-crash.exe
 Source/ThirdParty/Win64/Native/include/sentry.h
+Source/ThirdParty/Win64/Native/lib/sentry-wer.lib
 Source/ThirdParty/Win64/Native/lib/sentry.lib
 Source/ThirdParty/Win64/Sentry.CrashReporter.exe
 Source/ThirdParty/WinArm64/Crashpad/bin/crashpad_handler.exe
@@ -767,5 +766,6 @@ Source/ThirdParty/WinArm64/Crashpad/lib/mini_chromium.lib
 Source/ThirdParty/WinArm64/Crashpad/lib/sentry.lib
 Source/ThirdParty/WinArm64/Native/bin/sentry-crash.exe
 Source/ThirdParty/WinArm64/Native/include/sentry.h
+Source/ThirdParty/WinArm64/Native/lib/sentry-wer.lib
 Source/ThirdParty/WinArm64/Native/lib/sentry.lib
 Source/ThirdParty/WinArm64/Sentry.CrashReporter.exe

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -286,6 +286,7 @@ Source/SentryEditor/Public/SentrySymToolsDownloader.h
 Source/SentryEditor/SentryEditor.Build.cs
 Source/ThirdParty/Android/sentry-android-core-release.aar
 Source/ThirdParty/Android/sentry-android-ndk-release.aar
+Source/ThirdParty/Android/sentry-android-replay-release.aar
 Source/ThirdParty/Android/sentry-native-ndk-release.aar
 Source/ThirdParty/Android/sentry.jar
 Source/ThirdParty/CLI/sentry-cli-Darwin-universal
@@ -463,6 +464,8 @@ Source/ThirdParty/Mac/Native/lib/libsentry.a
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/_CodeSignature/CodeResources
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/CodeResources
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/Info.plist
+Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/MacOS/._Sentry.CrashReporter.deps.json
+Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/MacOS/._Sentry.CrashReporter.runtimeconfig.json
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/MacOS/libclrgcexp.dylib
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/MacOS/libclrjit.dylib
 Source/ThirdParty/Mac/Sentry.CrashReporter.app/Contents/MacOS/libcoreclr.dylib
@@ -745,7 +748,6 @@ Source/ThirdParty/Win64/Crashpad/lib/mini_chromium.lib
 Source/ThirdParty/Win64/Crashpad/lib/sentry.lib
 Source/ThirdParty/Win64/Native/bin/sentry-crash.exe
 Source/ThirdParty/Win64/Native/include/sentry.h
-Source/ThirdParty/Win64/Native/lib/sentry-wer.lib
 Source/ThirdParty/Win64/Native/lib/sentry.lib
 Source/ThirdParty/Win64/Sentry.CrashReporter.exe
 Source/ThirdParty/WinArm64/Crashpad/bin/crashpad_handler.exe
@@ -765,6 +767,5 @@ Source/ThirdParty/WinArm64/Crashpad/lib/mini_chromium.lib
 Source/ThirdParty/WinArm64/Crashpad/lib/sentry.lib
 Source/ThirdParty/WinArm64/Native/bin/sentry-crash.exe
 Source/ThirdParty/WinArm64/Native/include/sentry.h
-Source/ThirdParty/WinArm64/Native/lib/sentry-wer.lib
 Source/ThirdParty/WinArm64/Native/lib/sentry.lib
 Source/ThirdParty/WinArm64/Sentry.CrashReporter.exe


### PR DESCRIPTION
This PR adds Android session replay support, leveraging the new SurfaceView capture path introduced in sentry-java 8.41.0 (https://github.com/getsentry/sentry-java/pull/5333) so that Unreal Engine's render surface is included in the captured video (previously SurfaceView regions appeared as transparent/black holes).

[Example crash event](https://sentry-sdks.sentry.io/issues/7483067354/?project=4508816831873030&query=is%3Aunresolved&referrer=issue-stream) with session replay captured on Android.

## Key changes

- Forward the existing `AttachSessionReplay` setting through the Android subsystem to the Java bridge.
- When the setting is enabled, configure session replay with `sessionSampleRate=1.0` and `captureSurfaceViews=true`.
- Bundle the new `sentry-android-replay` AAR via UPL and add `kotlin-stdlib-jdk8:1.9.24` to the Android Gradle dependencies
- `scripts/build-android.sh` and `scripts/build-deps.ps1` now also build and copy `sentry-android-replay-release.aar`.
- Ported the `sentry-native-ndk` download step from `build-android.sh` to `build-deps.ps1`, so `-Java` is now a complete drop-in replacement for the CI-produced Android artifact (previously it wiped the directory without restoring native-ndk)

## Limitations

Currently, frame rate and replay duration aren't configurable since `sentry-java` keeps these `@ApiStatus.Internal` with no public setters.

## Related items

- https://github.com/getsentry/sentry-java/pull/5333