### PR TITLE
Add experimental Session Replay capturing on Mac

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -26,7 +26,7 @@ ObjCBreakBeforeNestedBlockParam:                false
 PointerAlignment:                               Left
 SpacesInContainerLiterals:                      true
 SpaceAfterTemplateKeyword:                      false
-Standard:                                       c++11
+Standard:                                       c++14
 TabWidth:                                       4
 UseTab:                                         Always
 MacroBlockBegin:                                '^BEGIN_DEFINE_SPEC'

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Strip experimental codec plugin refs (UE 4.27)
         if: ${{ inputs.unreal-version == '4.27' }}
         shell: pwsh
-        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs
+        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs,VTCodecs
 
       - name: Build Android package (Development)
         id: build-android-dev

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Strip experimental codec plugin refs (UE 4.27)
         if: ${{ inputs.unreal-version == '4.27' }}
         shell: pwsh
-        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs
+        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs,VTCodecs
 
       - name: Build and test (Crashpad)
         id: run-tests

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Strip experimental codec plugin refs (UE 4.27)
         if: ${{ inputs.unreal-version == '4.27' }}
         shell: pwsh
-        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs
+        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs,VTCodecs
 
       - name: Build and test (Crashpad)
         id: run-tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add experimental Session Replay capturing on Mac ([#1425](https://github.com/getsentry/sentry-unreal/pull/1425))
+
 ### Dependencies
 
 - Bump CLI from v3.4.3 to v3.5.0 ([#1419](https://github.com/getsentry/sentry-unreal/pull/1419))

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -53,6 +53,18 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 
 	isScreenshotAttachmentEnabled = settings->AttachScreenshot;
 	isGameLogAttachmentEnabled = settings->EnableAutoLogAttachment;
+	isSessionReplayAttachmentEnabled = settings->AttachSessionReplay;
+
+	if (settings->AttachSessionReplay)
+	{
+		// Capture the previous run's replay path before starting the recorder to
+		// avoid a race where onLastRunStatusDetermined picks up the current session's MP4
+		PrevSessionReplayPath = GetLatestSessionReplay();
+		if (PrevSessionReplayPath.IsEmpty())
+		{
+			UE_LOG(LogSentrySdk, Log, TEXT("No session replays from the previous session were found."));
+		}
+	}
 
 	[SENTRY_APPLE_CLASS(PrivateSentrySDKOnly) setSdkName:@"sentry.cocoa.unreal"];
 
@@ -80,6 +92,12 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 			options.onLastRunStatusDetermined = ^(SentryLastRunStatus status, SentryEvent* event) {
 				if (status != SentryLastRunStatusDidCrash || event == nil)
 				{
+					// No crash to attach to — drop the previous run's replay file so it
+					// doesn't linger and confuse the next session's "latest" detection
+					if (!PrevSessionReplayPath.IsEmpty() && FPaths::FileExists(PrevSessionReplayPath))
+					{
+						IFileManager::Get().Delete(*PrevSessionReplayPath);
+					}
 					return;
 				}
 				if (settings->AttachScreenshot)
@@ -93,6 +111,11 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 					// Unreal creates game log backups automatically on every app run. If logging is enabled for current configuration, SDK can
 					// find the most recent one and upload it to Sentry.
 					UploadGameLogForEvent(MakeShareable(new FAppleSentryId(event.eventId)), GetLatestGameLog());
+				}
+				if (settings->AttachSessionReplay)
+				{
+					// If a replay was captured during the previous app run upload it to Sentry.
+					UploadSessionReplayForEvent(MakeShareable(new FAppleSentryId(event.eventId)), PrevSessionReplayPath);
 				}
 			};
 			for (auto it = settings->InAppInclude.CreateConstIterator(); it; ++it)
@@ -670,6 +693,17 @@ void FAppleSentrySubsystem::UploadGameLogForEvent(TSharedPtr<ISentryId> eventId,
 	UploadAttachmentForEvent(eventId, logFilePath, SentryFileUtils::GetGameLogName());
 }
 
+void FAppleSentrySubsystem::UploadSessionReplayForEvent(TSharedPtr<ISentryId> eventId, const FString& replayPath) const
+{
+	if (replayPath.IsEmpty())
+	{
+		// Recorder only produces a file after the first keyframe so if a crash happens early and nothing is written to disk (empty path) skip the upload
+		return;
+	}
+
+	UploadAttachmentForEvent(eventId, replayPath, TEXT("session-replay.mp4"), true);
+}
+
 FString FAppleSentrySubsystem::GetScreenshotPath() const
 {
 	return FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("SentryScreenshots"), FString::Printf(TEXT("screenshot-%s.png"), *FDateTime::Now().ToString()));
@@ -701,6 +735,34 @@ FString FAppleSentrySubsystem::GetLatestScreenshot() const
 	});
 
 	return Screenshots[0];
+}
+
+FString FAppleSentrySubsystem::GetLatestSessionReplay() const
+{
+	const FString& ReplaysDir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("SentryReplays"));
+
+	TArray<FString> Replays;
+	IFileManager::Get().FindFiles(Replays, *ReplaysDir, TEXT("*.mp4"));
+
+	if (Replays.Num() == 0)
+	{
+		UE_LOG(LogSentrySdk, Log, TEXT("There are no session replays found."));
+		return FString("");
+	}
+
+	for (int i = 0; i < Replays.Num(); ++i)
+	{
+		Replays[i] = ReplaysDir / Replays[i];
+	}
+
+	Replays.Sort([](const FString& A, const FString& B)
+	{
+		const FDateTime TimestampA = IFileManager::Get().GetTimeStamp(*A);
+		const FDateTime TimestampB = IFileManager::Get().GetTimeStamp(*B);
+		return TimestampB < TimestampA;
+	});
+
+	return Replays[0];
 }
 
 #endif // !USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -63,15 +63,20 @@ protected:
 
 	void UploadScreenshotForEvent(TSharedPtr<ISentryId> eventId, const FString& screenshotPath) const;
 	void UploadGameLogForEvent(TSharedPtr<ISentryId> eventId, const FString& logFilePath) const;
+	void UploadSessionReplayForEvent(TSharedPtr<ISentryId> eventId, const FString& replayPath) const;
 
 	virtual FString GetScreenshotPath() const;
 	virtual FString GetLatestScreenshot() const;
 	virtual FString GetGameLogPath() const { return FString(); };
 	virtual FString GetLatestGameLog() const { return FString(); }
