### PR TITLE
Add integration with Session Replay product for Apple platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Add experimental session replay capturing on iOS (UE 5.8+) ([#1462](https://github.com/getsentry/sentry-unreal/pull/1462))
 - Add integration with Session Replay product for native platforms ([#1445](https://github.com/getsentry/sentry-unreal/pull/1445))
+- Add integration with Session Replay product for Apple platforms ([#1468](https://github.com/getsentry/sentry-unreal/pull/1468))
 
 ### Fixes
 

--- a/integration-test/Integration.Desktop.Tests.ps1
+++ b/integration-test/Integration.Desktop.Tests.ps1
@@ -497,7 +497,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
         }
     }
 
-    Context "Session Replay Tests" -Skip:($Platform -eq 'MacOS' -and -not $script:IsNativeBackend) {
+    Context "Session Replay Tests" {
         BeforeAll {
             $script:ReplayResult = $null
             $script:ReplayCrashEvent = $null
@@ -517,17 +517,19 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:AttachSessionReplay=True"
 
-            # -replay-capture stages a replay clip on disk and crashes; the crash backend
-            # is expected to send it as a replay_video envelope alongside the crash event
+            # -replay-capture stages a replay clip on disk and crashes; the SDK is
+            # expected to send it as a replay_video envelope alongside the crash event
             $script:ReplayResult = Invoke-DeviceApp -ExecutablePath $script:AppPath -Arguments ((@('-replay-capture') + $appArgs) -join ' ')
 
             # With the crashpad/breakpad/inproc backends the replay envelope is persisted
             # to the crashed run's directory and delivered on the next launch, so relaunch
             # the app to flush it. The native backend daemon sends it same-session.
+            # On macOS the cocoa backend builds and sends the replay envelope during the
+            # relaunch, which requires AttachSessionReplay to remain enabled.
             if (-not $script:IsNativeBackend) {
                 $flushArgs = @('-init-only', '-nullrhi', '-unattended', '-stdout', '-nosplash')
                 $flushArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
-                $flushArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:AttachSessionReplay=False"
+                $flushArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:AttachSessionReplay=True"
                 Invoke-DeviceApp -ExecutablePath $script:AppPath -Arguments ($flushArgs -join ' ')
             }
 
@@ -600,8 +602,9 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
             $script:ReplayEvent.duration | Should -Be 5
         }
 
-        It "Should have native platform" {
-            $script:ReplayEvent.platform | Should -Be 'native'
+        It "Should have expected platform" {
+            $expectedPlatform = if ($Platform -eq 'MacOS' -and -not $script:IsNativeBackend) { 'cocoa' } else { 'native' }
+            $script:ReplayEvent.platform | Should -Be $expectedPlatform
         }
     }
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
@@ -1,0 +1,285 @@
+// Copyright (c) 2026 Sentry. All Rights Reserved.
+
+#include "AppleSentryReplayEnvelope.h"
+
+#if !USE_SENTRY_NATIVE
+
+#include "SentryDefines.h"
+
+#include "SessionReplay/SentryReplayInfo.h"
+
+#include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
+
+#include "JsonObjectConverter.h"
+#include "Misc/FileHelper.h"
+#include "Misc/Paths.h"
+
+namespace
+{
+
+// The `replay_video` envelope item payload is a msgpack map matching the format produced
+// by sentry-cocoa's `SentryMsgPackSerializer` (and sentry-native): keys as str8, values as bin32
+
+void AppendMsgPackString(NSMutableData* data, const char* str)
+{
+	const uint8 header[] = { 0xD9, static_cast<uint8>(strlen(str)) };
+	[data appendBytes:header length:sizeof(header)];
+	[data appendBytes:str length:strlen(str)];
+}
+
+void AppendMsgPackBinary(NSMutableData* data, NSData* payload)
+{
+	const uint32 length = static_cast<uint32>(payload.length);
+	const uint8 header[] = { 0xC6,
+		static_cast<uint8>((length >> 24) & 0xFF), static_cast<uint8>((length >> 16) & 0xFF),
+		static_cast<uint8>((length >> 8) & 0xFF), static_cast<uint8>(length & 0xFF) };
+	[data appendBytes:header length:sizeof(header)];
+	[data appendData:payload];
+}
+
+// Crash event data originates from the SentryCrash report and may contain values
+// `NSJSONSerialization` can't handle (e.g. `NSDate`), so it has to be sanitized first
+id SanitizeForJson(id value)
+{
+	if ([value isKindOfClass:[NSDictionary class]])
+	{
+		NSDictionary* dict = (NSDictionary*)value;
+		NSMutableDictionary* result = [NSMutableDictionary dictionaryWithCapacity:dict.count];
+		for (id key in dict)
+		{
+			result[[key description]] = SanitizeForJson(dict[key]);
+		}
+		return result;
+	}
+	if ([value isKindOfClass:[NSArray class]])
+	{
+		NSArray* array = (NSArray*)value;
+		NSMutableArray* result = [NSMutableArray arrayWithCapacity:array.count];
+		for (id item in array)
+		{
+			[result addObject:SanitizeForJson(item)];
+		}
+		return result;
+	}
+	if ([value isKindOfClass:[NSString class]] || [value isKindOfClass:[NSNumber class]] || [value isKindOfClass:[NSNull class]])
+	{
+		return value;
+	}
+	if ([value isKindOfClass:[NSDate class]])
+	{
+		return @([(NSDate*)value timeIntervalSince1970]);
+	}
+	return [value description];
+}
+
+NSDictionary* SerializeUser(SentryObjCUser* user)
+{
+	NSMutableDictionary* dict = [NSMutableDictionary dictionary];
+	if (user.userId)
+		dict[@"id"] = user.userId;
+	if (user.email)
+		dict[@"email"] = user.email;
+	if (user.username)
+		dict[@"username"] = user.username;
+	if (user.ipAddress)
+		dict[@"ip_address"] = user.ipAddress;
+	if (user.name)
+		dict[@"name"] = user.name;
+	if (user.geo)
+	{
+		NSMutableDictionary* geo = [NSMutableDictionary dictionary];
+		if (user.geo.city)
+			geo[@"city"] = user.geo.city;
+		if (user.geo.countryCode)
+			geo[@"country_code"] = user.geo.countryCode;
+		if (user.geo.region)
+			geo[@"region"] = user.geo.region;
+		dict[@"geo"] = geo;
+	}
+	if (user.data)
+		dict[@"data"] = user.data;
+	return dict;
+}
+
+NSDictionary* BuildReplayEvent(SentryObjCEvent* event, const FSentryReplayInfo& info, double startSec, double endSec)
+{
+	NSMutableDictionary* dict = [NSMutableDictionary dictionary];
+	dict[@"type"] = @"replay_event";
+	dict[@"replay_type"] = info.ReplayType.IsEmpty() ? @"buffer" : info.ReplayType.GetNSString();
+	dict[@"segment_id"] = @(info.SegmentId);
+	dict[@"replay_id"] = info.ReplayId.GetNSString();
+	dict[@"event_id"] = info.ReplayId.GetNSString();
+	dict[@"platform"] = @"cocoa";
+	dict[@"timestamp"] = @(endSec);
+	dict[@"replay_start_timestamp"] = @(startSec);
+	dict[@"urls"] = @[];
+
+	if (event != nil)
+	{
+		// Copy the crash event's scope data onto the replay so it shares the crash's
+		// context; `error_ids` is deliberately omitted (deprecated in favor of trace ids)
+		if (event.tags)
+			dict[@"tags"] = event.tags;
+		if (event.context)
+			dict[@"contexts"] = event.context;
+		if (event.releaseName)
+			dict[@"release"] = event.releaseName;
+		if (event.environment)
+			dict[@"environment"] = event.environment;
+		if (event.dist)
+			dict[@"dist"] = event.dist;
+		if (event.user)
+			dict[@"user"] = SerializeUser(event.user);
+		if (event.sdk)
+			dict[@"sdk"] = event.sdk;
+
+		id traceId = event.context[@"trace"][@"trace_id"];
+		dict[@"trace_ids"] = [traceId isKindOfClass:[NSString class]] ? @[ traceId ] : @[];
+	}
+
+	return SanitizeForJson(dict);
+}
+
+// The recording payload is a `{"segment_id":N}` header line followed by an rrweb-style
+// list with two entries - a meta event and a video event describing the clip
+NSData* BuildReplayRecording(const FSentryReplayInfo& info, double startSec, uint64 videoSizeBytes)
+{
+	const double timestampMs = startSec * 1000.0;
+
+	NSDictionary* metaEvent = @{
+		@"type" : @4,
+		@"timestamp" : @(timestampMs),
+		@"data" : @{
+			@"href" : @"",
+			@"width" : @(info.Width),
+			@"height" : @(info.Height)
+		}
+	};
+
+	NSDictionary* videoEvent = @{
+		@"type" : @5,
+		@"timestamp" : @(timestampMs),
+		@"data" : @{
+			@"tag" : @"video",
+			@"payload" : @{
+				@"segmentId" : @(info.SegmentId),
+				@"size" : @(static_cast<double>(videoSizeBytes)),
+				@"duration" : @(static_cast<double>(info.DurationMs)),
+				@"encoding" : @"h264",
+				@"container" : @"mp4",
+				@"height" : @(info.Height),
+				@"width" : @(info.Width),
+				@"left" : @0,
+				@"top" : @0,
+				@"frameCount" : @(info.FrameCount),
+				@"frameRate" : @(info.FrameRate),
+				@"frameRateType" : @"variable"
+			}
+		}
+	};
+
+	NSError* error = nil;
+	NSData* eventsJson = [NSJSONSerialization dataWithJSONObject:@[ metaEvent, videoEvent ] options:0 error:&error];
+	if (eventsJson == nil)
+	{
+		return nil;
+	}
+
+	NSMutableData* recording = [NSMutableData data];
+	NSString* header = [NSString stringWithFormat:@"{\"segment_id\":%d}\n", info.SegmentId];
+	[recording appendData:[header dataUsingEncoding:NSUTF8StringEncoding]];
+	[recording appendData:eventsJson];
+	return recording;
+}
+
+} // namespace
+
+bool FAppleSentryReplayEnvelope::CaptureForCrashEvent(SentryObjCEvent* event, const FString& videoPath, const FString& sidecarPath)
+{
+	FString sidecarJson;
+	if (!FFileHelper::LoadFileToString(sidecarJson, *sidecarPath))
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to read metadata sidecar at %s"), *sidecarPath);
+		return false;
+	}
+
+	FSentryReplayInfo info;
+	if (!FJsonObjectConverter::JsonObjectStringToUStruct(sidecarJson, &info) || info.ReplayId.IsEmpty())
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to parse metadata sidecar at %s"), *sidecarPath);
+		return false;
+	}
+
+	if (FPaths::GetBaseFilename(videoPath) != FString::Printf(TEXT("replay-%s"), *info.ReplayId))
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: metadata sidecar %s doesn't match video file %s"), *sidecarPath, *videoPath);
+		return false;
+	}
+
+	NSData* video = [NSData dataWithContentsOfFile:videoPath.GetNSString()];
+	if (video == nil || video.length == 0)
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to read video file at %s"), *videoPath);
+		return false;
+	}
+
+	// The replay window ends at the crash time so the corresponding error appears
+	// on the replay timeline; the sidecar's own end timestamp is a fallback only
+	const double endSec = (event != nil && event.timestamp != nil)
+							  ? [event.timestamp timeIntervalSince1970]
+							  : info.EndTimestampSec;
+	const double startSec = endSec - static_cast<double>(info.DurationMs) / 1000.0;
+
+	NSDictionary* replayEvent = BuildReplayEvent(event, info, startSec, endSec);
+	if (![NSJSONSerialization isValidJSONObject:replayEvent])
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: replay event is not serializable to JSON"));
+		return false;
+	}
+
+	NSError* error = nil;
+	NSData* replayEventJson = [NSJSONSerialization dataWithJSONObject:replayEvent options:0 error:&error];
+	if (replayEventJson == nil)
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to serialize replay event"));
+		return false;
+	}
+
+	NSData* replayRecording = BuildReplayRecording(info, startSec, video.length);
+	if (replayRecording == nil)
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to serialize replay recording"));
+		return false;
+	}
+
+	NSMutableData* payload = [NSMutableData dataWithCapacity:replayEventJson.length + replayRecording.length + video.length + 64];
+	const uint8 mapHeader = 0x83;
+	[payload appendBytes:&mapHeader length:sizeof(mapHeader)];
+	AppendMsgPackString(payload, "replay_event");
+	AppendMsgPackBinary(payload, replayEventJson);
+	AppendMsgPackString(payload, "replay_recording");
+	AppendMsgPackBinary(payload, replayRecording);
+	AppendMsgPackString(payload, "replay_video");
+	AppendMsgPackBinary(payload, video);
+
+	SentryObjCEnvelopeItem* envelopeItem = [[SENTRY_APPLE_CLASS(SentryObjCEnvelopeItem) alloc] initWithType:@"replay_video"
+																									   data:payload
+																								addPlatform:NO];
+
+	SentryObjCId* replayId = [[SENTRY_APPLE_CLASS(SentryObjCId) alloc] initWithUUIDString:info.ReplayId.GetNSString()];
+
+	SentryObjCEnvelopeHeader* envelopeHeader = [[SENTRY_APPLE_CLASS(SentryObjCEnvelopeHeader) alloc] initWithId:replayId traceContext:nil];
+
+	SentryObjCEnvelope* envelope = [[SENTRY_APPLE_CLASS(SentryObjCEnvelope) alloc] initWithHeader:envelopeHeader singleItem:envelopeItem];
+	if (envelope == nil)
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to create replay envelope"));
+		return false;
+	}
+
+	[[[SENTRY_APPLE_CLASS(SentryObjCSDK) internal] envelope] capture:envelope];
+	return true;
+}
+
+#endif // !USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
@@ -18,9 +18,6 @@
 namespace
 {
 
-// The `replay_video` envelope item payload is a msgpack map matching the format produced
-// by sentry-cocoa's `SentryMsgPackSerializer` (and sentry-native): keys as str8, values as bin32
-
 void AppendMsgPackString(NSMutableData* data, const char* str)
 {
 	const uint8 header[] = { 0xD9, static_cast<uint8>(strlen(str)) };
@@ -38,8 +35,6 @@ void AppendMsgPackBinary(NSMutableData* data, NSData* payload)
 	[data appendData:payload];
 }
 
-// Crash event data originates from the SentryCrash report and may contain values
-// `NSJSONSerialization` can't handle (e.g. `NSDate`), so it has to be sanitized first
 id SanitizeForJson(id value)
 {
 	if ([value isKindOfClass:[NSDictionary class]])
@@ -117,8 +112,6 @@ NSDictionary* BuildReplayEvent(SentryObjCEvent* event, const FSentryReplayInfo& 
 
 	if (event != nil)
 	{
-		// Copy the crash event's scope data onto the replay so it shares the crash's
-		// context; `error_ids` is deliberately omitted (deprecated in favor of trace ids)
 		if (event.tags)
 			dict[@"tags"] = event.tags;
 		if (event.context)
@@ -141,8 +134,6 @@ NSDictionary* BuildReplayEvent(SentryObjCEvent* event, const FSentryReplayInfo& 
 	return SanitizeForJson(dict);
 }
 
-// The recording payload is a `{"segment_id":N}` header line followed by an rrweb-style
-// list with two entries - a meta event and a video event describing the clip
 NSData* BuildReplayRecording(const FSentryReplayInfo& info, double startSec, uint64 videoSizeBytes)
 {
 	const double timestampMs = startSec * 1000.0;

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Sentry. All Rights Reserved.
+
+#pragma once
+
+#if !USE_SENTRY_NATIVE
+
+#include "CoreMinimal.h"
+
+@class SentryObjCEvent;
+
+class FAppleSentryReplayEnvelope
+{
+public:
+	/**
+	 * Builds a `replay_video` envelope from the recorded clip and its metadata sidecar
+	 * and hands it over to sentry-cocoa for sending.
+	 *
+	 * @param event Crash event from the previous app run used as the source of scope data
+	 * (tags, contexts, user, etc.) for the replay; can be nil.
+	 * @param videoPath Path to the recorded replay video file.
+	 * @param sidecarPath Path to the JSON metadata sidecar describing the clip.
+	 *
+	 * @return true if the envelope was successfully captured.
+	 */
+	static bool CaptureForCrashEvent(SentryObjCEvent* event, const FString& videoPath, const FString& sidecarPath);
+};
+
+#endif // !USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -827,48 +827,33 @@ bool FAppleSentrySubsystem::GetLatestSessionReplay(FString& OutReplayPath, FStri
 {
 	const FString& ReplaysDir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("SentryReplays"));
 
-	auto FindLatestFile = [&ReplaysDir](const TCHAR* Pattern) -> FString
-	{
-		TArray<FString> Files;
-		IFileManager::Get().FindFiles(Files, *ReplaysDir, Pattern);
+	TArray<FString> Replays;
+	IFileManager::Get().FindFiles(Replays, *ReplaysDir, TEXT("*.mp4"));
 
-		if (Files.Num() == 0)
-		{
-			return FString();
-		}
-
-		for (int i = 0; i < Files.Num(); ++i)
-		{
-			Files[i] = ReplaysDir / Files[i];
-		}
-
-		Files.Sort([](const FString& A, const FString& B)
-		{
-			const FDateTime TimestampA = IFileManager::Get().GetTimeStamp(*A);
-			const FDateTime TimestampB = IFileManager::Get().GetTimeStamp(*B);
-			return TimestampB < TimestampA;
-		});
-
-		return Files[0];
-	};
-
-	const FString LatestReplay = FindLatestFile(TEXT("*.mp4"));
-	if (LatestReplay.IsEmpty())
+	if (Replays.Num() == 0)
 	{
 		return false;
 	}
 
-	const FString LatestSidecar = FindLatestFile(TEXT("*.json"));
-	if (LatestSidecar.IsEmpty())
+	for (int i = 0; i < Replays.Num(); ++i)
+	{
+		Replays[i] = ReplaysDir / Replays[i];
+	}
+
+	Replays.Sort([](const FString& A, const FString& B)
+	{
+		const FDateTime TimestampA = IFileManager::Get().GetTimeStamp(*A);
+		const FDateTime TimestampB = IFileManager::Get().GetTimeStamp(*B);
+		return TimestampB < TimestampA;
+	});
+
+	const FString& LatestReplay = Replays[0];
+
+	// The metadata sidecar is written alongside the video file and shares its name
+	const FString LatestSidecar = FPaths::ChangeExtension(LatestReplay, TEXT("json"));
+	if (!FPaths::FileExists(LatestSidecar))
 	{
 		UE_LOG(LogSentrySdk, Warning, TEXT("There is no metadata sidecar accompanying the latest session replay."));
-		return false;
-	}
-
-	// The metadata sidecar is usable only if it belongs to the same replay as the video file
-	if (FPaths::GetBaseFilename(LatestSidecar) != FPaths::GetBaseFilename(LatestReplay))
-	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("The latest metadata sidecar doesn't match the latest session replay."));
 		return false;
 	}
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -65,16 +65,11 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 
 	if (settings->AttachSessionReplay)
 	{
-		// Capture the previous run's replay path before starting the recorder to
-		// avoid a race where onLastRunStatusDetermined picks up the current session's MP4
-		prevSessionReplayPath = GetLatestSessionReplay();
-		if (prevSessionReplayPath.IsEmpty())
+		// Capture the previous run's replay paths before starting the recorder to
+		// avoid a race where onLastRunStatusDetermined picks up the current session's files
+		if (!GetLatestSessionReplay(prevSessionReplayPath, prevSessionReplaySidecarPath))
 		{
 			UE_LOG(LogSentrySdk, Log, TEXT("No session replays from the previous session were found."));
-		}
-		else
-		{
-			prevSessionReplaySidecarPath = FPaths::ChangeExtension(prevSessionReplayPath, TEXT("json"));
 		}
 	}
 
@@ -106,11 +101,11 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 				{
 					// No crash to attach to — drop the previous run's replay files so they
 					// don't linger and confuse the next session's "latest" detection
-					if (!prevSessionReplayPath.IsEmpty() && FPaths::FileExists(prevSessionReplayPath))
+					if (FPaths::FileExists(prevSessionReplayPath))
 					{
 						IFileManager::Get().Delete(*prevSessionReplayPath);
 					}
-					if (!prevSessionReplaySidecarPath.IsEmpty() && FPaths::FileExists(prevSessionReplaySidecarPath))
+					if (FPaths::FileExists(prevSessionReplaySidecarPath))
 					{
 						IFileManager::Get().Delete(*prevSessionReplaySidecarPath);
 					}
@@ -130,17 +125,21 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 				}
 				if (settings->AttachSessionReplay)
 				{
-					if (!prevSessionReplayPath.IsEmpty() && FPaths::FileExists(prevSessionReplayPath))
-					{
-						// Send the structured replay envelope first since the attachment upload below deletes the video file
-						FAppleSentryReplayEnvelope::CaptureForCrashEvent(event, prevSessionReplayPath, prevSessionReplaySidecarPath);
-					}
-
 					// If a replay was captured during the previous app run upload it to Sentry.
 					UploadSessionReplayForEvent(MakeShareable(new FAppleSentryId(event.eventId)), prevSessionReplayPath);
 
-					// Clean up the metadata sidecar accompanying the replay video
-					if (!prevSessionReplaySidecarPath.IsEmpty() && FPaths::FileExists(prevSessionReplaySidecarPath))
+					if (FPaths::FileExists(prevSessionReplayPath) && FPaths::FileExists(prevSessionReplaySidecarPath))
+					{
+						// Send the structured replay envelope for the crash.
+						FAppleSentryReplayEnvelope::CaptureForCrashEvent(event, prevSessionReplayPath, prevSessionReplaySidecarPath);
+					}
+
+					// Clean up the replay files processed above.
+					if (FPaths::FileExists(prevSessionReplayPath))
+					{
+						IFileManager::Get().Delete(*prevSessionReplayPath);
+					}
+					if (FPaths::FileExists(prevSessionReplaySidecarPath))
 					{
 						IFileManager::Get().Delete(*prevSessionReplaySidecarPath);
 					}
@@ -788,7 +787,7 @@ void FAppleSentrySubsystem::UploadSessionReplayForEvent(TSharedPtr<ISentryId> ev
 		return;
 	}
 
-	UploadAttachmentForEvent(eventId, replayPath, TEXT("session-replay.mp4"), true);
+	UploadAttachmentForEvent(eventId, replayPath, TEXT("session-replay.mp4"), false);
 }
 
 FString FAppleSentrySubsystem::GetScreenshotPath() const
@@ -824,32 +823,59 @@ FString FAppleSentrySubsystem::GetLatestScreenshot() const
 	return Screenshots[0];
 }
 
-FString FAppleSentrySubsystem::GetLatestSessionReplay() const
+bool FAppleSentrySubsystem::GetLatestSessionReplay(FString& OutReplayPath, FString& OutSidecarPath) const
 {
 	const FString& ReplaysDir = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("SentryReplays"));
 
-	TArray<FString> Replays;
-	IFileManager::Get().FindFiles(Replays, *ReplaysDir, TEXT("*.mp4"));
-
-	if (Replays.Num() == 0)
+	auto FindLatestFile = [&ReplaysDir](const TCHAR* Pattern) -> FString
 	{
-		UE_LOG(LogSentrySdk, Log, TEXT("There are no session replays found."));
-		return FString("");
+		TArray<FString> Files;
+		IFileManager::Get().FindFiles(Files, *ReplaysDir, Pattern);
+
+		if (Files.Num() == 0)
+		{
+			return FString();
+		}
+
+		for (int i = 0; i < Files.Num(); ++i)
+		{
+			Files[i] = ReplaysDir / Files[i];
+		}
+
+		Files.Sort([](const FString& A, const FString& B)
+		{
+			const FDateTime TimestampA = IFileManager::Get().GetTimeStamp(*A);
+			const FDateTime TimestampB = IFileManager::Get().GetTimeStamp(*B);
+			return TimestampB < TimestampA;
+		});
+
+		return Files[0];
+	};
+
+	const FString LatestReplay = FindLatestFile(TEXT("*.mp4"));
+	if (LatestReplay.IsEmpty())
+	{
+		return false;
 	}
 
-	for (int i = 0; i < Replays.Num(); ++i)
+	const FString LatestSidecar = FindLatestFile(TEXT("*.json"));
+	if (LatestSidecar.IsEmpty())
 	{
-		Replays[i] = ReplaysDir / Replays[i];
+		UE_LOG(LogSentrySdk, Warning, TEXT("There is no metadata sidecar accompanying the latest session replay."));
+		return false;
 	}
 
-	Replays.Sort([](const FString& A, const FString& B)
+	// The metadata sidecar is usable only if it belongs to the same replay as the video file
+	if (FPaths::GetBaseFilename(LatestSidecar) != FPaths::GetBaseFilename(LatestReplay))
 	{
-		const FDateTime TimestampA = IFileManager::Get().GetTimeStamp(*A);
-		const FDateTime TimestampB = IFileManager::Get().GetTimeStamp(*B);
-		return TimestampB < TimestampA;
-	});
+		UE_LOG(LogSentrySdk, Warning, TEXT("The latest metadata sidecar doesn't match the latest session replay."));
+		return false;
+	}
 
-	return Replays[0];
+	OutReplayPath = LatestReplay;
+	OutSidecarPath = LatestSidecar;
+
+	return true;
 }
 
 #ifdef USE_SENTRY_SESSION_REPLAY

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -11,6 +11,7 @@
 #include "AppleSentryId.h"
 #include "AppleSentryLog.h"
 #include "AppleSentryMetric.h"
