### PR TITLE
chore: Add Linux support to plugin dependencies build script

### DIFF
--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -363,9 +363,25 @@ function buildSentryNativeLinux()
         throw "Sentry Native path does not exist: $NativePath"
     }
 
-    Write-Host "Building Sentry Native for Linux (x64) using local repository at: $NativePath"
+    $arch = [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture
+    if ($arch -eq [System.Runtime.InteropServices.Architecture]::Arm64)
+    {
+        $platformDir = "$outDir/LinuxArm64"
+        $archName = "arm64"
+        $libcxxCFlags = "-mno-outline-atomics"
+        $libcxxCxxFlags = "-stdlib=libc++ -mno-outline-atomics"
+        $libcxxLinkFlags = "-stdlib=libc++ -mno-outline-atomics"
+    }
+    else
+    {
+        $platformDir = "$outDir/Linux"
+        $archName = "x64"
+        $libcxxCFlags = ""
+        $libcxxCxxFlags = "-stdlib=libc++"
+        $libcxxLinkFlags = "-stdlib=libc++"
+    }
 
-    $platformDir = "$outDir/Linux"
+    Write-Host "Building Sentry Native for Linux ($archName) using local repository at: $NativePath"
 
     # sentry-native is built with clang and libc++ for the static libs, but the crash handler
     # executables (crashpad_handler / sentry-crash) are built with libstdc++ to match Unreal.
@@ -384,7 +400,7 @@ function buildSentryNativeLinux()
         # Static libs with libc++
         cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
             -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$clangC -D CMAKE_CXX_COMPILER=$clangCxx `
-            -D CMAKE_CXX_FLAGS="-stdlib=libc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -D HAVE_COPY_FILE_RANGE=0
+            -D CMAKE_C_FLAGS="$libcxxCFlags" -D CMAKE_CXX_FLAGS="$libcxxCxxFlags" -D CMAKE_EXE_LINKER_FLAGS="$libcxxLinkFlags" -D HAVE_COPY_FILE_RANGE=0
         cmake --build "build" --target sentry --parallel
         cmake --install "build" --prefix "install"
 
@@ -421,7 +437,7 @@ function buildSentryNativeLinux()
         # Static libs with libc++
         cmake -B "build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
             -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$clangC -D CMAKE_CXX_COMPILER=$clangCxx `
-            -D CMAKE_CXX_FLAGS="-stdlib=libc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -D HAVE_COPY_FILE_RANGE=0
+            -D CMAKE_C_FLAGS="$libcxxCFlags" -D CMAKE_CXX_FLAGS="$libcxxCxxFlags" -D CMAKE_EXE_LINKER_FLAGS="$libcxxLinkFlags" -D HAVE_COPY_FILE_RANGE=0
         cmake --build "build_native" --target sentry --parallel
         cmake --install "build_native" --prefix "install_native"
 
@@ -446,7 +462,7 @@ function buildSentryNativeLinux()
     strip -x "$NativePath/build_native_crash/sentry-crash" -o "$nativeDir/bin/sentry-crash"
     Copy-Item "$NativePath/install_native/include/sentry.h" -Destination "$nativeDir/include"
 
-    Write-Host "Successfully built Sentry Native for Linux"
+    Write-Host "Successfully built Sentry Native for Linux ($archName)"
 }
 
 function buildSentryCrashReporter()

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -188,14 +188,11 @@ function buildSentryJava()
 
     Write-Host "Building Sentry Java for Android using local repository at: $JavaPath"
 
