### PR TITLE
Add experimental session replay capturing on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add experimental Session Replay capturing on Mac ([#1425](https://github.com/getsentry/sentry-unreal/pull/1425))
+- Add experimental session replay capturing on Linux ([#1428](https://github.com/getsentry/sentry-unreal/pull/1428))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -52,6 +52,7 @@
 #include "Misc/CoreDelegates.h"
 #include "Misc/EngineVersionComparison.h"
 #include "Misc/FileHelper.h"
+#include "Misc/Guid.h"
 #include "Misc/Paths.h"
 #include "UObject/UObjectThreadContext.h"
 
@@ -308,6 +309,16 @@ sentry_value_t FGenericPlatformSentrySubsystem::OnBeforeMetric(sentry_value_t me
 
 sentry_value_t FGenericPlatformSentrySubsystem::OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure)
 {
+#ifdef USE_SENTRY_SESSION_REPLAY
+	if (SessionReplay && SessionReplay->HasSnapshotOnDisk())
+	{
+		TSharedPtr<ISentryAttachment> ReplayAttachment =
+			MakeShareable(new FGenericPlatformSentryAttachment(SessionReplay->GetAttachmentPath(), TEXT("session-replay.mp4"), TEXT("video/mp4")));
+
+		AddFileAttachment(ReplayAttachment);
+	}
+#endif
+
 	if (isScreenshotAttachmentEnabled && !IsOutOfProcessScreenshotEnabled() && !IsRunningCommandlet())
 	{
 		if (IsScreenshotSupported())
@@ -629,11 +640,33 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 	// associated GC lock acquisition) inside the `before_send` callback when handling fatal errors,
 	// which can re-trigger memory-related crashes (e.g. stack overflow).
 	PooledCrashEvent = TStrongObjectPtr<USentryEvent>(NewObject<USentryEvent>());
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+	if (isEnabled && settings->AttachSessionReplay)
+	{
+		// Clear replay videos captured during previous session if any
+		IFileManager::Get().DeleteDirectory(*FPaths::Combine(GetDatabasePath(), TEXT("replays")), false, true);
+
+		SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
+		if (!SessionReplay->Initialize(settings, GetReplayPath()))
+		{
+			SessionReplay.Reset();
+		}
+	}
+#endif
 }
 
 void FGenericPlatformSentrySubsystem::Close()
 {
 	isEnabled = false;
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+	if (SessionReplay)
+	{
+		SessionReplay->Shutdown();
+		SessionReplay.Reset();
+	}
+#endif
 
 	PooledCrashEvent.Reset();
 
@@ -1316,5 +1349,14 @@ FString FGenericPlatformSentrySubsystem::GetScreenshotPath() const
 
 	return ScreenshotFullPath;
 }
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+FString FGenericPlatformSentrySubsystem::GetReplayPath() const
+{
+	const FString ReplayId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens).ToLower();
+	const FString ReplayPath = FPaths::Combine(GetDatabasePath(), TEXT("replays"), FString::Printf(TEXT("replay-%s.mp4"), *ReplayId));
+	return FPaths::ConvertRelativePathToFull(ReplayPath);
+}
+#endif
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -9,6 +9,10 @@
 
 #include "Interface/SentrySubsystemInterface.h"
 
+#ifdef USE_SENTRY_SESSION_REPLAY
+#include "SessionReplay/SentrySessionReplayRecorder.h"
+#endif
+
 class FGenericPlatformSentryAttachment;
 class FGenericPlatformSentryScope;
 class FGenericPlatformSentryCrashReporter;
@@ -157,6 +161,12 @@ private:
 	TStrongObjectPtr<USentryEvent> PooledCrashEvent;
 
 	FThreadSafeBool bIsCrashing;
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+	FString GetReplayPath() const;
+
+	TUniquePtr<FSentrySessionReplayRecorder> SessionReplay;
+#endif
 };
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
@@ -11,12 +11,6 @@
 
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
 
-#ifdef USE_SENTRY_SESSION_REPLAY
-#include "GenericPlatform/GenericPlatformSentryAttachment.h"
-#include "HAL/FileManager.h"
-#include "Misc/Guid.h"
-#endif
-
 void FMacSentrySubsystem::InitWithSettings(const USentrySettings* Settings, const FSentryCallbackHandlers& CallbackHandlers)
 {
 	FGenericPlatformSentrySubsystem::InitWithSettings(Settings, CallbackHandlers);
@@ -30,58 +24,7 @@ void FMacSentrySubsystem::InitWithSettings(const USentrySettings* Settings, cons
 	{
 		InitCrashReporter(Settings->GetEffectiveRelease(), Settings->GetEffectiveEnvironment());
 	}
-
-#ifdef USE_SENTRY_SESSION_REPLAY
-	if (IsEnabled() && Settings->AttachSessionReplay)
-	{
-		// Clear replay videos captured during previous session if any
-		IFileManager::Get().DeleteDirectory(*FPaths::Combine(GetDatabasePath(), TEXT("replays")), false, true);
-
-		SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
-		if (!SessionReplay->Initialize(Settings, GetReplayPath()))
-		{
-			SessionReplay.Reset();
-		}
-	}
-#endif
 }
-
-sentry_value_t FMacSentrySubsystem::OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure)
-{
-#ifdef USE_SENTRY_SESSION_REPLAY
-	if (SessionReplay && SessionReplay->HasSnapshotOnDisk())
-	{
-		TSharedPtr<ISentryAttachment> ReplayAttachment =
-			MakeShareable(new FGenericPlatformSentryAttachment(SessionReplay->GetAttachmentPath(), TEXT("session-replay.mp4"), TEXT("video/mp4")));
-
-		AddFileAttachment(ReplayAttachment);
-	}
-#endif
-
-	return FGenericPlatformSentrySubsystem::OnCrash(uctx, event, closure);
-}
-
-void FMacSentrySubsystem::Close()
-{
-#ifdef USE_SENTRY_SESSION_REPLAY
-	if (SessionReplay)
-	{
-		SessionReplay->Shutdown();
-		SessionReplay.Reset();
-	}
-#endif
-
-	FGenericPlatformSentrySubsystem::Close();
-}
-
-#ifdef USE_SENTRY_SESSION_REPLAY
-FString FMacSentrySubsystem::GetReplayPath() const
-{
-	const FString ReplayId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens).ToLower();
-	const FString ReplayPath = FPaths::Combine(GetDatabasePath(), TEXT("replays"), FString::Printf(TEXT("replay-%s.mp4"), *ReplayId));
-	return FPaths::ConvertRelativePathToFull(ReplayPath);
-}
-#endif
 
 FString FMacSentrySubsystem::GetHandlerExecutableName() const
 {

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
@@ -6,15 +6,10 @@
 
 #include "GenericPlatform/GenericPlatformSentrySubsystem.h"
 
-#ifdef USE_SENTRY_SESSION_REPLAY
-#include "SessionReplay/SentrySessionReplayRecorder.h"
-#endif
-
 class FMacSentrySubsystem : public FGenericPlatformSentrySubsystem
 {
 public:
 	virtual void InitWithSettings(const USentrySettings* settings, const FSentryCallbackHandlers& callbackHandlers) override;
-	virtual void Close() override;
 
 protected:
 	virtual void ConfigureHandlerPath(sentry_options_t* Options) override;
@@ -30,15 +25,6 @@ protected:
 	virtual bool IsHangTrackingSupported() const override { return false; }
 
 	virtual FString GetDeviceType() const override { return TEXT("Desktop"); }
-
-	virtual sentry_value_t OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure) override;
-
-private:
-#ifdef USE_SENTRY_SESSION_REPLAY
-	FString GetReplayPath() const;
-
-	TUniquePtr<FSentrySessionReplayRecorder> SessionReplay;
-#endif
 };
 
 #else

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -112,9 +112,16 @@ void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& 
 	constexpr ETextureCreateFlags PoolFlags = ETextureCreateFlags::CPUReadback;
 	constexpr ERHIAccess PoolInitialState = ERHIAccess::CPURead;
 #else
-	// NVENC reads from the pool slot directly. Shared adds cross-process interop and
-	// SRV|RT lets the draw pass write into it.
-	constexpr ETextureCreateFlags PoolFlags = ETextureCreateFlags::Shared | SrvRt;
+	// NVENC reads from the pool slot directly. The external-memory flag exposes the
+	// texture's GPU allocation to the encoder; SRV|RT lets the draw pass write into it.
+	// The flag is RHI-specific: D3D (Windows) uses Shared, while Vulkan (Linux, or
+	// Windows -vulkan) needs External so AVCodecs can import it through CUDA. This must
+	// match how the engine's FVideoResourceRHI::Create chooses the flag per RHI, otherwise
+	// the resource has no shareable handle and the encoder rejects every frame.
+	const ETextureCreateFlags InteropFlag = (RHIGetInterfaceType() == ERHIInterfaceType::Vulkan)
+												? ETextureCreateFlags::External
+												: ETextureCreateFlags::Shared;
+	const ETextureCreateFlags PoolFlags = InteropFlag | SrvRt;
 	constexpr ERHIAccess PoolInitialState = ERHIAccess::SRVGraphics;
 #endif
 

--- a/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.cpp
@@ -9,13 +9,7 @@
 
 #include "Utils/SentryPlatformDetectionUtils.h"
 
-#include "HAL/FileManager.h"
-#include "Misc/Guid.h"
 #include "Misc/Paths.h"
-
-#ifdef USE_SENTRY_SESSION_REPLAY
-#include "GenericPlatform/GenericPlatformSentryAttachment.h"
-#endif
 
 void FWindowsSentrySubsystem::InitWithSettings(const USentrySettings* Settings, const FSentryCallbackHandlers& CallbackHandlers)
 {
@@ -31,20 +25,6 @@ void FWindowsSentrySubsystem::InitWithSettings(const USentrySettings* Settings, 
 	{
 		ConfigureCrashReporterAppearance(Settings);
 	}
-
-#ifdef USE_SENTRY_SESSION_REPLAY
-	if (IsEnabled() && Settings->AttachSessionReplay)
-	{
-		// Clear replay videos captured during previous session if any
-		IFileManager::Get().DeleteDirectory(*FPaths::Combine(GetDatabasePath(), TEXT("replays")), false, true);
-
-		SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
-		if (!SessionReplay->Initialize(Settings, GetReplayPath()))
-		{
-			SessionReplay.Reset();
-		}
-	}
-#endif
 
 	// Add Wine/Proton context for all events if detected
 	if (WineProtonInfo.bIsRunningUnderWine && IsEnabled())
@@ -149,34 +129,6 @@ void FWindowsSentrySubsystem::ConfigureScreenshotCapturing(sentry_options_t* Opt
 	}
 }
 
-sentry_value_t FWindowsSentrySubsystem::OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure)
-{
-#ifdef USE_SENTRY_SESSION_REPLAY
-	if (SessionReplay && SessionReplay->HasSnapshotOnDisk())
-	{
-		TSharedPtr<ISentryAttachment> ReplayAttachment =
-			MakeShareable(new FGenericPlatformSentryAttachment(SessionReplay->GetAttachmentPath(), TEXT("session-replay.mp4"), TEXT("video/mp4")));
-
-		AddFileAttachment(ReplayAttachment);
-	}
-#endif
-
-	return FMicrosoftSentrySubsystem::OnCrash(uctx, event, closure);
-}
-
-void FWindowsSentrySubsystem::Close()
-{
-#ifdef USE_SENTRY_SESSION_REPLAY
-	if (SessionReplay)
-	{
-		SessionReplay->Shutdown();
-		SessionReplay.Reset();
-	}
-#endif
-
-	FMicrosoftSentrySubsystem::Close();
-}
-
 FString FWindowsSentrySubsystem::GetDeviceType() const
 {
 	if (FSentryPlatformDetectionUtils::IsSteamDeck())
@@ -185,15 +137,6 @@ FString FWindowsSentrySubsystem::GetDeviceType() const
 	}
 
 	return FMicrosoftSentrySubsystem::GetDeviceType();
-}
-
-FString FWindowsSentrySubsystem::GetReplayPath() const
-{
-	const FString ReplayId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens).ToLower();
-	const FString ReplayPath = FPaths::Combine(GetDatabasePath(), TEXT("replays"), FString::Printf(TEXT("replay-%s.mp4"), *ReplayId));
-	const FString ReplayFullPath = FPaths::ConvertRelativePathToFull(ReplayPath);
-
-	return ReplayFullPath;
 }
 
 #endif // USE_SENTRY_NATIVE && !SENTRY_WINGDK

