### PR TITLE
Migrate from `SentryObjCPrivateSDKOnly` to `[SentryObjCSDK internal]` on Apple platforms

### DIFF
--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -70,7 +70,7 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 		}
 	}
 
-	[SENTRY_APPLE_CLASS(SentryObjCPrivateSDKOnly) setSdkName:@"sentry.cocoa.unreal"];
+	[[[SENTRY_APPLE_CLASS(SentryObjCSDK) internal] sdk] setName:@"sentry.cocoa.unreal"];
 
 	dispatch_group_t sentryDispatchGroup = dispatch_group_create();
 	dispatch_group_enter(sentryDispatchGroup);
@@ -697,7 +697,7 @@ void FAppleSentrySubsystem::UploadAttachmentForEvent(TSharedPtr<ISentryId> event
 
 	SentryObjCEnvelope* envelope = [[SENTRY_APPLE_CLASS(SentryObjCEnvelope) alloc] initWithHeader:envelopeHeader singleItem:envelopeItem];
 
-	[SENTRY_APPLE_CLASS(SentryObjCPrivateSDKOnly) captureEnvelope:envelope];
+	[[[SENTRY_APPLE_CLASS(SentryObjCSDK) internal] envelope] capture:envelope];
 
 	if (deleteAfterUpload)
 	{


### PR DESCRIPTION
This PR migrates the two remaining Apple call sites off the deprecated `SentryObjCPrivateSDKOnly` class to the new structured hybrid-SDK API introduced in `sentry-cocoa` 9.19.0.

Setting the SDK name now goes through `[[[SentryObjCSDK internal] sdk] setName:]` and envelope capture through `[[[SentryObjCSDK internal] envelope] capture:]`. Message-send syntax is used instead of the issue's dot-syntax so it works with the dynamically `dlsym`-resolved `Class` on macOS as well as the direct class reference on iOS.

Closes #1455

#skip-changelog