### PR TITLE
Fix UE 5.8 compatibility issues

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.cpp
@@ -77,7 +77,7 @@ void FGenericPlatformSentryCrashReporter::SetContext(const FString& key, const T
 
 	for (auto it = values.CreateConstIterator(); it; ++it)
 	{
-		valuesConfig->Values.Add(it.Key(), FGenericPlatformSentryConverters::VariantToJsonValue(it.Value()));
+		valuesConfig->SetField(it.Key(), FGenericPlatformSentryConverters::VariantToJsonValue(it.Value()));
 	}
 
 	TSharedPtr<FJsonObject> contextConfig;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
@@ -326,12 +326,9 @@ TMap<FString, FSentryVariant> FGenericPlatformSentryConverters::VariantMapToUnre
 		return unrealMap;
 	}
 
-	TArray<FString> keysArr;
-	jsonObject->Values.GetKeys(keysArr);
-
-	for (auto it = keysArr.CreateConstIterator(); it; ++it)
+	for (const auto& pair : jsonObject->Values)
 	{
-		unrealMap.Add(*it, VariantToUnreal(sentry_value_get_by_key(map, TCHAR_TO_UTF8(**it))));
+		unrealMap.Add(FString(*pair.Key), VariantToUnreal(sentry_value_get_by_key(map, TCHAR_TO_UTF8(*pair.Key))));
 	}
 
 	sentry_string_free(jsonString);
@@ -378,12 +375,10 @@ TMap<FString, FString> FGenericPlatformSentryConverters::StringMapToUnreal(sentr
 		return unrealMap;
 	}
 
-	TArray<FString> keysArr;
-	jsonObject->Values.GetKeys(keysArr);
-
-	for (auto it = keysArr.CreateConstIterator(); it; ++it)
+	for (const auto& pair : jsonObject->Values)
 	{
-		unrealMap.Add(*it, jsonObject->GetStringField(*it));
+		FString key(*pair.Key);
+		unrealMap.Add(key, jsonObject->GetStringField(key));
 	}
 
 	sentry_string_free(jsonString);

--- a/plugin-dev/Source/Sentry/Private/Microsoft/Infrastructure/MicrosoftSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/Infrastructure/MicrosoftSentryConverters.cpp
@@ -4,6 +4,8 @@
 
 #if USE_SENTRY_NATIVE
 
+#include "Misc/EngineVersionComparison.h"
+
 /* static */ void FMicrosoftSentryConverters::SentryCrashContextToString(const sentry_ucontext_t* crashContext, TCHAR* outErrorString, int32 errorStringBufSize)
 {
 	EXCEPTION_RECORD* ExceptionRecord = crashContext->exception_ptrs.ExceptionRecord;
@@ -32,10 +34,14 @@
 			ErrorString += TEXT("writing address ");
 		}
 		ErrorString += FString::Printf(
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 #if PLATFORM_64BITS
 			TEXT("0x%016llx"),
 #else
 			TEXT("0x%08x"),
+#endif
+#else
+			TEXT("0x%016llx"),
 #endif
 			ExceptionRecord->ExceptionInformation[1]);
 		break;


### PR DESCRIPTION
This PR fixes compilation errors and warnings when building against UE 5.8 preview:

- `FJsonObject::Values` map key type changed from `FString` to `UE::FSharedString`. Switched direct `Values.Add` to `SetField` (cross-version), and replaced `Values.GetKeys` loops with a range-for over `Values` using `*Pair.Key`.
- `PLATFORM_64BITS` is deprecated in 5.8 (UE is now 64-bit only). Gated the existing branch behind `UE_VERSION_OLDER_THAN(5, 8, 0)` so older engine versions keep the conditional while 5.8+ unconditionally uses the 64-bit format.
- Clang now errors on `-Wunreachable-code-break` for the `break` after the OOM crash test’s infinite `Malloc` loop. Wrapped that `break` in `PRAGMA_DISABLE_UNREACHABLE_CODE_WARNINGS` / `PRAGMA_RESTORE_UNREACHABLE_CODE_WARNINGS`.

#skip-changelog