### PR TITLE
Fix `FOnBackBufferReadyToPresent` delegate params list in UE 5.8

### DIFF
--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -17,6 +17,10 @@
 #include "RenderingThread.h"
 #include "Widgets/SWindow.h"
 
+#if !UE_VERSION_OLDER_THAN(5, 8, 0)
+#include "Slate/SlateViewportProvider.h"
+#endif
+
 FSentryBackBufferCapture::FSentryBackBufferCapture(FSentryVideoEncoder& InEncoder)
 	: Encoder(InEncoder)
 {
@@ -72,7 +76,19 @@ void FSentryBackBufferCapture::Stop()
 	Converted.Texture.SafeRelease();
 }
 
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, const FTextureRHIRef& BackBuffer)
+{
+	CaptureBackBuffer_RenderThread(BackBuffer);
+}
+#else
+void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, ISlateViewportProvider& ViewportProvider)
+{
+	CaptureBackBuffer_RenderThread(ViewportProvider.GetBackBufferResource());
+}
+#endif
+
+void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIRef& BackBuffer)
 {
 	check(IsInRenderingThread());
 

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
@@ -7,12 +7,14 @@
 #ifdef USE_SENTRY_SESSION_REPLAY
 
 #include "Delegates/IDelegateInstance.h"
+#include "Misc/EngineVersionComparison.h"
 #include "PixelFormat.h"
 #include "RHIAccess.h"
 #include "RHIDefinitions.h"
 #include "RHIFwd.h"
 
 class FSentryVideoEncoder;
+class ISlateViewportProvider;
 class SWindow;
 
 /**
@@ -65,7 +67,14 @@ private:
 		ETextureCreateFlags Flags = ETextureCreateFlags::None;
 	};
 
+#if UE_VERSION_OLDER_THAN(5, 8, 0)
 	void OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, const FTextureRHIRef& BackBuffer);
+#else
+	void OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, ISlateViewportProvider& ViewportProvider);
+#endif
+
+	// Captures a single backbuffer frame and forwards it to the encoder (render thread)
+	void CaptureBackBuffer_RenderThread(const FTextureRHIRef& BackBuffer);
 
 	// Returns the cached texture, recreated when any of (Width, Height, Format,
 	// Flags) differs from the previous call. Returns null on creation failure


### PR DESCRIPTION
This is a follow-up to #1440. That change missed the UE 5.8 compatibility issue because the session replay code is guarded by the `USE_SENTRY_SESSION_REPLAY` definition and is compiled out by default.

In UE 5.8 the `FOnBackBufferReadyToPresent` delegate signature changed - instead of receiving an `FTextureRHIRef` directly, it now passes an `ISlateViewportProvider`, from which the backbuffer texture has to be retrieved via a separate `GetBackBufferResource()` call.

The fix version-guards the delegate callback (`UE_VERSION_OLDER_THAN(5, 8, 0)`) and routes both signatures through a shared `CaptureBackBuffer_RenderThread` helper, so the capture logic stays unchanged across engine versions.

#skip-changelog