### PR TITLE
Link structured logs with captured session replays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Add experimental session replay capturing on iOS (UE 5.8+) ([#1462](https://github.com/getsentry/sentry-unreal/pull/1462))
 - Add integration with Session Replay product for native platforms ([#1445](https://github.com/getsentry/sentry-unreal/pull/1445))
 - Add integration with Session Replay product for Apple platforms ([#1468](https://github.com/getsentry/sentry-unreal/pull/1468))
+- Link structured logs with captured session replays ([#1470](https://github.com/getsentry/sentry-unreal/pull/1470))
 
 ### Fixes
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -288,6 +288,8 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 			if (SessionReplay->Initialize(settings, SessionReplayId, GetReplayPath()))
 			{
 				SetContext(TEXT("replay"), { { TEXT("replay_id"), FSentryVariant(SessionReplayId) } });
+				SetAttribute(TEXT("sentry.replay_id"), FSentryVariant(SessionReplayId));
+				SetAttribute(TEXT("sentry._internal.replay_is_buffering"), FSentryVariant(true));
 			}
 			else
 			{

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -672,6 +672,8 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 		if (SessionReplay->Initialize(settings, SessionReplayId, GetReplayPath()))
 		{
 			SetContext(TEXT("replay"), { { TEXT("replay_id"), FSentryVariant(SessionReplayId) } });
+			SetAttribute(TEXT("sentry.replay_id"), FSentryVariant(SessionReplayId));
+			SetAttribute(TEXT("sentry._internal.replay_is_buffering"), FSentryVariant(true));
 		}
 		else
 		{


### PR DESCRIPTION
This PR adds automatic linking between structured logs and captured session replays on platforms where the plugin provides its own replay recording - desktop (`sentry-native`) and Apple (`sentry-cocoa`).

When session replay capturing is enabled and the recorder initializes successfully, the SDK now sets two scope-level log attributes (in addition to the existing `contexts.replay.replay_id` used for events):

- `sentry.replay_id` - the session's replay id, allowing Sentry to associate logs with the corresponding replay
- `sentry._internal.replay_is_buffering: true` - marks the replay link as provisional, since the Unreal SDK records replays into a local rolling video file and uploads them only when a crash occurs (equivalent to the `buffer`/`onError` mode in other SDKs)

Both attributes are set once during SDK initialization via the existing `SetAttribute` wrapper (`sentry_set_attribute` on native, `Scope.setAttributeValue` on cocoa). The underlying SDKs automatically apply scope attributes to every log at capture time, so there is no per-log overhead. This works for all log sources: the `Log*` subsystem API, Blueprint calls, and the automatic UE log forwarding.

[Example replay](https://sentry-sdks.sentry.io/explore/replays/f2c1c860e9425a88bd6fb982f06206a9/?playlistEnd=2026-07-08T12%3A58%3A13&playlistStart=2026-07-08T11%3A58%3A13&project=6253052&query=&referrer=%2Fexplore%2Freplays%2F%3AreplaySlug%2F&t_main=logs&t=6) with linked logs.

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1445
- https://github.com/getsentry/sentry-unreal/pull/1468