### PR TITLE
Enable session replay capturing with AMD GPUs on Windows

### DIFF
--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -156,7 +156,7 @@ jobs:
       - name: Strip experimental codec plugin refs (UE 4.27)
         if: ${{ inputs.unreal-version == '4.27' }}
         shell: pwsh
-        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs,VTCodecs
+        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs,VTCodecs,AMFCodecs
 
       - name: Build Android package (Development)
         id: build-android-dev

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -147,7 +147,7 @@ jobs:
       - name: Strip experimental codec plugin refs (UE 4.27)
         if: ${{ inputs.unreal-version == '4.27' }}
         shell: pwsh
-        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs,VTCodecs
+        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs,VTCodecs,AMFCodecs
 
       - name: Build and test (Crashpad)
         id: run-tests

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Strip experimental codec plugin refs (UE 4.27)
         if: ${{ inputs.unreal-version == '4.27' }}
         shell: pwsh
-        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs,VTCodecs
+        run: ./checkout/scripts/strip-plugin-refs.ps1 -ProjectPath checkout/sample/SentryPlayground.uproject -PluginNames AVCodecsCore,NVCodecs,VTCodecs,AMFCodecs
 
       - name: Build and test (Crashpad)
         id: run-tests

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -76,7 +76,7 @@ void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& 
 {
 	check(IsInRenderingThread());
 
-	if (!BackBuffer.IsValid())
+	if (!BackBuffer.IsValid() || Encoder.IsEncodingDisabled())
 	{
 		return;
 	}

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -152,6 +152,10 @@ uint32 FSentryVideoEncoder::Run()
 			const uint32 ResH = FrameTexture->GetSizeY();
 			if (!EnsureEncoderOpen(ResW, ResH))
 			{
+				if (bEncodingDisabled)
+				{
+					break;
+				}
 				continue;
 			}
 
@@ -277,7 +281,8 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 	Encoder = FVideoEncoder::Create<FVideoResourceRHI>(Device, Config);
 	if (!Encoder.IsValid())
 	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to create H.264 encoder"));
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to create H.264 encoder - check that a codec plugin matching the GPU vendor is enabled. Recording disabled for this session."));
+		bEncodingDisabled.AtomicSet(true);
 		return false;
 	}
 

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
@@ -46,6 +46,8 @@ public:
 
 	uint32 GetFramerate() const { return Framerate; }
 
+	bool IsEncodingDisabled() const { return bEncodingDisabled; }
+
 	// FRunnable
 	virtual bool Init() override;
 	virtual void Stop() override;

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -556,17 +556,17 @@ class SENTRY_API USentrySettings : public UObject
 	float HangTimeoutDuration;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Session Replay",
-		Meta = (DisplayName = "Enable session replay (experimental)", ToolTip = "Captures gameplay video and attaches it to crash reports. On Windows, requires the AVCodecsCore/NVCodecs plugins, NVIDIA GPU and rebuild after changing. On Xbox, development kits only. On Android, a 30s clip sampled at 1 frame/second.",
+		Meta = (DisplayName = "Enable session replay (experimental)", ToolTip = "Captures gameplay video and attaches it to crash reports. On desktop platforms (Windows/Mac/Linux), requires the AVCodecsCore plugin plus a codec plugin matching the GPU vendor (NVCodecs for NVIDIA on Windows/Linux, AMFCodecs for AMD on Windows, VTCodecs on Mac) and rebuild after changing. On Xbox, development kits only. On Android, a 30s clip sampled at 1 frame/second.",
 			ConfigRestartRequired = true))
 	bool AttachSessionReplay;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Session Replay",
-		Meta = (DisplayName = "Replay duration (ms)", ToolTip = "Requested duration of the retroactive replay window. On Windows this is the rolling clip length kept on disk for crash attachment; on Xbox the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). Ignored on Android, where the SDK determines the duration.",
+		Meta = (DisplayName = "Replay duration (ms)", ToolTip = "Requested duration of the retroactive replay window. On desktop platforms (Windows/Mac/Linux) this is the rolling clip length kept on disk for crash attachment; on Xbox the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). Ignored on Android, where the SDK determines the duration.",
 			EditCondition = "AttachSessionReplay", ClampMin = "1000", ClampMax = "60000"))
 	uint32 SessionReplayDurationMs;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Session Replay",
-		Meta = (DisplayName = "Advanced recording options (Windows)", ToolTip = "Low-level encoder/muxer tuning for the Windows session-replay recorder. Defaults are sensible for most projects.",
+		Meta = (DisplayName = "Advanced recording options (Desktop)", ToolTip = "Low-level encoder/muxer tuning for the desktop (Windows/Mac/Linux) session-replay recorder. Defaults are sensible for most projects.",
 			EditCondition = "AttachSessionReplay", AdvancedDisplay))
 	FSentrySessionReplayOptions SessionReplayOptions;
 

--- a/sample/SentryPlayground.uproject
+++ b/sample/SentryPlayground.uproject
@@ -49,6 +49,11 @@
 			"Name": "VTCodecs",
 			"Enabled": true,
 			"PlatformAllowList": [ "Mac" ]
+		},
+		{
+			"Name": "AMFCodecs",
+			"Enabled": true,
+			"PlatformAllowList": [ "Win64" ]
 		}
 	],
 	"TargetPlatforms": [


### PR DESCRIPTION
This PR enables Session Replay capture with AMD GPUs on Windows. No changes to the recorder itself were required, as it already creates encoders through the engine's vendor-agnostic AVCodecs factory (`FVideoEncoder::Create<FVideoResourceRHI>`), which selects the appropriate hardware encoder for the player's GPU at runtime.

With the engine's `AMFCodecs` plugin (AMD Advanced Media Framework) enabled alongside `NVCodecs`, a single build can now support both AMD and NVIDIA GPUs.

## Key changes

- Enable the `AMFCodecs` plugin in the sample project (Win64 only)
- Add `AMFCodecs` to the UE 4.27 codec-plugin strip lists in the test workflows (the AVCodecs plugin family does not exist in UE versions older then 5.2)
- Update Session Replay settings tooltips to document the per-vendor codec plugin requirements and align the wording with the recorder's shared Windows/macOS/Linux implementation
- Stop retrying encoder creation every frame after a failure (e.g. missing codec plugin or unsupported GPU). Recording is now disabled for the remainder of the session after the first failed attempt, with a single actionable warning emitted. This avoids flooding the log with `LogSentrySdk` and `LogAVCodecs` messages N times per second. Once disabled, backbuffer capture also skips its per-frame GPU copy work.

## Known limitations

- AMD encoding is available only with the D3D11 and D3D12 RHIs. The engine's AMF integration does not support Vulkan, so this change does not affect Linux (still NVIDIA-only) and will not work on Windows when running with `-vulkan`.

## Testing

- Verified end-to-end on an AMD Radeon 780M iGPU (Ryzen 7 8745HS): encoder selection, recording, and crash-time attachment all work correctly with `AMFCodecs` enabled - [example event](https://sentry-sdks.sentry.io/issues/6565469462/events/010ca4510e654f1e83471ff9b7f26640/).

## Documentation

- https://github.com/getsentry/sentry-docs/pull/18389

## Related items

- https://github.com/getsentry/sentry-unreal/issues/1393

#skip-changelog