--- a/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Windows/WindowsSentrySubsystem.h
@@ -8,15 +8,10 @@
 
 #include "Microsoft/MicrosoftSentrySubsystem.h"
 
-#ifdef USE_SENTRY_SESSION_REPLAY
-#include "SessionReplay/SentrySessionReplayRecorder.h"
-#endif
-
 class FWindowsSentrySubsystem : public FMicrosoftSentrySubsystem
 {
 public:
 	virtual void InitWithSettings(const USentrySettings* Settings, const FSentryCallbackHandlers& CallbackHandlers) override;
-	virtual void Close() override;
 
 	virtual bool IsHangTrackingSupported() const override { return true; }
 	virtual FString GetDeviceType() const override;
@@ -30,23 +25,15 @@ protected:
 	virtual FString GetHandlerExecutableName() const override;
 	virtual FString GetCrashReporterExecutableName() const override { return TEXT("Sentry.CrashReporter.exe"); }
 
-	virtual sentry_value_t OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure) override;
-
 	virtual bool IsScreenshotSupported() const override { return true; }
 	virtual bool IsOutOfProcessScreenshotEnabled() const override { return bOutOfProcessScreenshots; }
 
 private:
-	FString GetReplayPath() const;
-
 	/** Wine/Proton detection info */
 	FWineProtonInfo WineProtonInfo;
 
 	/** Whether native out-of-process screenshot capturing is enabled */
 	bool bOutOfProcessScreenshots = false;