+	virtual FString GetLatestSessionReplay() const;
 
 protected:
 	bool isScreenshotAttachmentEnabled = false;
 	bool isGameLogAttachmentEnabled = false;
+	bool isSessionReplayAttachmentEnabled = false;
+
+	FString PrevSessionReplayPath;
 };
 
 #endif // !USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
@@ -11,6 +11,12 @@
 
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
 
+#ifdef USE_SENTRY_SESSION_REPLAY
+#include "GenericPlatform/GenericPlatformSentryAttachment.h"
+#include "HAL/FileManager.h"
+#include "Misc/Guid.h"
+#endif
+
 void FMacSentrySubsystem::InitWithSettings(const USentrySettings* Settings, const FSentryCallbackHandlers& CallbackHandlers)
 {
 	FGenericPlatformSentrySubsystem::InitWithSettings(Settings, CallbackHandlers);
@@ -24,7 +30,58 @@ void FMacSentrySubsystem::InitWithSettings(const USentrySettings* Settings, cons
 	{
 		InitCrashReporter(Settings->GetEffectiveRelease(), Settings->GetEffectiveEnvironment());
 	}
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+	if (IsEnabled() && Settings->AttachSessionReplay)
+	{
+		// Clear replay videos captured during previous session if any
+		IFileManager::Get().DeleteDirectory(*FPaths::Combine(GetDatabasePath(), TEXT("replays")), false, true);
+
+		SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
+		if (!SessionReplay->Initialize(Settings, GetReplayPath()))
+		{
+			SessionReplay.Reset();
+		}
+	}
+#endif
 }
+
+sentry_value_t FMacSentrySubsystem::OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure)
+{
+#ifdef USE_SENTRY_SESSION_REPLAY
+	if (SessionReplay && SessionReplay->HasSnapshotOnDisk())
+	{
+		TSharedPtr<ISentryAttachment> ReplayAttachment =
+			MakeShareable(new FGenericPlatformSentryAttachment(SessionReplay->GetAttachmentPath(), TEXT("session-replay.mp4"), TEXT("video/mp4")));
+
+		AddFileAttachment(ReplayAttachment);
+	}
+#endif
+
+	return FGenericPlatformSentrySubsystem::OnCrash(uctx, event, closure);
+}
+
+void FMacSentrySubsystem::Close()
+{
+#ifdef USE_SENTRY_SESSION_REPLAY
+	if (SessionReplay)
+	{
+		SessionReplay->Shutdown();
+		SessionReplay.Reset();
+	}
+#endif
+
+	FGenericPlatformSentrySubsystem::Close();
+}
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+FString FMacSentrySubsystem::GetReplayPath() const
+{
+	const FString ReplayId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens).ToLower();
+	const FString ReplayPath = FPaths::Combine(GetDatabasePath(), TEXT("replays"), FString::Printf(TEXT("replay-%s.mp4"), *ReplayId));
+	return FPaths::ConvertRelativePathToFull(ReplayPath);
+}
+#endif
 
 FString FMacSentrySubsystem::GetHandlerExecutableName() const
 {
@@ -96,8 +153,10 @@ void FMacSentrySubsystem::ConfigureCrashReporterPath(sentry_options_t* Options)
 
 #include "Utils/SentryFileUtils.h"
 
+#include "HAL/FileManager.h"
 #include "Misc/CoreDelegates.h"
 #include "Misc/FileHelper.h"
+#include "Misc/Guid.h"
 
 void FMacSentrySubsystem::InitWithSettings(const USentrySettings* settings, const FSentryCallbackHandlers& callbackHandlers)
 {
@@ -112,11 +171,30 @@ void FMacSentrySubsystem::InitWithSettings(const USentrySettings* settings, cons
 				TryCaptureScreenshot();
 			});
 		}
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+		if (settings->AttachSessionReplay)
+		{
+			SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
+			if (!SessionReplay->Initialize(settings, GetReplayPath()))
+			{
+				SessionReplay.Reset();
+			}
+		}
+#endif
 	}
 }
 
 void FMacSentrySubsystem::Close()
 {
+#ifdef USE_SENTRY_SESSION_REPLAY
+	if (SessionReplay)
+	{
+		SessionReplay->Shutdown();
+		SessionReplay.Reset();
+	}
+#endif
+
 	if (OnHandleSystemErrorDelegateHandle.IsValid())
 	{
 		FCoreDelegates::OnHandleSystemError.Remove(OnHandleSystemErrorDelegateHandle);
@@ -125,6 +203,15 @@ void FMacSentrySubsystem::Close()
 
 	FAppleSentrySubsystem::Close();
 }
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+FString FMacSentrySubsystem::GetReplayPath() const
+{
+	const FString ReplayId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens).ToLower();
+	const FString ReplayPath = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("SentryReplays"), FString::Printf(TEXT("replay-%s.mp4"), *ReplayId));
+	return FPaths::ConvertRelativePathToFull(ReplayPath);
+}
+#endif
 
 TSharedPtr<ISentryId> FMacSentrySubsystem::CaptureEnsure(const FString& type, const FString& message)
 {

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
@@ -6,10 +6,15 @@
 
 #include "GenericPlatform/GenericPlatformSentrySubsystem.h"
 
+#ifdef USE_SENTRY_SESSION_REPLAY
+#include "SessionReplay/SentrySessionReplayRecorder.h"
+#endif
+
 class FMacSentrySubsystem : public FGenericPlatformSentrySubsystem
 {
 public:
 	virtual void InitWithSettings(const USentrySettings* settings, const FSentryCallbackHandlers& callbackHandlers) override;
+	virtual void Close() override;
 
 protected:
 	virtual void ConfigureHandlerPath(sentry_options_t* Options) override;
@@ -25,11 +30,24 @@ protected:
 	virtual bool IsHangTrackingSupported() const override { return false; }
 
 	virtual FString GetDeviceType() const override { return TEXT("Desktop"); }
+
+	virtual sentry_value_t OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure) override;
+
+private:
+#ifdef USE_SENTRY_SESSION_REPLAY
+	FString GetReplayPath() const;
+
+	TUniquePtr<FSentrySessionReplayRecorder> SessionReplay;
+#endif
 };
 
 #else
 
 #include "Apple/AppleSentrySubsystem.h"
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+#include "SessionReplay/SentrySessionReplayRecorder.h"
+#endif
 
 class FMacSentrySubsystem : public FAppleSentrySubsystem
 {
@@ -49,6 +67,12 @@ protected:
 
 private:
 	FDelegateHandle OnHandleSystemErrorDelegateHandle;
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+	FString GetReplayPath() const;
+
+	TUniquePtr<FSentrySessionReplayRecorder> SessionReplay;
+#endif
 };
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -98,11 +98,11 @@ void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& 
 
 	constexpr ETextureCreateFlags SrvRt = ETextureCreateFlags::ShaderResource | ETextureCreateFlags::RenderTargetable;
 