-    # Gradle build is platform-agnostic (only needs a JDK); pick the wrapper for the current OS
-    $gradlew = if ($isWindowsPlatform) { ".\gradlew.bat" } else { "./gradlew" }
-
     Push-Location -Path $JavaPath
 
     try
     {
-        & $gradlew -PsentryAndroidSdkName="sentry.native.android.unreal" `
+        ./gradlew -PsentryAndroidSdkName="sentry.native.android.unreal" `
             :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry-android-replay:assembleRelease :sentry:jar --no-daemon --stacktrace --warning-mode none
 
         if ($LASTEXITCODE -ne 0)

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -1,10 +1,10 @@
 # Builds plugin dependencies locally and replaces corresponding binaries in `plugin-dev/Sources/ThirdParty/...`
 #
 # Plugin dependencies:
-# * sentry-native - for Windows support (can be built only on Windows)
+# * sentry-native - for Windows/Linux/Mac support
 # * sentry-cocoa - for Mac and iOS support (can be built only on MacOS)
-# * sentry-java - for Android support (can be built both on Windows and MacOS)
-# * sentry-crash-reporter - external crash reporter (can be built on Windows, MacOS and Linux)
+# * sentry-java - for Android support
+# * sentry-crash-reporter - external crash reporter
 #
 # Usage:
 #   .\build-deps.ps1 -All                                  # Build all SDKs for current platform
@@ -45,6 +45,12 @@ $isWindowsPlatform = if ($null -eq (Get-Variable -Name IsWindows -ErrorAction Si
 if ($All)
 {
     if ($isWindowsPlatform)
+    {
+        $Native = $true
+        $Java = $true
+        $CrashReporter = $true
+    }
+    elseif ($IsLinux)
     {
         $Native = $true
         $Java = $true
@@ -182,11 +188,14 @@ function buildSentryJava()
 
     Write-Host "Building Sentry Java for Android using local repository at: $JavaPath"
 
+    # Gradle build is platform-agnostic (only needs a JDK); pick the wrapper for the current OS
+    $gradlew = if ($isWindowsPlatform) { ".\gradlew.bat" } else { "./gradlew" }
+
     Push-Location -Path $JavaPath
 
     try
     {
-        ./gradlew -PsentryAndroidSdkName="sentry.native.android.unreal" `
+        & $gradlew -PsentryAndroidSdkName="sentry.native.android.unreal" `
             :sentry-android-core:assembleRelease :sentry-android-ndk:assembleRelease :sentry-android-replay:assembleRelease :sentry:jar --no-daemon --stacktrace --warning-mode none
 
         if ($LASTEXITCODE -ne 0)
@@ -350,6 +359,99 @@ function buildSentryNativeMac()
     Write-Host "Successfully built Sentry Native for macOS"
 }
 
+function buildSentryNativeLinux()
+{
+    if (-not (Test-Path $NativePath))
+    {
+        throw "Sentry Native path does not exist: $NativePath"
+    }
+
+    Write-Host "Building Sentry Native for Linux (x64) using local repository at: $NativePath"
+
+    $platformDir = "$outDir/Linux"
+
+    # sentry-native is built with clang and libc++ for the static libs, but the crash handler
+    # executables (crashpad_handler / sentry-crash) are built with libstdc++ to match Unreal.
+    $clangC = "clang"
+    $clangCxx = "clang++"
+    if (-not (Get-Command $clangC -ErrorAction SilentlyContinue))
+    {
+        throw "clang not found. Install clang (with libc++) to build Sentry Native for Linux."
+    }
+
+    # Build Crashpad backend
+    Write-Host "Building Crashpad backend..."
+    Push-Location -Path $NativePath
+    try
+    {
+        # Static libs with libc++
+        cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
+            -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$clangC -D CMAKE_CXX_COMPILER=$clangCxx `
+            -D CMAKE_CXX_FLAGS="-stdlib=libc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -D HAVE_COPY_FILE_RANGE=0
+        cmake --build "build" --target sentry --parallel
+        cmake --install "build" --prefix "install"
+
+        # crashpad_handler executable with libstdc++ (no transport needed)
+        cmake -B "build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
+            -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$clangC -D CMAKE_CXX_COMPILER=$clangCxx `
+            -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++" -D HAVE_COPY_FILE_RANGE=0
+        cmake --build "build_crashpad_handler" --target sentry --parallel
+        cmake --install "build_crashpad_handler" --prefix "install_crashpad_handler"
+
+        # Replace crashpad_handler from the first build with the libstdc++ one
+        Copy-Item "$NativePath/install_crashpad_handler/bin/crashpad_handler" -Destination "$NativePath/install/bin/crashpad_handler" -Force
+    }
+    finally
+    {
+        Pop-Location
+    }
+
+    $crashpadDir = "$platformDir/Crashpad"
+    if (Test-Path $crashpadDir) { Remove-Item $crashpadDir -Recurse -Force }
+    New-Item "$crashpadDir/lib" -ItemType Directory -Force > $null
+    New-Item "$crashpadDir/bin" -ItemType Directory -Force > $null
+    New-Item "$crashpadDir/include" -ItemType Directory -Force > $null
+
+    Get-ChildItem -Path "$NativePath/install/lib" -Filter "*.a" -Recurse | Copy-Item -Destination "$crashpadDir/lib"
+    strip -x "$NativePath/install/bin/crashpad_handler" -o "$crashpadDir/bin/crashpad_handler"
+    Copy-Item "$NativePath/install/include/sentry.h" -Destination "$crashpadDir/include"
+
+    # Build Native backend
+    Write-Host "Building Native backend..."
+    Push-Location -Path $NativePath
+    try
+    {
+        # Static libs with libc++
+        cmake -B "build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
+            -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$clangC -D CMAKE_CXX_COMPILER=$clangCxx `
+            -D CMAKE_CXX_FLAGS="-stdlib=libc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" -D HAVE_COPY_FILE_RANGE=0
+        cmake --build "build_native" --target sentry --parallel
+        cmake --install "build_native" --prefix "install_native"
+
+        # sentry-crash executable with libstdc++ (needs transport to send crash envelopes)
+        cmake -B "build_native_crash" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
+            -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$clangC -D CMAKE_CXX_COMPILER=$clangCxx `
+            -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++" -D HAVE_COPY_FILE_RANGE=0
+        cmake --build "build_native_crash" --target sentry-crash --parallel
+    }
+    finally
+    {
+        Pop-Location
+    }
+
+    $nativeDir = "$platformDir/Native"
+    if (Test-Path $nativeDir) { Remove-Item $nativeDir -Recurse -Force }
+    New-Item "$nativeDir/lib" -ItemType Directory -Force > $null
+    New-Item "$nativeDir/bin" -ItemType Directory -Force > $null
+    New-Item "$nativeDir/include" -ItemType Directory -Force > $null
+
+    Get-ChildItem -Path "$NativePath/install_native/lib" -Filter "*.a" -Recurse | Copy-Item -Destination "$nativeDir/lib"
+    strip -x "$NativePath/build_native_crash/sentry-crash" -o "$nativeDir/bin/sentry-crash"
+    Copy-Item "$NativePath/install_native/include/sentry.h" -Destination "$nativeDir/include"
+
+    Write-Host "Successfully built Sentry Native for Linux"
+}
+
 function buildSentryCrashReporter()
 {
     if (-not (Test-Path $CrashReporterPath))
@@ -459,6 +561,10 @@ if ($buildNative)
         elseif ($IsMacOS)
         {
             buildSentryNativeMac
+        }
+        elseif ($IsLinux)
+        {
+            buildSentryNativeLinux
         }
         else
         {


### PR DESCRIPTION
This PR adds Linux support to `scripts/build-deps.ps1` so all plugin dependencies can be built locally on Linux, matching the existing Windows and macOS flows.

#skip-changelog