### PR TITLE
chore: update Claude instructions and integration test docs

### DIFF
--- a/.claude/skills/ue-build/SKILL.md
+++ b/.claude/skills/ue-build/SKILL.md
@@ -24,20 +24,22 @@ Build the SentryPlayground sample project.
 
 3. Determine the build configuration: use `Development` by default, or `Shipping` if the user mentions it.
 
-4. Run the build command from the repository root:
+4. Resolve the repo root and run the build command:
 
 ```bash
+REPO=$(git rev-parse --show-toplevel)
+
 # Windows
 "$UNREAL_ENGINE_ROOT/Engine/Build/BatchFiles/RunUAT.bat" BuildCookRun \
-    -project="$PWD/sample/SentryPlayground.uproject" \
-    -archivedirectory="$PWD/sample/dist" \
+    -project="$REPO/sample/SentryPlayground.uproject" \
+    -archivedirectory="$REPO/sample/dist" \
     -platform=Win64 -clientconfig=Development \
     -build -cook -stage -package -archive -nop4
 
 # macOS
 "$UNREAL_ENGINE_ROOT/Engine/Build/BatchFiles/RunUAT.sh" BuildCookRun \
-    -project="$PWD/sample/SentryPlayground.uproject" \
-    -archivedirectory="$PWD/sample/dist" \
+    -project="$REPO/sample/SentryPlayground.uproject" \
+    -archivedirectory="$REPO/sample/dist" \
     -platform=Mac -clientconfig=Development \
     -build -cook -stage -package -archive -nop4
 ```

--- a/.claude/skills/ue-unit-test/SKILL.md
+++ b/.claude/skills/ue-unit-test/SKILL.md
@@ -17,21 +17,23 @@ Prerequisite: the project must be built first. If unsure whether it's been built
 | macOS   | `Engine/Binaries/Mac/UnrealEditor`       | `Engine/Binaries/Mac/UE4Editor`       |
 | Linux   | `Engine/Binaries/Linux/UnrealEditor`     | `Engine/Binaries/Linux/UE4Editor`     |
 
-3. Run the automation command from the repository root:
+3. Resolve the repo root and run the automation command:
 
 ```bash
+REPO=$(git rev-parse --show-toplevel)
+
 # Windows UE5
 "$UNREAL_ENGINE_ROOT/Engine/Binaries/Win64/UnrealEditor.exe" \
-    "$PWD/sample/SentryPlayground.uproject" \
-    -ReportExportPath="$PWD/sample/Saved/Automation" \
+    "$REPO/sample/SentryPlayground.uproject" \
+    -ReportExportPath="$REPO/sample/Saved/Automation" \
     -ExecCmds="Automation RunTests Sentry;quit" \
     -TestExit="Automation Test Queue Empty" \
     -Unattended -NoPause -NoSplash -NullRHI
 
 # macOS UE5
 "$UNREAL_ENGINE_ROOT/Engine/Binaries/Mac/UnrealEditor" \
-    "$PWD/sample/SentryPlayground.uproject" \
-    -ReportExportPath="$PWD/sample/Saved/Automation" \
+    "$REPO/sample/SentryPlayground.uproject" \
+    -ReportExportPath="$REPO/sample/Saved/Automation" \
     -ExecCmds="Automation RunTests Sentry;quit" \
     -TestExit="Automation Test Queue Empty" \
     -Unattended -NoPause -NoSplash -NullRHI

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,7 @@ Supported Unreal Engine versions are listed in `scripts/packaging/engine-version
 
 - When introducing a new public API that becomes part of the common interface, ensure that a corresponding stub is added to its `Null` implementation to avoid compilation errors on unsupported platforms.
 