+#include "AppleSentryReplayEnvelope.h"
 #include "AppleSentrySamplingContext.h"
 #include "AppleSentryScope.h"
 #include "AppleSentryTransaction.h"
@@ -59,14 +60,21 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 	isSessionReplayAttachmentEnabled = settings->AttachSessionReplay;
 	maxAttachmentSize = settings->MaxAttachmentSize;
 
+	FString prevSessionReplayPath;
+	FString prevSessionReplaySidecarPath;
+
 	if (settings->AttachSessionReplay)
 	{
 		// Capture the previous run's replay path before starting the recorder to
 		// avoid a race where onLastRunStatusDetermined picks up the current session's MP4
-		PrevSessionReplayPath = GetLatestSessionReplay();
-		if (PrevSessionReplayPath.IsEmpty())
+		prevSessionReplayPath = GetLatestSessionReplay();
+		if (prevSessionReplayPath.IsEmpty())
 		{
 			UE_LOG(LogSentrySdk, Log, TEXT("No session replays from the previous session were found."));
+		}
+		else
+		{
+			prevSessionReplaySidecarPath = FPaths::ChangeExtension(prevSessionReplayPath, TEXT("json"));
 		}
 	}
 
@@ -96,11 +104,15 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 			options.onLastRunStatusDetermined = ^(SentryObjCLastRunStatus status, SentryObjCEvent* event) {
 				if (status != SentryObjCLastRunStatusDidCrash || event == nil)
 				{
-					// No crash to attach to — drop the previous run's replay file so it
-					// doesn't linger and confuse the next session's "latest" detection
-					if (!PrevSessionReplayPath.IsEmpty() && FPaths::FileExists(PrevSessionReplayPath))
+					// No crash to attach to — drop the previous run's replay files so they
+					// don't linger and confuse the next session's "latest" detection
+					if (!prevSessionReplayPath.IsEmpty() && FPaths::FileExists(prevSessionReplayPath))
 					{
-						IFileManager::Get().Delete(*PrevSessionReplayPath);
+						IFileManager::Get().Delete(*prevSessionReplayPath);
+					}
+					if (!prevSessionReplaySidecarPath.IsEmpty() && FPaths::FileExists(prevSessionReplaySidecarPath))
+					{
+						IFileManager::Get().Delete(*prevSessionReplaySidecarPath);
 					}
 					return;
 				}
@@ -118,8 +130,20 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 				}
 				if (settings->AttachSessionReplay)
 				{
+					if (!prevSessionReplayPath.IsEmpty() && FPaths::FileExists(prevSessionReplayPath))
+					{
+						// Send the structured replay envelope first since the attachment upload below deletes the video file
+						FAppleSentryReplayEnvelope::CaptureForCrashEvent(event, prevSessionReplayPath, prevSessionReplaySidecarPath);
+					}
+
 					// If a replay was captured during the previous app run upload it to Sentry.
-					UploadSessionReplayForEvent(MakeShareable(new FAppleSentryId(event.eventId)), PrevSessionReplayPath);
+					UploadSessionReplayForEvent(MakeShareable(new FAppleSentryId(event.eventId)), prevSessionReplayPath);
+
+					// Clean up the metadata sidecar accompanying the replay video
+					if (!prevSessionReplaySidecarPath.IsEmpty() && FPaths::FileExists(prevSessionReplaySidecarPath))
+					{
+						IFileManager::Get().Delete(*prevSessionReplaySidecarPath);
+					}
 				}
 			};
 			for (auto it = settings->InAppInclude.CreateConstIterator(); it; ++it)

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -83,8 +83,6 @@ protected:
 
 	int32 maxAttachmentSize = 0;
 
