### PR TITLE
chore: bump getsentry/github-workflows to v3

### DIFF
--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -8,4 +8,4 @@ jobs:
   danger:
     runs-on: ubuntu-latest
     steps:
-      - uses: getsentry/github-workflows/danger@26f565c05d0dd49f703d238706b775883037d76b # v3
+      - uses: getsentry/github-workflows/danger@607fed74f812e69201531a5185b6c3c57caa4e89 # v3

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -28,7 +28,6 @@ jobs:
           path: modules/sentry-native
           name: Native SDK
           ssh-key: ${{ env.CI_DEPLOY_KEY }}
-          # v3 default is 'update'; keep 'create' to preserve previous behavior.
           pr-strategy: create
 
   java:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -11,51 +11,72 @@ on:
   # Allow a manual trigger to be able to run the update when there are new dependencies.
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+env:
+  CI_DEPLOY_KEY: ${{ secrets.CI_DEPLOY_KEY }}
+
 jobs:
   native:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2
-    with:
-      path: modules/sentry-native
-      name: Native SDK
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
+        with:
+          path: modules/sentry-native
+          name: Native SDK
+          ssh-key: ${{ env.CI_DEPLOY_KEY }}
+          # v3 default is 'update'; keep 'create' to preserve previous behavior.
+          pr-strategy: create
 
   java:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2
-    with:
-      path: modules/sentry-java
-      name: Java SDK
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
+        with:
+          path: modules/sentry-java
+          name: Java SDK
+          ssh-key: ${{ env.CI_DEPLOY_KEY }}
+          pr-strategy: create
 
   cocoa:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2
-    with:
-      path: modules/sentry-cocoa.properties
-      name: Cocoa SDK
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
+        with:
+          path: modules/sentry-cocoa.properties
+          name: Cocoa SDK
+          ssh-key: ${{ env.CI_DEPLOY_KEY }}
+          pr-strategy: create
 
   crash-reporter:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2
-    with:
-      path: modules/sentry-crash-reporter.properties
-      name: Crash Reporter
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
+        with:
+          path: modules/sentry-crash-reporter.properties
+          name: Crash Reporter
+          ssh-key: ${{ env.CI_DEPLOY_KEY }}
+          pr-strategy: create
 
   cli:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2
-    with:
-      path: plugin-dev/sentry-cli.properties
-      name: CLI
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
+        with:
+          path: plugin-dev/sentry-cli.properties
+          name: CLI
+          ssh-key: ${{ env.CI_DEPLOY_KEY }}
+          pr-strategy: create
 
   android-gradle-plugin:
-    uses: getsentry/github-workflows/.github/workflows/updater.yml@1949ea01ec2da6139d1bcc306c372e6aea76fb72 # v2
-    with:
-      path: scripts/update-android-gradle-plugin.sh
-      name: Android Gradle Plugin
-    secrets:
-      api-token: ${{ secrets.CI_DEPLOY_KEY }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: getsentry/github-workflows/updater@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
+        with:
+          path: scripts/update-android-gradle-plugin.sh
+          name: Android Gradle Plugin
+          ssh-key: ${{ env.CI_DEPLOY_KEY }}
+          pr-strategy: create

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: getsentry/github-workflows/validate-pr@71588ddf95134f804e82c5970a8098588e2eaecd
+      - uses: getsentry/github-workflows/validate-pr@607fed74f812e69201531a5185b6c3c57caa4e89 # v3
         with:
           app-id: ${{ vars.SDK_MAINTAINER_BOT_APP_ID }}
           private-key: ${{ secrets.SDK_MAINTAINER_BOT_PRIVATE_KEY }}


### PR DESCRIPTION
This PR updates all shared workflows consumed from [`getsentry/github-workflows`](https://github.com/getsentry/github-workflows) to **v3** (`607fed7`), and migrates the dependency updater from the removed reusable-workflow form to the new composite action.

### Key Changes

- **`danger.yml`** - bump `danger` action to v3. The previous pin (`26f565c`, commented `# v3`) actually pointed at the 3.3.0 release, not the v3 tip.
- **`validate-pr.yml`** - bump `validate-pr` action to v3 and add the missing `# v3` ref comment. The old pin was an unreleased intermediate commit.
- **`update-dependencies.yml`** - migrate the updater from the v2 reusable workflow (`.github/workflows/updater.yml`, removed in v3) to the v3 composite action (`getsentry/github-workflows/updater`):
  - Each job now invokes the action as a step (with `runs-on` + `steps`) instead of a job-level `uses:`.
  - Credential moved from the `secrets:` block to the `ssh-key:` input (`CI_DEPLOY_KEY` is an SSH deploy key; passing it as `api-token` would fail v3's key-type validation).
  - Secret surfaced once via a workflow-level `env` var instead of being interpolated into each job's `with:` block.
  - Added required `permissions` (`contents: write`, `pull-requests: write`, `actions: write` - the composite action runs in the caller's job context and its first step cancels previous runs).
  - Set `pr-strategy: create` explicitly to preserve current behavior (one PR per released version), since v3's default changed to `update`.

#skip-changelog