### PR TITLE
Fix deprecation warnings caused by `RHICreateTexture` usage in UE 5.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix deprecation warnings caused by `RHICreateTexture` usage in UE 5.8 ([#1466](https://github.com/getsentry/sentry-unreal/pull/1466))
+
 ### Dependencies
 
 - Bump Android Gradle Plugin from v6.12.0 to v6.14.0 ([#1452](https://github.com/getsentry/sentry-unreal/pull/1452), [#1460](https://github.com/getsentry/sentry-unreal/pull/1460))

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -245,7 +245,7 @@ FTextureRHIRef FSentryBackBufferCapture::AcquireCachedTexture_RenderThread(FCach
 											   .SetFormat(Format)
 											   .SetFlags(Flags)
 											   .SetInitialState(InitialState);
-		Cache.Texture = RHICreateTexture(Desc);
+		Cache.Texture = FRHICommandListImmediate::Get().CreateTexture(Desc);
 	}
 
 	return Cache.Texture;
@@ -288,7 +288,7 @@ FTextureRHIRef FSentryBackBufferCapture::AcquireTexturePoolSlot_RenderThread(FCa
 											   .SetFormat(Format)
 											   .SetFlags(Flags)
 											   .SetInitialState(InitialState);
-		*FreeSlot = RHICreateTexture(Desc);
+		*FreeSlot = FRHICommandListImmediate::Get().CreateTexture(Desc);
 	}
 
 	return *FreeSlot;


### PR DESCRIPTION
This PR fixes deprecation warnings caused by uses of the [RHICreateTexture](https://github.com/EpicGames/UnrealEngine/blob/6673776aad735f49a5ce3bbed474ffcc701e7a8e/Engine/Source/Runtime/RHI/Public/RHICommandList.h#L5345-L5349) utility function in UE 5.8. It was replaced with `FRHICommandListImmediate::Get().CreateTexture` which is available in all Unreal Engine versions where Session Replay feature is currently supported.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1440