-	FString PrevSessionReplayPath;
-
 private:
 #ifdef USE_SENTRY_SESSION_REPLAY
 	FString GetReplayPath() const;

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -74,7 +74,7 @@ protected:
 	virtual FString GetLatestScreenshot() const;
 	virtual FString GetGameLogPath() const { return FString(); };
 	virtual FString GetLatestGameLog() const { return FString(); }
-	virtual FString GetLatestSessionReplay() const;
+	virtual bool GetLatestSessionReplay(FString& OutReplayPath, FString& OutSidecarPath) const;
 
 protected:
 	bool isScreenshotAttachmentEnabled = false;

--- a/sample/Source/SentryPlayground/IntegrationTests/SentryReplayTest.cpp
+++ b/sample/Source/SentryPlayground/IntegrationTests/SentryReplayTest.cpp
@@ -26,9 +26,17 @@ constexpr int32 ClipFrameRate = 30;
 constexpr int32 ClipFrameCount = ClipDurationMs / 1000 * ClipFrameRate;
 constexpr int32 ClipSizeBytes = 64 * 1024;
 
-// Mirrors FGenericPlatformSentrySubsystem::GetDatabasePath which is not exposed publicly
+// Mirrors the directories the SDK scans for replay files which are not exposed publicly:
+// FAppleSentrySubsystem::GetReplayPath (cocoa) and FGenericPlatformSentrySubsystem::GetDatabasePath (sentry-native)
 FString GetReplaysDir(const USentrySettings* Settings)
 {
+#if PLATFORM_MAC
+	if (!Settings->UseNativeBackend)
+	{
+		return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("SentryReplays")));
+	}
+#endif
+
 	const FString DatabaseParentPath = Settings->DatabaseLocation == ESentryDatabaseLocation::ProjectDirectory
 		? FPaths::ProjectDir()
 		: FPaths::ProjectUserDir();

