### PR TITLE
Fix iOS Simulator build for UE 5.6+

### DIFF
--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -62,11 +62,14 @@ public class Sentry : ModuleRules
 		{
 			PrivateIncludePaths.Add(Path.Combine(ModuleDirectory, "Private", "Apple"));
 
+#if UE_5_6_OR_LATER
+			PublicAdditionalFrameworks.Add(new Framework("Sentry", Path.Combine(PlatformThirdPartyPath, "Sentry.xcframework.zip"), null, true));
+#else
 			PublicAdditionalFrameworks.Add(new Framework("Sentry", Path.Combine(PlatformThirdPartyPath, "Sentry.embeddedframework.zip"), null, true));
 
 			string PluginPath = Utils.MakePathRelativeTo(ModuleDirectory, Target.RelativeEnginePath);
-
 			AdditionalPropertiesForReceipt.Add("IOSPlugin", Path.Combine(PluginPath, "Sentry_IOS_UPL.xml"));
+#endif
 
 			PublicDefinitions.Add("USE_SENTRY_NATIVE=0");
 			PublicDefinitions.Add("COCOAPODS=0");

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -177,6 +177,20 @@ function buildSentryCocoaIos()
 
     # Cleanup
     Remove-Item "$iosOutDir/Sentry.embeddedframework" -Recurse -Force
+
+    # Create xcframework.zip for UE 5.6+
+    Copy-Item "$tempExtractDir/Sentry-Dynamic.xcframework" -Destination "$iosOutDir/Sentry.xcframework" -Recurse
+    Push-Location $iosOutDir
+    try
+    {
+        zip -r "Sentry.xcframework.zip" "Sentry.xcframework"
+    }
+    finally
+    {
+        Pop-Location
+    }
+    Remove-Item "$iosOutDir/Sentry.xcframework" -Recurse -Force
+
     Remove-Item $tempExtractDir -Recurse -Force
 
     Write-Host "Successfully built Sentry Cocoa for iOS"

--- a/scripts/download-cocoa.sh
+++ b/scripts/download-cocoa.sh
@@ -39,6 +39,12 @@ cp -R "Sentry.embeddedframework.zip" "$(dirname $sentryArtifactsDestination)/IOS
 rm -rf "Sentry.embeddedframework"
 rm "Sentry.embeddedframework.zip"
 
+cp -R "${sentryCocoaCache}/Sentry-Dynamic.xcframework" "Sentry.xcframework"
+zip -r "Sentry.xcframework.zip" "Sentry.xcframework"
+cp "Sentry.xcframework.zip" "$(dirname $sentryArtifactsDestination)/IOS/Sentry.xcframework.zip"
+rm -rf "Sentry.xcframework"
+rm "Sentry.xcframework.zip"
+
 # Prepare Mac artifacts
 if ! [ -d "$(dirname $sentryArtifactsDestination)/Mac/Cocoa" ]; then
     mkdir -p "$(dirname $sentryArtifactsDestination)/Mac/Cocoa"

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -293,6 +293,7 @@ Source/ThirdParty/CLI/sentry-cli-Darwin-universal
 Source/ThirdParty/CLI/sentry-cli-Linux-x86_64
 Source/ThirdParty/CLI/sentry-cli-Windows-x86_64.exe
 Source/ThirdParty/IOS/Sentry.embeddedframework.zip
+Source/ThirdParty/IOS/Sentry.xcframework.zip
 Source/ThirdParty/IOS/Sentry.framework/Headers/PrivateSentrySDKOnly.h
 Source/ThirdParty/IOS/Sentry.framework/Headers/PrivatesHeader.h
 Source/ThirdParty/IOS/Sentry.framework/Headers/Sentry-Swift.h


### PR DESCRIPTION
**Changelog:**

* Switch to Sentry.xcframework.zip containing both device and simulator slices
* Keep Sentry.embeddedframework.zip with UPL embedding for older UE versions

**Description:**

When building an Unreal project for iOS Simulator, the build fails because
`Sentry.embeddedframework.zip` contains only an `arm64 iphoneos` slice with no
simulator slice included.

**Build command:**

`Engine/Build/BatchFiles/Mac/Build.sh ProjectName IOS Development -Project=ProjectName.uproject -Architecture=iossimulator`

**Error:**

`ld: building for 'iOS-simulator', but linking in dylib
  (.../UnzippedFrameworks/Sentry/Sentry.embeddedframework/Sentry.framework/Sentry)
  built for 'iOS'
clang++: error: linker command failed with exit code 1`