### PR TITLE
Add game-thread ANR detection on Android

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -28,6 +28,7 @@
 
 #include "Dom/JsonObject.h"
 #include "HAL/FileManager.h"
+#include "HAL/PlatformTLS.h"
 #include "Misc/CoreDelegates.h"
 #include "Misc/FileHelper.h"
 #include "Misc/OutputDeviceError.h"
@@ -73,6 +74,10 @@ void FAndroidSentrySubsystem::InitWithSettings(const USentrySettings* settings, 
 	SettingsJson->SetBoolField(TEXT("sendDefaultPii"), settings->SendDefaultPii);
 	SettingsJson->SetBoolField(TEXT("enableAnrTracking"), settings->EnableAppNotRespondingTracking);
 	SettingsJson->SetNumberField(TEXT("anrTimeoutMillis"), settings->AppNotRespondingTimeout * 1000.0f);
+	if (settings->EnableAppNotRespondingTracking)
+	{
+		SettingsJson->SetNumberField(TEXT("anrThreadId"), static_cast<double>(FPlatformTLS::GetCurrentThreadId()));
+	}
 	SettingsJson->SetBoolField(TEXT("enableNdk"), settings->AndroidCrashBackend != ESentryAndroidCrashBackend::TombstoneOnly);
 	SettingsJson->SetBoolField(TEXT("enableTombstone"),
 		settings->AndroidCrashBackend == ESentryAndroidCrashBackend::TombstoneOnly || settings->AndroidCrashBackend == ESentryAndroidCrashBackend::TombstoneMergedWithNdk);
@@ -123,6 +128,14 @@ void FAndroidSentrySubsystem::InitWithSettings(const USentrySettings* settings, 
 			TryCaptureScreenshot();
 		});
 	}
+
+	if (IsEnabled() && settings->EnableAppNotRespondingTracking)
+	{
+		AnrHeartbeatDelegateHandle = FCoreDelegates::OnEndFrame.AddLambda([]()
+		{
+			FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, "notifyAnrThreadAlive", "()V");
+		});
+	}
 }
 
 void FAndroidSentrySubsystem::Close()
@@ -131,6 +144,12 @@ void FAndroidSentrySubsystem::Close()
 	{
 		FCoreDelegates::OnHandleSystemError.Remove(OnHandleSystemErrorDelegateHandle);
 		OnHandleSystemErrorDelegateHandle.Reset();
+	}
+
+	if (AnrHeartbeatDelegateHandle.IsValid())
+	{
+		FCoreDelegates::OnEndFrame.Remove(AnrHeartbeatDelegateHandle);
+		AnrHeartbeatDelegateHandle.Reset();
 	}
 
 	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::Sentry, "flush", "(J)V", (jlong)3000);

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
@@ -64,6 +64,7 @@ private:
 	bool isScreenshotAttachmentEnabled = false;
 
 	FDelegateHandle OnHandleSystemErrorDelegateHandle;
+	FDelegateHandle AnrHeartbeatDelegateHandle;
 };
 
 typedef FAndroidSentrySubsystem FPlatformSentrySubsystem;

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -85,6 +85,9 @@ public class SentryBridgeJava {
 					}
 					options.setAnrEnabled(settingJson.getBoolean("enableAnrTracking"));
 					options.setAnrTimeoutIntervalMillis(settingJson.getLong("anrTimeoutMillis"));
+					if (settingJson.has("anrThreadId")) {
+						options.setAnrThreadId(settingJson.getLong("anrThreadId"));
+					}
                     options.setEnableNdk(settingJson.getBoolean("enableNdk"));
                     options.setTombstoneEnabled(settingJson.getBoolean("enableTombstone"));
 					options.getLogs().setEnabled(settingJson.getBoolean("enableStructuredLogging"));
@@ -324,6 +327,10 @@ public class SentryBridgeJava {
 
 	public static void clearAttachments() {
 		Sentry.getGlobalScope().clearAttachments();
+	}
+
+	public static void notifyAnrThreadAlive() {
+		io.sentry.AnrHeartbeatRegistry.notifyAlive();
 	}
 
 	public static void addLogFatal(final String message, final HashMap<String, Object> attributesMap) {


### PR DESCRIPTION
This PR routes sentry-java's heartbeat ANR watchdog at Unreal's game thread so its hangs are detected and reported with a native stacktrace.

Related items:
- https://github.com/getsentry/sentry-unity/pull/2681
- https://github.com/getsentry/sentry-java/pull/5431
- https://github.com/getsentry/sentry-native/pull/1721 