--- a/sample/Source/SentryPlayground/IntegrationTests/SentryReplayTest.cpp
+++ b/sample/Source/SentryPlayground/IntegrationTests/SentryReplayTest.cpp
@@ -30,7 +30,9 @@ constexpr int32 ClipSizeBytes = 64 * 1024;
 // FAppleSentrySubsystem::GetReplayPath (cocoa) and FGenericPlatformSentrySubsystem::GetDatabasePath (sentry-native)
 FString GetReplaysDir(const USentrySettings* Settings)
 {
-#if PLATFORM_MAC
+#if PLATFORM_IOS
+	return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("SentryReplays")));
+#elif PLATFORM_MAC
 	if (!Settings->UseNativeBackend)
 	{
 		return FPaths::ConvertRelativePathToFull(FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("SentryReplays")));

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -68,6 +68,8 @@ Source/Sentry/Private/Apple/AppleSentryLog.cpp
 Source/Sentry/Private/Apple/AppleSentryLog.h
 Source/Sentry/Private/Apple/AppleSentryMetric.cpp
 Source/Sentry/Private/Apple/AppleSentryMetric.h
+Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
+Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.h
 Source/Sentry/Private/Apple/AppleSentrySamplingContext.cpp
 Source/Sentry/Private/Apple/AppleSentrySamplingContext.h
 Source/Sentry/Private/Apple/AppleSentryScope.cpp