-	FTextureRHIRef ScratchTex = AcquireSingletonTexture_RenderThread(Scratch, W, H, BackBuffer->GetFormat(),
+	FTextureRHIRef ScratchTex = AcquireCachedTexture_RenderThread(Scratch, W, H, BackBuffer->GetFormat(),
 		SrvRt, ERHIAccess::SRVGraphics, TEXT("SentrySessionReplayScratch"));
 
 #if PLATFORM_MAC
-	FTextureRHIRef ConvertedTex = AcquireSingletonTexture_RenderThread(Converted, W, H, PF_B8G8R8A8,
+	FTextureRHIRef ConvertedTex = AcquireCachedTexture_RenderThread(Converted, W, H, PF_B8G8R8A8,
 		SrvRt, ERHIAccess::SRVGraphics, TEXT("SentrySessionReplayConverted"));
 #endif
 
@@ -118,7 +118,7 @@ void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& 
 	constexpr ERHIAccess PoolInitialState = ERHIAccess::SRVGraphics;
 #endif
 
-	FTextureRHIRef EncoderTex = AcquirePoolSlot_RenderThread(EncoderPool, W, H, PF_B8G8R8A8,
+	FTextureRHIRef EncoderTex = AcquireTexturePoolSlot_RenderThread(EncoderPool, W, H, PF_B8G8R8A8,
 		PoolFlags, PoolInitialState, TEXT("SentrySessionReplayCapture"));
 
 	if (!ScratchTex.IsValid())
@@ -203,7 +203,7 @@ void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& 
 	Encoder.SubmitFrame(EncoderTex, Now);
 }
 
-FTextureRHIRef FSentryBackBufferCapture::AcquireSingletonTexture_RenderThread(FCachedTextureState& Cache, uint32 Width, uint32 Height, EPixelFormat Format,
+FTextureRHIRef FSentryBackBufferCapture::AcquireCachedTexture_RenderThread(FCachedTexture& Cache, uint32 Width, uint32 Height, EPixelFormat Format,
 	ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName)
 {
 	if (Width != Cache.Width || Height != Cache.Height || Format != Cache.Format || Flags != Cache.Flags)
@@ -228,7 +228,7 @@ FTextureRHIRef FSentryBackBufferCapture::AcquireSingletonTexture_RenderThread(FC
 	return Cache.Texture;
 }
 
-FTextureRHIRef FSentryBackBufferCapture::AcquirePoolSlot_RenderThread(FPooledTextureState& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
+FTextureRHIRef FSentryBackBufferCapture::AcquireTexturePoolSlot_RenderThread(FCachedTexturePool& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
 	ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName)
 {
 	if (Width != Pool.Width || Height != Pool.Height || Format != Pool.Format || Flags != Pool.Flags)

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -20,7 +20,7 @@
 FSentryBackBufferCapture::FSentryBackBufferCapture(FSentryVideoEncoder& InEncoder)
 	: Encoder(InEncoder)
 {
-	TexturePool.SetNum(FSentryVideoEncoder::MaxQueueDepth);
+	EncoderPool.Slots.SetNum(FSentryVideoEncoder::MaxQueueDepth);
 	CapturePeriodSeconds = 1.0 / static_cast<double>(FMath::Max(1u, Encoder.GetFramerate()));
 }
 
@@ -64,11 +64,12 @@ void FSentryBackBufferCapture::Stop()
 
 	// Ensure render thread is done with our textures before destruction
 	FlushRenderingCommands();
-	for (FTextureRHIRef& Slot : TexturePool)
+	for (FTextureRHIRef& Slot : EncoderPool.Slots)
 	{
 		Slot.SafeRelease();
 	}
-	ScratchTexture.SafeRelease();
+	Scratch.Texture.SafeRelease();
+	Converted.Texture.SafeRelease();
 }
 
 void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, const FTextureRHIRef& BackBuffer)
@@ -95,14 +96,53 @@ void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& 
 		return;
 	}
 
-	const EPixelFormat SrcFormat = BackBuffer->GetFormat();
+	constexpr ETextureCreateFlags SrvRt = ETextureCreateFlags::ShaderResource | ETextureCreateFlags::RenderTargetable;
 
-	FTextureRHIRef ScratchTex = AcquireScratchTexture_RenderThread(W, H, SrcFormat);
-	FTextureRHIRef DestTexture = AcquireTexturePoolSlot_RenderThread(W, H);
-	if (!ScratchTex.IsValid() || !DestTexture.IsValid())
+	FTextureRHIRef ScratchTex = AcquireSingletonTexture_RenderThread(Scratch, W, H, BackBuffer->GetFormat(),
+		SrvRt, ERHIAccess::SRVGraphics, TEXT("SentrySessionReplayScratch"));
+
+#if PLATFORM_MAC
+	FTextureRHIRef ConvertedTex = AcquireSingletonTexture_RenderThread(Converted, W, H, PF_B8G8R8A8,
+		SrvRt, ERHIAccess::SRVGraphics, TEXT("SentrySessionReplayConverted"));
+#endif
+
+#if PLATFORM_MAC
+	// VT requires pool slot to have CPUReadback flag so it can be read via Metal's getBytes().
+	// Note: Metal forbids RT|CPUReadback on the same texture so an extra pass is needed (step 3)
+	constexpr ETextureCreateFlags PoolFlags = ETextureCreateFlags::CPUReadback;
+	constexpr ERHIAccess PoolInitialState = ERHIAccess::CPURead;
+#else
+	// NVENC reads from the pool slot directly. Shared adds cross-process interop and
+	// SRV|RT lets the draw pass write into it.
+	constexpr ETextureCreateFlags PoolFlags = ETextureCreateFlags::Shared | SrvRt;
+	constexpr ERHIAccess PoolInitialState = ERHIAccess::SRVGraphics;
+#endif
+
+	FTextureRHIRef EncoderTex = AcquirePoolSlot_RenderThread(EncoderPool, W, H, PF_B8G8R8A8,
+		PoolFlags, PoolInitialState, TEXT("SentrySessionReplayCapture"));
+
+	if (!ScratchTex.IsValid())
 	{
 		return;
 	}
+
+#if PLATFORM_MAC
+	if (!ConvertedTex.IsValid())
+	{
+		return;
+	}
+#endif
+
+	if (!EncoderTex.IsValid())
+	{
+		return;
+	}
+
+#if PLATFORM_MAC
+	FTextureRHIRef DrawTarget = ConvertedTex;
+#else
+	FTextureRHIRef DrawTarget = EncoderTex;
+#endif
 
 	FRHICommandListImmediate& RHICmdList = FRHICommandListExecutor::GetImmediateCommandList();
 
@@ -123,14 +163,14 @@ void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& 
 		RHICmdList.Transition(FRHITransitionInfo(ScratchTex.GetReference(), ERHIAccess::CopyDest, ERHIAccess::SRVGraphics));
 	}
 
-	// Step 2: AddDrawTexturePass scratch -> pool (BGRA8). Same-format fast
-	// path is a hardware copy; format mismatch (HDR / 10-bit source) falls
-	// back to the engine's built-in FDrawTexturePS pixel shader
+	// Step 2: AddDrawTexturePass scratch -> DrawTarget (BGRA8). Same-format fast
+	// path is a hardware copy; format mismatch (HDR / 10-bit source) falls back
+	// to the engine's built-in FDrawTexturePS pixel shader
 	{
 		FRDGBuilder GraphBuilder(RHICmdList);
 
 		FRDGTextureRef RDGSource = RegisterExternalTexture(GraphBuilder, ScratchTex, TEXT("SentrySR_Scratch"));
-		FRDGTextureRef RDGDest = RegisterExternalTexture(GraphBuilder, DestTexture, TEXT("SentrySR_Dest"));
+		FRDGTextureRef RDGDest = RegisterExternalTexture(GraphBuilder, DrawTarget, TEXT("SentrySR_Dest"));
 
 		FRDGDrawTextureInfo DrawInfo;
 		DrawInfo.Size = FIntPoint(static_cast<int32>(W), static_cast<int32>(H));
@@ -139,26 +179,72 @@ void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& 
 		GraphBuilder.Execute();
 	}
 
-	// Leave the destination in a shader-readable state for NVENC
-	RHICmdList.Transition(FRHITransitionInfo(DestTexture.GetReference(), ERHIAccess::Unknown, ERHIAccess::SRVGraphics));
+#if PLATFORM_MAC
+	// Step 3 (Mac only): hardware-copy Converted -> EncoderPool slot. Both are BGRA8 same-format
+	{
+		FRHITransitionInfo Transitions[] = {
+			FRHITransitionInfo(DrawTarget.GetReference(), ERHIAccess::Unknown, ERHIAccess::CopySrc),
+			FRHITransitionInfo(EncoderTex.GetReference(), ERHIAccess::Unknown, ERHIAccess::CopyDest),
+		};
+		RHICmdList.Transition(MakeArrayView(Transitions, UE_ARRAY_COUNT(Transitions)));
 
-	Encoder.SubmitFrame(DestTexture, Now);
+		FRHICopyTextureInfo CopyInfo;
+		CopyInfo.Size = FIntVector(static_cast<int32>(W), static_cast<int32>(H), 1);
+		RHICmdList.CopyTexture(DrawTarget.GetReference(), EncoderTex.GetReference(), CopyInfo);
+	}
+#endif
+
+#if PLATFORM_MAC
+	RHICmdList.Transition(FRHITransitionInfo(EncoderTex.GetReference(), ERHIAccess::CopyDest, ERHIAccess::CPURead));
+#else
+	RHICmdList.Transition(FRHITransitionInfo(EncoderTex.GetReference(), ERHIAccess::Unknown, ERHIAccess::SRVGraphics));
+#endif
+
+	Encoder.SubmitFrame(EncoderTex, Now);
 }
 
-FTextureRHIRef FSentryBackBufferCapture::AcquireTexturePoolSlot_RenderThread(uint32 Width, uint32 Height)
+FTextureRHIRef FSentryBackBufferCapture::AcquireSingletonTexture_RenderThread(FCachedTextureState& Cache, uint32 Width, uint32 Height, EPixelFormat Format,
+	ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName)
 {
-	if (Width != TexturePoolWidth || Height != TexturePoolHeight)
+	if (Width != Cache.Width || Height != Cache.Height || Format != Cache.Format || Flags != Cache.Flags)
 	{
-		for (FTextureRHIRef& Slot : TexturePool)
+		Cache.Texture.SafeRelease();
+		Cache.Width = Width;
+		Cache.Height = Height;
+		Cache.Format = Format;
+		Cache.Flags = Flags;
+	}
+
+	if (!Cache.Texture.IsValid())
+	{
+		const FRHITextureCreateDesc Desc = FRHITextureCreateDesc::Create2D(DebugName)
+											   .SetExtent(static_cast<int32>(Width), static_cast<int32>(Height))
+											   .SetFormat(Format)
+											   .SetFlags(Flags)
+											   .SetInitialState(InitialState);
+		Cache.Texture = RHICreateTexture(Desc);
+	}
+
+	return Cache.Texture;
+}
+
+FTextureRHIRef FSentryBackBufferCapture::AcquirePoolSlot_RenderThread(FPooledTextureState& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
+	ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName)
+{
+	if (Width != Pool.Width || Height != Pool.Height || Format != Pool.Format || Flags != Pool.Flags)
+	{
+		for (FTextureRHIRef& Slot : Pool.Slots)
 		{
 			Slot.SafeRelease();
 		}
-		TexturePoolWidth = Width;
-		TexturePoolHeight = Height;
+		Pool.Width = Width;
+		Pool.Height = Height;
+		Pool.Format = Format;
+		Pool.Flags = Flags;
 	}
 
 	FTextureRHIRef* FreeSlot = nullptr;
-	for (FTextureRHIRef& Slot : TexturePool)
+	for (FTextureRHIRef& Slot : Pool.Slots)
 	{
 		if (Slot.GetRefCount() <= 1)
 		{
@@ -174,47 +260,15 @@ FTextureRHIRef FSentryBackBufferCapture::AcquireTexturePoolSlot_RenderThread(uin
 
 	if (!FreeSlot->IsValid())
 	{
-		// Texture flags follow what AVCodecs expects for its NVENC resources
-		// on D3D (see Engine/.../AVCodecsCoreRHI/.../VideoResourceRHI.cpp):
-		// Shared (cross-process for NVENC interop) + ShaderResource +
-		// RenderTargetable. Format is always PF_B8G8R8A8 because that's what
-		// NVENC D3D12 requires; source-format conversion happens at draw time
-		const ETextureCreateFlags CreateFlags = ETextureCreateFlags::Shared | ETextureCreateFlags::ShaderResource | ETextureCreateFlags::RenderTargetable;
-		const FRHITextureCreateDesc Desc = FRHITextureCreateDesc::Create2D(TEXT("SentrySessionReplayCapture"))
-											   .SetExtent(static_cast<int32>(Width), static_cast<int32>(Height))
-											   .SetFormat(PF_B8G8R8A8)
-											   .SetFlags(CreateFlags)
-											   .SetInitialState(ERHIAccess::SRVGraphics);
-		*FreeSlot = RHICreateTexture(Desc);
-	}
-	return *FreeSlot;
-}
-
-FTextureRHIRef FSentryBackBufferCapture::AcquireScratchTexture_RenderThread(uint32 Width, uint32 Height, EPixelFormat Format)
-{
-	if (Width != ScratchWidth || Height != ScratchHeight || Format != ScratchFormat)
-	{
-		ScratchTexture.SafeRelease();
-		ScratchWidth = Width;
-		ScratchHeight = Height;
-		ScratchFormat = Format;
-	}
-
-	if (!ScratchTexture.IsValid())
-	{
-		// Mirror the backbuffer's format, but add ShaderResource so
-		// AddDrawTexturePass can sample it. RenderTargetable lets the same
-		// scratch double as a draw target in the same-format fast path
-		// inside AddDrawTexturePass (it still ends up as a HW copy)
-		const ETextureCreateFlags CreateFlags = ETextureCreateFlags::ShaderResource | ETextureCreateFlags::RenderTargetable;
-		const FRHITextureCreateDesc Desc = FRHITextureCreateDesc::Create2D(TEXT("SentrySessionReplayScratch"))
+		const FRHITextureCreateDesc Desc = FRHITextureCreateDesc::Create2D(DebugName)
 											   .SetExtent(static_cast<int32>(Width), static_cast<int32>(Height))
 											   .SetFormat(Format)
-											   .SetFlags(CreateFlags)
-											   .SetInitialState(ERHIAccess::SRVGraphics);
-		ScratchTexture = RHICreateTexture(Desc);
+											   .SetFlags(Flags)
+											   .SetInitialState(InitialState);
+		*FreeSlot = RHICreateTexture(Desc);
 	}
-	return ScratchTexture;
+
+	return *FreeSlot;
 }
 
 #endif // USE_SENTRY_SESSION_REPLAY

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -108,7 +108,7 @@ void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& 
 
 #if PLATFORM_MAC
 	// VT requires pool slot to have CPUReadback flag so it can be read via Metal's getBytes().
-	// Note: Metal forbids RT|CPUReadback on the same texture so an extra pass is needed (step 3)
+	// Note: Metal forbids RT|CPUReadback on the same texture so an extra copy is needed (step 3)
 	constexpr ETextureCreateFlags PoolFlags = ETextureCreateFlags::CPUReadback;
 	constexpr ERHIAccess PoolInitialState = ERHIAccess::CPURead;
 #else

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
@@ -89,7 +89,7 @@ private:
 	// before the final hardware copy into the CPUReadback EncoderPool slot
 	FCachedTextureState Converted;
 
-	// Pool of textures that are submited to the encoder. Ref-counted because
+	// Pool of textures that are submitted to the encoder. Ref-counted because
 	// the encoder thread holds these across frames
 	FPooledTextureState EncoderPool;
 

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
@@ -45,7 +45,7 @@ public:
 private:
 	// Single texture tracked alongside the config it was created with, so the
 	// acquire helper can detect changes and recreate
-	struct FCachedTextureState
+	struct FCachedTexture
 	{
 		FTextureRHIRef Texture;
 		uint32 Width = 0;
@@ -56,7 +56,7 @@ private:
 
 	// N-slot pool sharing one config across all slots. Slots are created lazily
 	// and recycled when their refcount drops back to 1 (no other holder)
-	struct FPooledTextureState
+	struct FCachedTexturePool
 	{
 		TArray<FTextureRHIRef> Slots;
 		uint32 Width = 0;
@@ -69,12 +69,12 @@ private:
 
 	// Returns the cached texture, recreated when any of (Width, Height, Format,
 	// Flags) differs from the previous call. Returns null on creation failure
-	static FTextureRHIRef AcquireSingletonTexture_RenderThread(FCachedTextureState& Cache, uint32 Width, uint32 Height, EPixelFormat Format,
+	static FTextureRHIRef AcquireCachedTexture_RenderThread(FCachedTexture& Cache, uint32 Width, uint32 Height, EPixelFormat Format,
 		ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName);
 
-	// Returns a slot whose refcount is <= 1, recreating the entire pool when
+	// Returns a texture pool slot whose refcount is <= 1, recreating the entire pool when
 	// the config changes. Returns null when every slot is still in flight
-	static FTextureRHIRef AcquirePoolSlot_RenderThread(FPooledTextureState& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
+	static FTextureRHIRef AcquireTexturePoolSlot_RenderThread(FCachedTexturePool& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
 		ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName);
 
 	FSentryVideoEncoder& Encoder;
@@ -83,15 +83,15 @@ private:
 
 	// SRV-able copy of the backbuffer at its source format. Slate backbuffers
 	// don't carry the SRV flag, so they can't be sampled in a shader directly
-	FCachedTextureState Scratch;
+	FCachedTexture Scratch;
 
 	// BGRA8 RenderTargetable texture. Used on Mac as the draw pass output
 	// before the final hardware copy into the CPUReadback EncoderPool slot
-	FCachedTextureState Converted;
+	FCachedTexture Converted;
 
 	// Pool of textures that are submitted to the encoder. Ref-counted because
 	// the encoder thread holds these across frames
-	FPooledTextureState EncoderPool;
+	FCachedTexturePool EncoderPool;
 
 	// Frame throttling
 	double NextCaptureTime = 0.0;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
@@ -8,23 +8,28 @@
 
 #include "Delegates/IDelegateInstance.h"
 #include "PixelFormat.h"
+#include "RHIAccess.h"
+#include "RHIDefinitions.h"
 #include "RHIFwd.h"
 
 class FSentryVideoEncoder;
 class SWindow;
 
 /**
- * Hooks FSlateRenderer::OnBackBufferReadyToPresent and forwards each
- * rendered frame of the primary game window to the encoder.
+ * Hooks FSlateRenderer::OnBackBufferReadyToPresent and forwards each rendered
+ * frame of the primary game window to the encoder.
  *
  * Per frame on the render thread:
- *   1. Hardware-copy the backbuffer into a "scratch" texture that has the
- *      same format but also carries ShaderResource flag (Slate backbuffers
- *      don't, which makes them unusable as an SRV directly).
- *   2. AddDrawTexturePass(scratch -> pool[BGRA8]). When the scratch format
- *      matches BGRA8 this stays a hardware copy; otherwise the engine's
- *      built-in pixel-shader path converts HDR/10-bit to BGRA8.
- * The pool slot is then handed to NVENC.
+ *   1. Hardware-copy the backbuffer into a "scratch" texture that has the same
+ *      format but also carries the ShaderResource flag (Slate backbuffers don't,
+ *      which makes them unusable as an SRV directly).
+ *   2. AddDrawTexturePass scratch -> a BGRA8 destination. When the scratch
+ *      format is already BGRA8 this stays a hardware copy; otherwise the
+ *      engine's built-in pixel-shader path converts HDR/10-bit to BGRA8.
+ *      Destination is the encoder pool slot on Windows; on Mac it's the
+ *      "converted" texture because Metal forbids RenderTargetable | CPUReadback.
+ *   3. Mac only: hardware-copy converted -> encoder pool slot (CPUReadback BGRA8).
+ * The pool slot is then handed to the encoder.
  */
 class FSentryBackBufferCapture
 {
@@ -38,28 +43,55 @@ public:
 	void Stop();
 
 private:
+	// Single texture tracked alongside the config it was created with, so the
+	// acquire helper can detect changes and recreate
+	struct FCachedTextureState
+	{
+		FTextureRHIRef Texture;
+		uint32 Width = 0;
+		uint32 Height = 0;
+		EPixelFormat Format = PF_Unknown;
+		ETextureCreateFlags Flags = ETextureCreateFlags::None;
+	};
+
+	// N-slot pool sharing one config across all slots. Slots are created lazily
+	// and recycled when their refcount drops back to 1 (no other holder)
+	struct FPooledTextureState
+	{
+		TArray<FTextureRHIRef> Slots;
+		uint32 Width = 0;
+		uint32 Height = 0;
+		EPixelFormat Format = PF_Unknown;
+		ETextureCreateFlags Flags = ETextureCreateFlags::None;
+	};
+
 	void OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, const FTextureRHIRef& BackBuffer);
 
-	FTextureRHIRef AcquireTexturePoolSlot_RenderThread(uint32 Width, uint32 Height);
-	FTextureRHIRef AcquireScratchTexture_RenderThread(uint32 Width, uint32 Height, EPixelFormat Format);
+	// Returns the cached texture, recreated when any of (Width, Height, Format,
+	// Flags) differs from the previous call. Returns null on creation failure
+	static FTextureRHIRef AcquireSingletonTexture_RenderThread(FCachedTextureState& Cache, uint32 Width, uint32 Height, EPixelFormat Format,
+		ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName);
+
+	// Returns a slot whose refcount is <= 1, recreating the entire pool when
+	// the config changes. Returns null when every slot is still in flight
+	static FTextureRHIRef AcquirePoolSlot_RenderThread(FPooledTextureState& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
+		ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName);
 
 	FSentryVideoEncoder& Encoder;
 
 	FDelegateHandle BackBufferReadyHandle;
 
-	// Pool of capture-destination textures handed to the encoder. Sized to the
-	// encoder queue depth and created lazily. A slot is reused only once nothing
-	// else references it (ref count back to 1); if every slot is still in flight
-	// the frame is dropped rather than overwriting one the encoder hasn't read
-	TArray<FTextureRHIRef> TexturePool;
-	uint32 TexturePoolWidth = 0;
-	uint32 TexturePoolHeight = 0;
+	// SRV-able copy of the backbuffer at its source format. Slate backbuffers
+	// don't carry the SRV flag, so they can't be sampled in a shader directly
+	FCachedTextureState Scratch;
 
-	// Scratch texture matching the backbuffer's format with ShaderResource flag added
-	FTextureRHIRef ScratchTexture;
-	uint32 ScratchWidth = 0;
-	uint32 ScratchHeight = 0;
-	EPixelFormat ScratchFormat = PF_Unknown;
+	// BGRA8 RenderTargetable texture. Used on Mac as the draw pass output
+	// before the final hardware copy into the CPUReadback EncoderPool slot
+	FCachedTextureState Converted;
+
+	// Pool of textures that are submited to the encoder. Ref-counted because
+	// the encoder thread holds these across frames
+	FPooledTextureState EncoderPool;
 
 	// Frame throttling
 	double NextCaptureTime = 0.0;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentrySessionReplayRecorder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentrySessionReplayRecorder.cpp
@@ -147,6 +147,11 @@ void FSentrySessionReplayRecorder::OnInitSegmentReady(TArray<uint8>&& NewInitSeg
 {
 	FScopeLock Lock(&RingLock);
 	InitSegment = MoveTemp(NewInitSegment);
+
+	if (!FragmentRing.IsEmpty())
+	{
+		FragmentRing.Reset();
+	}
 }
 
 void FSentrySessionReplayRecorder::OnFragmentReady(TArray<uint8>&& Fragment)

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -172,7 +172,7 @@ uint32 FSentryVideoEncoder::Run()
 
 			// VT interprets SendFrame's timestamp as microseconds (see Engine's VideoEncoderVT.hpp)
 #if PLATFORM_MAC
-			static constexpr double SendTimestampScale = 1'000'000.0;
+			static constexpr double SendTimestampScale = 1 '000' 000.0;
 #else
 			static constexpr double SendTimestampScale = 1'000.0;
 #endif

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -172,13 +172,29 @@ uint32 FSentryVideoEncoder::Run()
 
 			// VT interprets SendFrame's timestamp as microseconds (see Engine's VideoEncoderVT.hpp)
 #if PLATFORM_MAC
-			static constexpr double SendTimestampScale = 1 '000' 000.0;
+			static constexpr double SendTimestampScale = 1'000'000.0;
 #else
 			static constexpr double SendTimestampScale = 1'000.0;
 #endif
 
 			const double TimestampSeconds = FMath::Max(0.0, Frame.CaptureTimeSeconds - CaptureTimeBaseSeconds);
-			const uint32 SendTimestamp = static_cast<uint32>(TimestampSeconds * SendTimestampScale);
+			const double ScaledTimestamp = TimestampSeconds * SendTimestampScale;
+
+#if PLATFORM_MAC
+			// Restart the encoder every hour of recording. On Mac this stays well clear of the
+			// uint32-microseconds wrap at ~71 min which would otherwise feed VT a backward PTS
+			// and corrupt all subsequent fragments. On Windows the natural wrap is at ~49 days
+			// so realistically periodic refresh of encoder state won't be needed there
+			constexpr double RestartThreshold = 3600.0 * SendTimestampScale;
+			if (ScaledTimestamp > RestartThreshold)
+			{
+				UE_LOG(LogSentrySdk, Log, TEXT("Session replay: encoder has been running for %.0f s; restarting to refresh state."), TimestampSeconds);
+				Restart();
+				continue;
+			}
+#endif
+
+			const uint32 SendTimestamp = static_cast<uint32>(ScaledTimestamp);
 
 			const FAVResult Result = Encoder->SendFrame(Resource, SendTimestamp, bForceKeyframe);
 			if (Result.IsSuccess())
@@ -274,6 +290,38 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 		Width, Height, Framerate, BitrateBps / 1000, FragmentSeconds);
 
 	return true;
+}
+
+void FSentryVideoEncoder::Restart()
+{
+	DrainPackets();
+
+	if (CurrentSamples.Num() > 0 && bInitSegmentPublished)
+	{
+		TArray<uint8> Frag = FSentryFMP4Writer::BuildFragment(NextFragmentSequence++, CurrentFragmentDecodeTime, CurrentSamples);
+		Recorder.OnFragmentReady(MoveTemp(Frag));
+	}
+	CurrentSamples.Reset();
+
+	Encoder.Reset();
+
+	bEncoderOpen = false;
+
+	CaptureTimeBaseSeconds = -1.0;
+	LastPacketTimestampMs = 0;
+	bHavePrevPacketTimestamp = false;
+	LastForcedKeyframeTime = 0.0;
+	CurrentFragmentDecodeTime = 0;
+	SampleClock = 0;
+	NextFragmentSequence = 1;
+	CachedSps.Empty();
+	CachedPps.Empty();
+	bInitSegmentPublished = false;
+
+	{
+		FScopeLock Lock(&QueueLock);
+		PendingQueue.Reset();
+	}
 }
 
 void FSentryVideoEncoder::DrainPackets()

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -241,6 +241,12 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 	Config.RepeatSPSPPS = true;
 	Config.bFillData = 0;
 	Config.MultipassMode = EMultipassMode::Disabled;
+	
+#if PLATFORM_MAC
+	// Work around a VT bug where H.264 Auto maps to a null EntropyCodingMode
+	// causing a crash in CFStringGetLength. Use CABAC instead (supported by Main/High profiles)
+	Config.EntropyCodingMode = EH264EntropyCodingMode::CABAC;
+#endif
 
 	TSharedRef<FAVDevice>& Device = FAVDevice::GetHardwareDevice();
 

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -317,6 +317,8 @@ void FSentryVideoEncoder::Restart()
 	CachedSps.Empty();
 	CachedPps.Empty();
 	bInitSegmentPublished = false;
+	bFirstFrameValidated = false;
+	ConsecutiveSendFrameFailures = 0;
 
 	{
 		FScopeLock Lock(&QueueLock);

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -172,7 +172,7 @@ uint32 FSentryVideoEncoder::Run()
 
 			// VT interprets SendFrame's timestamp as microseconds (see Engine's VideoEncoderVT.hpp)
 #if PLATFORM_MAC
-			static constexpr double SendTimestampScale = 1 '000' 000.0;
+			static constexpr double SendTimestampScale = 1'000'000.0;
 #else
 			static constexpr double SendTimestampScale = 1'000.0;
 #endif

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -170,9 +170,17 @@ uint32 FSentryVideoEncoder::Run()
 				CaptureTimeBaseSeconds = Frame.CaptureTimeSeconds;
 			}
 
-			const uint32 TimestampMs = static_cast<uint32>(FMath::Max(0.0, (Frame.CaptureTimeSeconds - CaptureTimeBaseSeconds) * 1000.0));
+			// VT interprets SendFrame's timestamp as microseconds (see Engine's VideoEncoderVT.hpp)
+#if PLATFORM_MAC
+			static constexpr double SendTimestampScale = 1'000'000.0;
+#else
+			static constexpr double SendTimestampScale = 1'000.0;
+#endif
 
-			const FAVResult Result = Encoder->SendFrame(Resource, TimestampMs, bForceKeyframe);
+			const double TimestampSeconds = FMath::Max(0.0, Frame.CaptureTimeSeconds - CaptureTimeBaseSeconds);
+			const uint32 SendTimestamp = static_cast<uint32>(TimestampSeconds * SendTimestampScale);
+
+			const FAVResult Result = Encoder->SendFrame(Resource, SendTimestamp, bForceKeyframe);
 			if (Result.IsSuccess())
 			{
 				bFirstFrameValidated = true;
@@ -241,7 +249,7 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 	Config.RepeatSPSPPS = true;
 	Config.bFillData = 0;
 	Config.MultipassMode = EMultipassMode::Disabled;
-	
+
 #if PLATFORM_MAC
 	// Work around a VT bug where H.264 Auto maps to a null EntropyCodingMode
 	// causing a crash in CFStringGetLength. Use CABAC instead (supported by Main/High profiles)
@@ -315,13 +323,17 @@ void FSentryVideoEncoder::DrainPackets()
 		}
 
 		// The encoder echoes back the capture timestamp we passed to SendFrame
-		// (ms, relative to the first frame). Sample duration is the gap to the
+		// (relative to the first frame). Sample duration is the gap to the
 		// previously emitted sample, so playback follows the real capture cadence
 		// rather than the bursty encoder output cadence (and stays real-time even
 		// when the source renders below the configured target rate). A skipped
 		// packet never updates the marker, so its interval folds into the next
 		// sample. The first sample falls back to a nominal 1/Framerate
+#if PLATFORM_MAC
+		const uint32 PacketTimestampMs = static_cast<uint32>(FPlatformTime::ToMilliseconds64(Packet.Timestamp));
+#else
 		const uint32 PacketTimestampMs = static_cast<uint32>(Packet.Timestamp);
+#endif
 		double DurationSeconds;
 		if (!bHavePrevPacketTimestamp)
 		{

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
@@ -61,6 +61,13 @@ private:
 	// Pulls available packets from the encoder, converts them to AVCC samples and emits a fragment at each keyframe boundary
 	void DrainPackets();
 
+	// Tears down the current encoder and resets per-encoder state so the next frame
+	// re-baselines against a fresh VT timestamp origin and republishes a new init
+	// segment. Used to avoid uint32 overflow of the SendFrame timestamp (~71 min of
+	// microseconds on Mac, ~49 days of milliseconds on Windows). Must be called only
+	// from the encoder thread
+	void Restart();
+
 	FSentrySessionReplayRecorder& Recorder;
 
 	bool bEncoderOpen = false;

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -184,17 +184,6 @@ public class Sentry : ModuleRules
 			PublicSystemLibraries.Add("version.lib");
 			PublicSystemLibraries.Add("Synchronization.lib");
 
-			if (bAttachSessionReplay && IsPluginEnabled(Target, "AVCodecsCore"))
-			{
-				PrivateDependencyModuleNames.AddRange(new string[]
-				{
-					"RHI",
-					"RenderCore",
-					"AVCodecsCore",
-					"AVCodecsCoreRHI",
-				});
-				PublicDefinitions.Add("USE_SENTRY_SESSION_REPLAY=1");
-			}
 		}
 #if UE_5_0_OR_LATER
 		else if (Target.Platform == UnrealTargetPlatform.Linux || Target.Platform == UnrealTargetPlatform.LinuxArm64)
@@ -254,6 +243,19 @@ public class Sentry : ModuleRules
 
 				Console.WriteLine("To use Sentry SDK on game consoles follow the instructions at https://docs.sentry.io/platforms/unreal/game-consoles/");
 			}
+		}
+
+		if (bAttachSessionReplay && IsPluginEnabled(Target, "AVCodecsCore") &&
+			(Target.Platform == UnrealTargetPlatform.Win64 || Target.Platform == UnrealTargetPlatform.Mac))
+		{
+			PrivateDependencyModuleNames.AddRange(new string[]
+			{
+				"RHI",
+				"RenderCore",
+				"AVCodecsCore",
+				"AVCodecsCoreRHI",
+			});
+			PublicDefinitions.Add("USE_SENTRY_SESSION_REPLAY=1");
 		}
 	}
 

--- a/sample/SentryPlayground.uproject
+++ b/sample/SentryPlayground.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "5.7",
+	"EngineAssociation": "4.27",
 	"Category": "",
 	"Description": "",
 	"Modules": [

--- a/sample/SentryPlayground.uproject
+++ b/sample/SentryPlayground.uproject
@@ -1,6 +1,6 @@
 {
 	"FileVersion": 3,
-	"EngineAssociation": "4.27",
+	"EngineAssociation": "5.7",
 	"Category": "",
 	"Description": "",
 	"Modules": [
@@ -38,12 +38,17 @@
 		{
 			"Name": "AVCodecsCore",
 			"Enabled": true,
-			"PlatformAllowList": [ "Win64" ]
+			"PlatformAllowList": [ "Win64", "Mac" ]
 		},
 		{
 			"Name": "NVCodecs",
 			"Enabled": true,
 			"PlatformAllowList": [ "Win64" ]
+		},
+		{
+			"Name": "VTCodecs",
+			"Enabled": true,
+			"PlatformAllowList": [ "Mac" ]
 		}
 	],
 	"TargetPlatforms": [


### PR DESCRIPTION
This PR extends the opt-in Session Replay feature support to macOS allowing the SDK to continuously record the last several seconds of gameplay into a MP4 file and attach it to crash reports.

[Example crash event](https://sentry-sdks.sentry.io/issues/7532510000/events/19598ab67a8a4d149d5cc55918aba73c/) with Session Replay attached (Mac).

## Key Changes

- `FMacSentrySubsystem` now spawns the recorder in both backend modes (Cocoa and Native). The resulting `.mp4` is attached via `onLastRunStatusDetermined` when using the Cocoa backend and via the in-process `OnCrash` hook when using the Native backend.

- `FSentryBackBufferCapture` now parameterizes its texture acquisition helpers over `(format, flags, initial state)`, allowing the same `FCachedTexture` / `FCachedTexturePool` infrastructure to be shared across platforms.

- On macOS, the capture pipeline introduces an intermediate texture between the format-conversion draw pass and the CPU-readable pool slot, as Metal does not allow `RenderTargetable` and `CPUReadback` flags on the same texture.
## Engine Dependencies

In addition to `AVCodecsCore`, Mac builds require the experimental `VTCodecs` plugin (Mac-only, ships with UE 5.2+). Both must be enabled in the project for `USE_SENTRY_SESSION_REPLAY` to be defined (guards session replay code).

## Other Considerations

- **Metal flag restrictions:** VT's RHI bridge requires `TexCreate_CPUReadback` on the texture it receives, while Metal RHI does not allow `TexCreate_CPUReadback` and `TexCreate_RenderTargetable` to be used on the same texture. As a result, the macOS path performs one additional GPU copy from a singleton `BGRA8` render-target intermediate into the CPU-readable texture from the pool.
- **VT timestamp units:** `Encoder->SendFrame` expects timestamps in microseconds on VT (whereas NVENC treats them as opaque values), and `Packet.Timestamp` is returned as `mach_absolute_time` host-clock ticks (whereas NVENC echoes the original value unchanged). The encoder thread now performs platform-specific timestamp conversion, scaling `SendFrame` timestamps to microseconds on macOS and converting packet timestamps via `FPlatformTime::ToMilliseconds64`.

## Documentation

- https://github.com/getsentry/sentry-docs/pull/18292

## Related items

- https://github.com/getsentry/sentry-unreal/pull/1404