### PR TITLE
Add configurable cache mode setting for Sentry Crash Reporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add experimental session replay capturing for Android ([#1386](https://github.com/getsentry/sentry-unreal/pull/1386))
+- Add configurable cache mode setting for Sentry Crash Reporter ([#1408](https://github.com/getsentry/sentry-unreal/pull/1408))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -1249,6 +1249,11 @@ void FGenericPlatformSentrySubsystem::ConfigureCrashReporterAppearance(const USe
 	{
 		AppConfigObject->SetBoolField(TEXT("WindowClosable"), false);
 	}
+	if (Appearance.CacheKeep != ESentryCrashReporterCacheKeep::Default)
+	{
+		const FString CacheKeepStr = StaticEnum<ESentryCrashReporterCacheKeep>()->GetNameStringByValue(static_cast<int64>(Appearance.CacheKeep));
+		AppConfigObject->SetStringField(TEXT("CacheKeep"), CacheKeepStr);
+	}
 
 	const FString FilePath = FPaths::Combine(GetDatabasePath(), TEXT("appsettings.json"));
 

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -44,6 +44,19 @@ enum class ESentryDatabaseLocation : uint8
 };
 
 UENUM(BlueprintType)
+enum class ESentryCrashReporterCacheKeep : uint8
+{
+	// Use the crash reporter's compiled-in default (Offline)
+	Default,
+	// Never retain envelopes after submission attempts
+	None,
+	// Retain envelopes only when the host appears offline
+	Offline,
+	// Always retain envelopes regardless of submission outcome
+	Always
+};
+
+UENUM(BlueprintType)
 enum class ESentryAndroidCrashBackend : uint8
 {
 	// Capture crashes using the sentry-native NDK signal handler only
@@ -280,6 +293,10 @@ struct FSentryCrashReporterAppearance
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "General",
 		Meta = (DisplayName = "Window closable", ToolTip = "When disabled, the user cannot close the crash reporter window without submitting the report. The native close button is disabled and the cancel button is hidden."))
 	bool bWindowClosable = true;
+
+	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "General",
+		Meta = (DisplayName = "Cache mode", ToolTip = "Initial cache mode shown to the user in the crash reporter when they have not selected one. The user can still override this at runtime. 'None' never keeps envelopes after submission, 'Offline' keeps them only while the host is offline, 'Always' keeps them regardless of submission outcome. Leave as 'Default' to let the crash reporter use its built-in default."))
+	ESentryCrashReporterCacheKeep CacheKeep = ESentryCrashReporterCacheKeep::Default;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "General",
 		Meta = (DisplayName = "App logo", ToolTip = "Replace the default crash reporter logo with a custom PNG image. The file is stored in Build/SentryCrashReporter/ under your project and staged alongside the plugin during packaging."))


### PR DESCRIPTION
This PR adds a new `Cache mode` setting to the Sentry Crash Reporter section of the plugin settings, exposing the cache-mode preference introduced in https://github.com/getsentry/sentry-desktop-crash-reporter/pull/211.

The new `ESentryCrashReporterCacheKeep` enum (`Default` / `None` / `Offline` / `Always`) lets users pick the initial cache mode shown in the crash reporter dialog. When set to anything other than `Default`, the value is serialized into `appsettings.json` in the sentry-native database directory alongside the existing appearance overrides; the user can still change their preference at runtime via the crash reporter UI.

Documentation:
- https://github.com/getsentry/sentry-docs/pull/17908

Closes #1401