### PR TITLE
Add Switch 2 support in console extension setup script

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ Path to extensions source code may be set via environment variables. When workin
 
 - `SENTRY_PLAYSTATION_PATH` → PS5
 - `SENTRY_XBOX_PATH` → XSX, XB1, WinGDK
-- `SENTRY_SWITCH_PATH` → Switch
+- `SENTRY_SWITCH_PATH` → Switch, Switch2
 
 **Setup console extensions:**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ $env:SENTRY_XBOX_PATH = "D:\projects\sentry-xbox"
 ./scripts/init-consoles.ps1 -All
 
 # Option 2: Setup specific platforms
-./scripts/init-consoles.ps1 -Switch -PS5 -XSX -XB1 -WinGDK
+./scripts/init-consoles.ps1 -Switch -Switch2 -PS5 -XSX -XB1 -WinGDK
 
 # Option 3: Setup individual platform without configuring environment variables
 ./scripts/init-console-ext.ps1 -Platform Switch -ExtensionPath D:\projects\sentry-switch

--- a/scripts/init-console-ext.ps1
+++ b/scripts/init-console-ext.ps1
@@ -1,6 +1,6 @@
 param(
     [Parameter(Mandatory=$true)]
-    [ValidateSet('Switch', 'PS5', 'XSX', 'XB1', 'WinGDK')]
+    [ValidateSet('Switch', 'Switch2', 'PS5', 'XSX', 'XB1', 'WinGDK')]
     [string]$Platform,
 
     [Parameter(Mandatory=$true)]
@@ -45,9 +45,16 @@ function New-SymbolicLink {
 $platformConfig = @{
     'Switch' = @{
         PlatformFolder = 'Switch'
-        SourceDir      = 'Sentry'
+        SourceDir      = 'Sentry_Switch'
         Variants = @(
             @{ Name = 'Default'; Preset = 'nx64-unreal'; BuildDir = 'nx64-unreal' }
+        )
+    }
+    'Switch2' = @{
+        PlatformFolder = 'Switch2'
+        SourceDir      = 'Sentry_Switch2'
+        Variants = @(
+            @{ Name = 'Default'; Preset = 'ounce64-unreal'; BuildDir = 'ounce64-unreal' }
         )
     }
     'PS5' = @{

--- a/scripts/init-consoles.ps1
+++ b/scripts/init-consoles.ps1
@@ -1,6 +1,7 @@
 param(
     [switch]$All,
     [switch]$Switch,
+    [switch]$Switch2,
     [switch]$PS5,
     [switch]$XSX,
     [switch]$XB1,
@@ -15,6 +16,7 @@ Write-Host "Setting up console plugin extensions" -ForegroundColor Cyan
 # If -All is specified, enable all platforms
 if ($All) {
     $Switch = $true
+    $Switch2 = $true
     $PS5 = $true
     $XSX = $true
     $XB1 = $true
@@ -22,12 +24,12 @@ if ($All) {
 }
 
 # Check if at least one platform is selected
-if (-not ($Switch -or $PS5 -or $XSX -or $XB1 -or $WinGDK)) {
-    Write-Host "Error: No platform specified. Use -All or specify individual platforms (-Switch, -PS5, -XSX, -XB1, -WinGDK)" -ForegroundColor Red
+if (-not ($Switch -or $Switch2 -or $PS5 -or $XSX -or $XB1 -or $WinGDK)) {
+    Write-Host "Error: No platform specified. Use -All or specify individual platforms (-Switch, -Switch2, -PS5, -XSX, -XB1, -WinGDK)" -ForegroundColor Red
     Write-Host ""
     Write-Host "Examples:"
     Write-Host "  ./scripts/init-consoles.ps1 -All"
-    Write-Host "  ./scripts/init-consoles.ps1 -Switch -PS5"
+    Write-Host "  ./scripts/init-consoles.ps1 -Switch -Switch2 -PS5"
     Write-Host "  ./scripts/init-consoles.ps1 -XSX -XB1 -WinGDK"
     Write-Host ""
     Write-Host "Environment variables required:"
@@ -42,6 +44,10 @@ $platformConfigs = @{
     'Switch' = @{
         EnvVar = 'SENTRY_SWITCH_PATH'
         Enabled = $Switch
+    }
+    'Switch2' = @{
+        EnvVar = 'SENTRY_SWITCH_PATH'
+        Enabled = $Switch2
     }
     'PS5' = @{
         EnvVar = 'SENTRY_PLAYSTATION_PATH'


### PR DESCRIPTION
This PR adds Switch 2 support to the console extension setup scripts so the new `ounce64-unreal` cmake preset in `sentry-switch` can be built and wired into the sample project alongside the existing Switch target.

Related items:
- https://github.com/getsentry/sentry-switch/pull/138

#skip-changelog