### PR TITLE
chore(CI): bump GitHub Actions off deprecated Node.js 20 runtime

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,13 +21,13 @@ jobs:
     steps:
       - name: Get auth token
         id: token
-        uses: actions/create-github-app-token@5d869da34e18e7287c1daad50e0b8ea0f506ce69 # v1.11.0
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ vars.SENTRY_RELEASE_BOT_CLIENT_ID }}
           private-key: ${{ secrets.SENTRY_RELEASE_BOT_PRIVATE_KEY }}
 
       - name: Check out current commit (${{ github.sha }})
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           token: ${{ steps.token.outputs.token }}
           fetch-depth: 0

--- a/.github/workflows/ue-docker-android.yml
+++ b/.github/workflows/ue-docker-android.yml
@@ -69,7 +69,7 @@ jobs:
           df -h
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12.8'
           architecture: 'x64'

--- a/.github/workflows/ue-docker-linux.yml
+++ b/.github/workflows/ue-docker-linux.yml
@@ -69,7 +69,7 @@ jobs:
           df -h
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12.8'
           architecture: 'x64'

--- a/.github/workflows/ue-docker-windows.yml
+++ b/.github/workflows/ue-docker-windows.yml
@@ -64,7 +64,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.12.8'
           architecture: 'x64'


### PR DESCRIPTION
This PR bumps `actions/checkout` (v3 → v6), `actions/setup-python` (v5 → v6.2.0) and `actions/create-github-app-token` (v1 → v3) across all workflows to versions running on Node.js 24, resolving the deprecation warnings for the Node.js 20 runtime (removed from runners September 16, 2026).

```
Node.js 20 actions are deprecated.

The following actions are running on Node.js 20 and may not work as expected:
- actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5

Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
Node.js 20 will be removed from the runner on September 16th, 2026.

Please check whether updated versions of these actions are available that support Node.js 24.

To opt into Node.js 24 now, set:
FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true

on the runner or in your workflow file.

Once Node.js 24 becomes the default, you can temporarily opt out by setting:
ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true

For more information:
https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
```

#skip-chagelog