-
-#ifdef USE_SENTRY_SESSION_REPLAY
-	TUniquePtr<FSentrySessionReplayRecorder> SessionReplay;
-#endif
 };
 
 typedef FWindowsSentrySubsystem FPlatformSentrySubsystem;

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -246,7 +246,7 @@ public class Sentry : ModuleRules
 		}
 
 		if (bAttachSessionReplay && IsPluginEnabled(Target, "AVCodecsCore") &&
-			(Target.Platform == UnrealTargetPlatform.Win64 || Target.Platform == UnrealTargetPlatform.Mac))
+			(Target.Platform == UnrealTargetPlatform.Win64 || Target.Platform == UnrealTargetPlatform.Mac || Target.Platform == UnrealTargetPlatform.Linux))
 		{
 			PrivateDependencyModuleNames.AddRange(new string[]
 			{

--- a/sample/SentryPlayground.uproject
+++ b/sample/SentryPlayground.uproject
@@ -38,12 +38,12 @@
 		{
 			"Name": "AVCodecsCore",
 			"Enabled": true,
-			"PlatformAllowList": [ "Win64", "Mac" ]
+			"PlatformAllowList": [ "Win64", "Mac", "Linux" ]
 		},
 		{
 			"Name": "NVCodecs",
 			"Enabled": true,
-			"PlatformAllowList": [ "Win64" ]
+			"PlatformAllowList": [ "Win64", "Linux" ]
 		},
 		{
 			"Name": "VTCodecs",


### PR DESCRIPTION
This PR adds an opt-in session replay feature for Linux allowing the SDK to continuously record the last several seconds of gameplay into a MP4 file and attach it to crash reports.

[Example crash event](https://sentry-sdks.sentry.io/issues/7165181036/events/b9ac420098684a09fb8ebb96c05e4c82/) with Session Replay attached (Linux)

## Key Changes

- The desktop recorder lifecycle (initialization, crash-time attachment, teardown, and replay path) is now consolidated into `FGenericPlatformSentrySubsystem`, the shared `sentry-native` base. All native desktop backends (Windows, Linux and the macOS Native backend) now use this unified path for Session Replay, and the duplicated implementations have been removed from `FWindowsSentrySubsystem` and the Native branch of `FMacSentrySubsystem`. The Cocoa backend retains its own implementation as it lives in a separate class hierarchy (`FAppleSentrySubsystem`).

- `FSentryBackBufferCapture` now selects the encoder input texture interop flag at runtime based on the active RHI type - `External` for Vulkan (Linux, or Windows with `-vulkan`) and `Shared` for D3D - aligning with how the engine’s `FVideoResourceRHI::Create` chooses the appropriate flag per RHI.

## Engine Dependencies

In addition to `AVCodecsCore`, Linux builds require the experimental `NVCodecs` plugin (which provides the NVENC encoder, available on Win64/Linux from UE 5.2+). Both must be enabled in the project for `USE_SENTRY_SESSION_REPLAY` to be defined (guards session replay code), and the platform must be Win64, Mac, or Linux.

## Other Considerations

- **Vulkan → CUDA external-memory interop:** On Linux the RHI is Vulkan, and AVCodecs has no native Vulkan H.264 encoder - NVENC is reached through CUDA. The encoder imports the capture texture's GPU allocation via an external-memory handle (`OPAQUE_FD` on Linux), which requires the texture to be created with `TexCreate_External` rather than the D3D-oriented `TexCreate_Shared`. The capture path now picks the flag per RHI so the Vulkan allocation exposes a shareable handle; with the wrong flag the resource has no shareable handle and the encoder rejects every frame.

## Known Limitations

- Currently works only with NVIDIA GPUs (driver 530.41 or newer)

## Documentation

- https://github.com/getsentry/sentry-docs/pull/18366

## Related items:

- https://github.com/getsentry/sentry-unreal/pull/1404
- https://github.com/getsentry/sentry-unreal/pull/1425