### PR TITLE
Fix crash when captured log messages contain printf-style format specifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - Add experimental Session Replay capturing on Mac ([#1425](https://github.com/getsentry/sentry-unreal/pull/1425))
 - Add experimental session replay capturing on Linux ([#1428](https://github.com/getsentry/sentry-unreal/pull/1428))
 
+### Fixes
+
+- Fix crash when captured log messages contain printf-style format specifiers ([#1434](https://github.com/getsentry/sentry-unreal/pull/1434))
+
 ### Dependencies
 
 - Bump CLI from v3.4.3 to v3.5.0 ([#1419](https://github.com/getsentry/sentry-unreal/pull/1419))

--- a/integration-test/Integration.Android.Tests.ps1
+++ b/integration-test/Integration.Android.Tests.ps1
@@ -472,9 +472,9 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             $script:CapturedLogs.Count | Should -BeGreaterThan 0
         }
 
-        It "Should have correct log message" {
+        It "Should have correct log message with format specifiers delivered verbatim" {
             $log = $script:CapturedLogs[0]
-            $log.message | Should -Match 'Integration test structured log'
+            $log.message | Should -Be '[LogSentryTest] Integration test structured log metadata="%s" (%d fields)'
         }
 
         It "Should have correct severity level" {

--- a/integration-test/Integration.Desktop.Tests.ps1
+++ b/integration-test/Integration.Desktop.Tests.ps1
@@ -715,9 +715,9 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
             $script:CapturedLogs.Count | Should -BeGreaterThan 0
         }
 
-        It "Should have correct log message" {
+        It "Should have correct log message with format specifiers delivered verbatim" {
             $log = $script:CapturedLogs[0]
-            $log.message | Should -Match 'Integration test structured log'
+            $log.message | Should -Be '[LogSentryTest] Integration test structured log metadata="%s" (%d fields)'
         }
 
         It "Should have correct severity level" {

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -581,7 +581,6 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 	sentry_options_set_crashpad_wait_for_upload(options, settings->CrashpadWaitForUpload);
 	sentry_options_set_logger_enabled_when_crashed(options, settings->EnableOnCrashLogging);
 	sentry_options_set_enable_logs(options, settings->EnableStructuredLogging);
-	sentry_options_set_logs_with_attributes(options, true);
 	sentry_options_set_enable_metrics(options, settings->EnableMetrics);
 	sentry_options_set_before_send_metric(options, HandleBeforeMetric, this);
 	sentry_options_set_http_retry(options, 1);
@@ -728,25 +727,7 @@ void FGenericPlatformSentrySubsystem::AddLog(const FString& Message, ESentryLeve
 
 	sentry_value_t attributes = FGenericPlatformSentryConverters::VariantMapToAttributesNative(Attributes);
 
-	switch (Level)
-	{
-	case ESentryLevel::Fatal:
-		sentry_log_fatal(MessageUtf8.Get(), attributes);
-		break;
-	case ESentryLevel::Error:
-		sentry_log_error(MessageUtf8.Get(), attributes);
-		break;
-	case ESentryLevel::Warning:
-		sentry_log_warn(MessageUtf8.Get(), attributes);
-		break;
-	case ESentryLevel::Info:
-		sentry_log_info(MessageUtf8.Get(), attributes);
-		break;
-	case ESentryLevel::Debug:
-	default:
-		sentry_log_debug(MessageUtf8.Get(), attributes);
-		break;
-	}
+	sentry_log(FGenericPlatformSentryConverters::SentryLevelToNative(Level), MessageUtf8.Get(), attributes);
 }
 
 void FGenericPlatformSentrySubsystem::AddCount(const FString& Key, int32 Value, const TMap<FString, FSentryVariant>& Attributes)

--- a/sample/Source/SentryPlayground/IntegrationTests/SentryLogTest.cpp
+++ b/sample/Source/SentryPlayground/IntegrationTests/SentryLogTest.cpp
@@ -13,7 +13,7 @@ void FSentryLogTest::Run()
 {
 	USentrySubsystem* Subsystem = GetSubsystem();
 
-	const FString LogMessage = TEXT("Integration test structured log");
+	const FString LogMessage = TEXT("Integration test structured log metadata=\"%s\" (%d fields)");
 	const FString LogCategory = TEXT("LogSentryTest");
 
 	FString TestId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens);


### PR DESCRIPTION
This PR fixes a crash on desktop and console platforms that occurs when a captured structured log message contains printf-style format specifiers (e.g. a literal `%s`).

Closes #1430

## Summary

`FGenericPlatformSentrySubsystem::AddLog` forwarded messages to the variadic `sentry_log_*` functions which interpret the message as a `printf`-style format string. Since the only variadic argument passed was the attributes object, any conversion specifier in the message text caused `vsnprintf` to read variadic arguments that were never provided:

- `%s` dereferences a garbage pointer → access violation
- `%d` / `%u` / etc. read garbage integers → silently corrupted log payloads sent to Sentry

Since structured logging is enabled by default (1.11.0+), any forwarded engine/game log line containing a `%` specifier could trigger this issue.

## Key changes

- Route messages through `sentry_log()` (available since sentry-native 0.13.2), which takes the body as a plain string and the attributes explicitly so log text is never treated as a format string. The now-unused `logs_with_attributes` option was removed.
- The `-log-capture` integration test message now contains literal `%s`/`%d` specifiers - it crashes without the fix, and the Pester assertions (desktop + Android) now verify the message arrives in Sentry verbatim guarding against both the crash and silent specifier substitution.

## Related items

- https://github.com/getsentry/sentry-native/pull/1566