### PR DESCRIPTION
This PR adds [Session Replay](https://docs.sentry.io/product/explore/session-replay/) product integration for platforms where sentry-cocoa is used (macOS and iOS). The gameplay recorded in the rolling buffer before a crash is now delivered to Sentry as a separate [session replay envelope](https://develop.sentry.dev/sdk/foundations/envelopes/event-payloads/replay-recording/#mobile-replay-events) (discoverable in the Replays dashboard and associated with the crash) instead of only being attached to the event as an MP4 file. This closes the macOS limitation noted in #1445 and extends the integration to iOS.

Since sentry-cocoa sends crash reports on the next application launch, the replay envelope is assembled in-process within the `onLastRunStatusDetermined` callback: the plugin reads the recorded MP4 and its JSON metadata sidecar, builds the `replay_event`/`replay_recording` payloads, packs them together with the video into a msgpack payload (same wire format as sentry-cocoa's own `SentryMsgPackSerializer` and the sentry-native implementation), and hands the envelope to the SDK for sending via the internal envelope API.

[Example replay](https://sentry-sdks.sentry.io/explore/replays/551fdcf8d248b42d854d428c547dbb07/?groupId=7532510000&referrer=%2Fexplore%2Freplays%2F%3AreplaySlug%2F&t=5&t_main=errors) captured on macOS.

## Key Changes

- Added `AppleSentryReplayEnvelope` which builds the `replay_video` envelope from the recorded clip, its metadata sidecar, and the crash event from the previous app run, and captures it through sentry-cocoa's envelope API.
- The replay event is enriched from the crash event's scope (tags, contexts, release, environment, dist, user) and the matching trace id so it correlates with the crash's events/spans; the replay window is anchored to the crash timestamp.
- `GetLatestSessionReplay` now resolves both the replay video and its metadata sidecar, succeeding only when the latest pair belongs to the same replay.
- Replay files (MP4 + JSON sidecar) are cleaned up explicitly after processing on both crash and no-crash launches (previously the metadata sidecar was left behind).
- The replay clip remains attached to the crash event as an MP4 attachment (rollout parity with the sentry-native platforms).

## Testing

- Extended integration test checks for replay envelope capturing to Apple platforms. 

## Documentation

- https://github.com/getsentry/sentry-docs/pull/18670

## Related items

- #1445
- #1462