### PR TITLE
Fix Sentry Crash Reporter showing an empty window for packaged games on Mac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 - Add ANR timeout setting for mobile platforms ([#1413](https://github.com/getsentry/sentry-unreal/pull/1413))
 - Enable ANR error capturing by default on Android and Apple platforms ([#1415](https://github.com/getsentry/sentry-unreal/pull/1415))
 
+### Fixes
+
+- Fix Sentry Crash Reporter showing an empty window for packaged games on Mac ([#1420](https://github.com/getsentry/sentry-unreal/pull/1420))
+
 ### Dependencies
 
 - Bump Native SDK from v0.14.1 to v0.14.2 ([#1387](https://github.com/getsentry/sentry-unreal/pull/1387))

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
@@ -80,7 +80,7 @@ void FMacSentrySubsystem::ConfigureLogFileAttachment(sentry_options_t* Options)
 void FMacSentrySubsystem::ConfigureCrashReporterPath(sentry_options_t* Options)
 {
 	const FString CrashReporterPath = GetCrashReporterPath();
-	if (!FPaths::DirectoryExists(CrashReporterPath))
+	if (!FPaths::FileExists(CrashReporterPath))
 	{
 		UE_LOG(LogSentrySdk, Error, TEXT("External crash reporter executable couldn't be found at: %s"), *CrashReporterPath);
 		return;

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
@@ -19,7 +19,7 @@ protected:
 	virtual void ConfigureCrashReporterPath(sentry_options_t* Options) override;
 
 	virtual FString GetHandlerExecutableName() const override;
-	virtual FString GetCrashReporterExecutableName() const override { return TEXT("Sentry.CrashReporter.app"); }
+	virtual FString GetCrashReporterExecutableName() const override { return TEXT("Sentry.CrashReporter.app/Contents/MacOS/Sentry.CrashReporter"); }
 
 	virtual bool IsScreenshotSupported() const override { return true; }
 	virtual bool IsHangTrackingSupported() const override { return false; }

--- a/sample/Config/DefaultEngine.ini
+++ b/sample/Config/DefaultEngine.ini
@@ -242,4 +242,5 @@ UploadSymbolsAutomatically=True
 [/Script/MacTargetPlatform.XcodeProjectSettings]
 BundleIdentifier=io.sentry.unreal.sample
 CodeSigningPrefix=
+ShippingSpecificMacEntitlements=(FilePath="/Game/Build/Mac/Resources/Sandbox.Server.entitlements")
 


### PR DESCRIPTION
This PR fixes the Sentry Crash Reporter showing an empty window (no crash details) when the game runs under the macOS App Sandbox (packaged game build).

`MacSentrySubsystem::GetCrashReporterExecutableName()` now returns the path to the executable inside the bundle (`Sentry.CrashReporter.app/Contents/MacOS/Sentry.CrashReporter`) instead of the `.app` directory. sentry-native's process spawner branches on the `.app` suffix - with the direct binary path the daemon spawns the Crash Reporter via `execv` rather than `/usr/bin/open`. The Crash Reporter then inherits the game's sandbox at the kernel level and can read the crash envelope inside the parent's container natively with no TCC permission prompt (which wouldn't appear during a crash anyway) and no cross-container access denial.

Also updates the sample's `DefaultEngine.ini` to override `ShippingSpecificMacEntitlements` so the playground's Shipping packaged builds retain `com.apple.security.network.client` (Unreal's default Shipping template is  `Sandbox.NoNet.entitlements`).

Related items:
- https://github.com/getsentry/sentry-docs/pull/18010