-- Package plugin and update snapshot after adding/removing files (see `/pack` skill).
+- Package plugin and update snapshot after adding/removing files under `plugin-dev` dir (use `/pack` skill).
 
 ### Code Style
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -285,7 +285,7 @@ On Windows, when checking env vars via PowerShell through the Bash tool, use the
 - [sentry-cli](https://github.com/getsentry/sentry-cli): uploading debug symbols for symbolicating stack traces gathered via the SDK
 - [sentry-android-gradle-plugin](https://github.com/getsentry/sentry-android-gradle-plugin): uploading Android debug symbols
 - [app-runner](https://github.com/getsentry/app-runner): PowerShell module used in integration tests
-- [sentry-docs](https://github.com/getsentry/seentry-docs): documentation sources for Sentry products
+- [sentry-docs](https://github.com/getsentry/sentry-docs): documentation sources for Sentry products
 
 ## Maintaining This Document
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,8 @@ plugin-dev/Source/
 │       ├── Mac/             # macOS overrides for Apple/GenericPlatform
 │       ├── Microsoft/       # Windows/Xbox/WinGDK base, overrides GenericPlatform
 │       ├── Null/            # Stubs for unsupported platforms
+│       ├── Performance/     # Performance monitors (frame time, GC, network, game stats)
+│       ├── SessionReplay/   # Session replay recording (backbuffer capture, MP4 encoder)
 │       ├── Tests/           # Unit test specs
 │       ├── Utils/           # Common utilities
 │       └── Windows/         # Windows overrides for Microsoft

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,6 +209,14 @@ Build and test workflows are available as skills:
 - Never print or display environment variables that may contain secrets (passwords, API keys, auth tokens, DSNs)
 - When checking environment variables, only verify if they are set (non-empty), don't output their values
 
+### Documentation
+
+When introducing a new SDK feature or changing existing behavior, consider whether the Unreal plugin documentation needs to be updated as part of the change.
+
+For guidance on content, structure, and writing style, look for similar documentation in sibling SDKs. Reuse existing patterns whenever possible to keep documentation consistent across SDKs.
+
+The `SENTRY_DOCS_PATH` environment variable points to a local checkout of the documentation repository where any required updates should be made.
+
 ### Troubleshooting
 
 - If the build, test, or script execution fails, try to understand the root cause of the error and suggest a fix. Check logs for additional issue insights.
@@ -277,6 +285,7 @@ On Windows, when checking env vars via PowerShell through the Bash tool, use the
 - [sentry-cli](https://github.com/getsentry/sentry-cli): uploading debug symbols for symbolicating stack traces gathered via the SDK
 - [sentry-android-gradle-plugin](https://github.com/getsentry/sentry-android-gradle-plugin): uploading Android debug symbols
 - [app-runner](https://github.com/getsentry/app-runner): PowerShell module used in integration tests
+- [sentry-docs](https://github.com/getsentry/seentry-docs): documentation sources for Sentry products
 
 ## Maintaining This Document
 

--- a/integration-test/README.md
+++ b/integration-test/README.md
@@ -5,7 +5,10 @@ This directory contains integration tests for the Sentry Unreal SDK using Pester
 Supports testing on:
 - **Windows** - Desktop (x64)
 - **Linux** - Desktop (x64)
+- **macOS** - Desktop (arm64)
 - **Android** - Local device/emulator (via adb) or SauceLabs Real Device Cloud
+
+The desktop test script (`Integration.Desktop.Tests.ps1`) auto-detects the host platform and adjusts test selection based on the active crash handler backend (Crashpad/Cocoa/Breakpad vs. Native). Some tests are skipped on certain backend combinations — see notes under [Test Coverage](#test-coverage).
 
 ## Prerequisites
 
@@ -94,13 +97,17 @@ cd integration-test
 Invoke-Pester Integration.Desktop.Tests.ps1
 ```
 
-### Linux
+### Linux / macOS
 
 ```bash
 # Set environment variables
 export SENTRY_UNREAL_TEST_DSN="https://key@org.ingest.sentry.io/project"
 export SENTRY_AUTH_TOKEN="sntrys_your_token_here"
+
+# Linux: shell-script entrypoint
 export SENTRY_UNREAL_TEST_APP_PATH="./path/to/SentryPlayground.sh"
+# macOS: executable inside the .app bundle
+export SENTRY_UNREAL_TEST_APP_PATH="./path/to/SentryPlayground.app/Contents/MacOS/SentryPlayground"
 
 # Run tests
 cd integration-test
@@ -137,6 +144,9 @@ Invoke-Pester Integration.Android.Tests.ps1
 The integration tests cover:
 
 ### Crash Capture Tests
+
+Runs once per crash type. The desktop suite parameterizes over: `NullPointer`, `StackOverflow`, `MemoryCorruption`, `Assert`, `OutOfMemory`. `OutOfMemory` is skipped on Linux and on macOS with the native backend (memory overcommit makes the OOM condition unreliable to trigger).
+
 - Application crashes with non-zero exit code
 - Event ID is captured from output (set via `test.crash_id` tag)
 - Crash event appears in Sentry
@@ -146,10 +156,26 @@ The integration tests cover:
 - Integration test tags are set
 - Breadcrumbs are collected
 
-**Note**: Crash capture tests are currently disabled on Android due to a known issue with tag persistence across app sessions.
+**Note**: On Android and macOS (cocoa backend), the crash event is uploaded on the next app launch (an init-only run), and the crash is captured from the Java layer (platform `java` rather than `native`).
+
+### Ensure Capture Tests
+
+- Application exits cleanly after a non-fatal `ensure()` failure
+- Event ID is captured from output and TEST_RESULT indicates success
+- Ensure event appears in Sentry with exception type "Ensure failed"
+- Stack trace, user context, and integration test tags are present
+
+### Hang Tracking Tests
+
+Desktop-only; skipped on macOS (sentry-cocoa provides its own AppHang detection that isn't exercised here).
+
+- Application exits cleanly after a tracked hang
+- Hang event appears in Sentry with the "App Hanging" exception type and `AppHang` mechanism
+- Stack trace and CrashType tag are present
 
 ### Message Capture Tests
-- Application exits cleanly (exit code 0 on Windows/Linux, Android doesn't report exit codes)
+
+- Application exits cleanly (exit code 0 on Windows/Linux/macOS, Android doesn't report exit codes)
 - Event ID is captured from output
 - TEST_RESULT indicates success
 - Message event appears in Sentry
@@ -161,6 +187,7 @@ The integration tests cover:
 **Note**: On Android, events are captured from the Java layer, so the platform will be `java` instead of `native`.
 
 ### Structured Logging Tests
+
 - Application exits cleanly
 - Test ID is captured from output
 - TEST_RESULT indicates success
@@ -174,6 +201,7 @@ The integration tests cover:
 **Note**: Global log attributes (`SetAttribute`/`RemoveAttribute`) are not supported on Android (sentry-java) and are only tested on desktop.
 
 ### Metrics Capture Tests
+
 - Application exits cleanly
 - Test ID is captured from output
 - TEST_RESULT indicates success
@@ -182,9 +210,10 @@ The integration tests cover:
 - Attribute removed by BeforeMetricHandler is absent
 - Test ID attribute matches captured ID
 
-**Note**: Metrics are not supported on Apple platforms (macOS/iOS) and the test is skipped accordingly.
+**Note**: Metrics are not supported on the cocoa backend, so the test is skipped on macOS when the cocoa backend is active. With the native backend on macOS, metrics are tested.
 
 ### Tracing Capture Tests
+
 - Application exits cleanly
 - Trace ID is captured from output
 - Transaction appears in Sentry with correct name and operation
@@ -196,7 +225,8 @@ The integration tests cover:
 
 Test outputs are saved to `integration-test/output/`:
 
-### Windows/Linux
+### Windows/Linux/macOS
+
 - `*-crash-stdout.log` - Crash test standard output
 - `*-crash-stderr.log` - Crash test standard error
 - `*-crash-result.json` - Full crash test result
@@ -206,6 +236,7 @@ Test outputs are saved to `integration-test/output/`:
 - `event-*.json` - Events fetched from Sentry API
 
 ### Android
+
 - `*-logcat.txt` - Logcat output from app execution (one file per launch)
 - `event-*.json` - Events fetched from Sentry API
 


### PR DESCRIPTION
This PR refreshes the repository's Claude Code instructions and integration test documentation to match the current state of the codebase. Changes are scoped to docs and Claude skill files (no runtime/plugin code is touched).

#skip-changelog