### PR TITLE
chore: Update CLAUDE.md and skills

### DIFF
--- a/.claude/skills/build-deps/SKILL.md
+++ b/.claude/skills/build-deps/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: build-deps
+description: Build plugin SDK dependencies locally and refresh ThirdParty binaries
+---
+
+Build plugin dependencies from local SDK checkouts and replace the pre-built binaries under `plugin-dev/Source/ThirdParty/`. Use when testing unreleased SDK changes.
+
+## Steps
+
+### 1. Select dependencies to build
+
+Determine which dependencies to build from conversation context:
+
+| Dependency          | Flag             | Path parameter       | Env var fallback             | Notes                                                                                     |
+|---------------------|------------------|----------------------|------------------------------|-------------------------------------------------------------------------------------------|
+| sentry-native       | `-Native`        | `-NativePath`        | `SENTRY_NATIVE_PATH`         | Builds for host platform: Windows/Linux (Crashpad + Native backends), macOS (Native backend) |
+| sentry-cocoa        | `-Cocoa`         | `-CocoaPath`         | `SENTRY_COCOA_PATH`          | macOS host only; produces iOS + Mac artifacts                                              |
+| sentry-java         | `-Java`          | `-JavaPath`          | `SENTRY_JAVA_PATH`           | Gradle build; also downloads the matching sentry-native NDK release                        |
+| crash reporter      | `-CrashReporter` | `-CrashReporterPath` | `SENTRY_CRASH_REPORTER_PATH` | .NET build for host platform                                                               |
+
+`-All` builds everything supported on the host platform.
+
+### 2. Verify source paths
+
+For each selected dependency, check that its env var is set (verify non-empty only, never print values; on Windows use `[System.Environment]::GetEnvironmentVariable('VAR_NAME')`) or that an explicit path parameter was provided. If missing, ask the user for the repository path and pass it via the corresponding path parameter.
+
+### 3. Run the build
+
+Execute from the repo root:
+
+```bash
+pwsh ./scripts/build-deps.ps1 -All                                        # everything for host platform
+pwsh ./scripts/build-deps.ps1 -Cocoa -Java                                # specific SDKs
+pwsh ./scripts/build-deps.ps1 -Native -NativePath "/path/to/sentry-native" # explicit source path
+```
+
+The build can take longer than the default command timeout — run it in the background and monitor its output, or raise the timeout accordingly.
+
+**Linux notes (sentry-native):** the build requires clang with libc++ (static libs are built against libc++ to match Unreal; the crash handler executables use libstdc++). The host machine's clang may not match the version Unreal uses — prefer the clang toolchain bundled with the engine by prepending its `bin` directory to `PATH` before running the script. Look for it under `$UNREAL_ENGINE_ROOT/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/<toolchain-version>/x86_64-unknown-linux-gnu/bin` (the target architecture is auto-detected by the script).
+
+### 4. Clean stale build artifacts
+
+UnrealBuildTool does not reliably detect ThirdParty binary changes, so after a successful deps rebuild remove the plugin `Binaries`/`Intermediate` directories to avoid linking against stale binaries:
+
+```bash
+REPO=$(git rev-parse --show-toplevel)
+rm -rf "$REPO/plugin-dev/Binaries" "$REPO/plugin-dev/Intermediate"
+```
+
+`sample/Plugins/sentry` is a symlink to `plugin-dev`, so the plugin artifacts live in `plugin-dev/` itself.
+
+### 5. Rebuild the project
+
+Suggest running `/ue-build` so the project is recompiled against the freshly built dependencies.

--- a/.claude/skills/build-deps/SKILL.md
+++ b/.claude/skills/build-deps/SKILL.md
@@ -36,8 +36,6 @@ pwsh ./scripts/build-deps.ps1 -Native -NativePath "/path/to/sentry-native" # exp
 
 The build can take longer than the default command timeout — run it in the background and monitor its output, or raise the timeout accordingly.
 
-**Linux notes (sentry-native):** the build requires clang with libc++ (static libs are built against libc++ to match Unreal; the crash handler executables use libstdc++). The host machine's clang may not match the version Unreal uses — prefer the clang toolchain bundled with the engine by prepending its `bin` directory to `PATH` before running the script. Look for it under `$UNREAL_ENGINE_ROOT/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/<toolchain-version>/x86_64-unknown-linux-gnu/bin` (the target architecture is auto-detected by the script).
-
 ### 4. Clean stale build artifacts
 
 UnrealBuildTool does not reliably detect ThirdParty binary changes, so after a successful deps rebuild remove the plugin `Binaries`/`Intermediate` directories to avoid linking against stale binaries:

--- a/.claude/skills/ue-build/SKILL.md
+++ b/.claude/skills/ue-build/SKILL.md
@@ -7,7 +7,12 @@ Build the SentryPlayground sample project.
 
 1. Check the `UNREAL_ENGINE_ROOT` environment variable (use PowerShell `.NET` method on Windows: `[System.Environment]::GetEnvironmentVariable('UNREAL_ENGINE_ROOT')`). If unset or the path doesn't exist, ask the user for the engine path.
 
-2. Determine the target platform from conversation context using this lookup table. If no platform is mentioned, default to the host platform (`Win64` on Windows, `Mac` on macOS, `Linux` on Linux). If ambiguous, ask the user.
+2. Choose the build mode from conversation context:
+
+   - **Compile-only** (default) - when the goal is verifying that code compiles after changes, or as a prerequisite for `/ue-unit-test`. Invokes UnrealBuildTool directly and is much faster than a full package.
+   - **Full package** - when the user wants a packaged, runnable game build (e.g. as a prerequisite for `/ue-integration-test`, or if they mention packaging/cooking/distribution).
+
+3. Determine the target platform from conversation context using this lookup table. If no platform is mentioned, default to the host platform (`Win64` on Windows, `Mac` on macOS, `Linux` on Linux). If ambiguous, ask the user.
 
    | Alias                | Platform flag |
    |----------------------|---------------|
@@ -22,9 +27,33 @@ Build the SentryPlayground sample project.
    | PS5, PlayStation     | PS5           |
    | Switch, NX           | Switch        |
 
-3. Determine the build configuration: use `Development` by default, or `Shipping` if the user mentions it.
+4. Determine the build configuration: use `Development` by default, or `Shipping` if the user mentions it.
 
-4. Resolve the repo root and run the build command:
+## Compile-only build
+
+Resolve the repo root and invoke UnrealBuildTool with the editor target for the host platform:
+
+```bash
+REPO=$(git rev-parse --show-toplevel)
+
+# Windows
+"$UNREAL_ENGINE_ROOT/Engine/Build/BatchFiles/Build.bat" SentryPlaygroundEditor Win64 Development \
+    -project="$REPO/sample/SentryPlayground.uproject" -waitmutex
+
+# macOS
+"$UNREAL_ENGINE_ROOT/Engine/Build/BatchFiles/Mac/Build.sh" SentryPlaygroundEditor Mac Development \
+    -project="$REPO/sample/SentryPlayground.uproject" -waitmutex
+
+# Linux
+"$UNREAL_ENGINE_ROOT/Engine/Build/BatchFiles/Linux/Build.sh" SentryPlaygroundEditor Linux Development \
+    -project="$REPO/sample/SentryPlayground.uproject" -waitmutex
+```
+
+To compile-check a non-host or non-editor platform (e.g. Android, iOS, consoles), build the game target instead, substituting the platform and configuration: `SentryPlayground <Platform> <Config>`.
+
+## Full package build
+
+Resolve the repo root and run the BuildCookRun command:
 
 ```bash
 REPO=$(git rev-parse --show-toplevel)
@@ -42,8 +71,22 @@ REPO=$(git rev-parse --show-toplevel)
     -archivedirectory="$REPO/sample/dist" \
     -platform=Mac -clientconfig=Development \
     -build -cook -stage -package -archive -nop4
+
+# Linux
+"$UNREAL_ENGINE_ROOT/Engine/Build/BatchFiles/RunUAT.sh" BuildCookRun \
+    -project="$REPO/sample/SentryPlayground.uproject" \
+    -archivedirectory="$REPO/sample/dist" \
+    -platform=Linux -clientconfig=Development \
+    -build -cook -stage -package -archive -nop4
 ```
 
 Substitute the platform and config values as determined above.
 
 For Android `Shipping` builds, add the `-distribution` flag.
+
+## Execution notes
+
+- Builds regularly take longer than the default command timeout. Run the build command in the background and monitor its output, or raise the timeout accordingly.
+- On failure, check the logs for the root cause:
+  - UnrealBuildTool: `$UNREAL_ENGINE_ROOT/Engine/Programs/UnrealBuildTool/Log.txt`
+  - UAT (BuildCookRun): `$UNREAL_ENGINE_ROOT/Engine/Programs/AutomationTool/Saved/Logs/`

--- a/.claude/skills/ue-integration-test/SKILL.md
+++ b/.claude/skills/ue-integration-test/SKILL.md
@@ -78,10 +78,21 @@ Execute from the `integration-test/` directory:
 
 ```bash
 cd integration-test
+
+# Desktop (Windows, Linux, macOS)
 pwsh -Command 'Invoke-Pester ./Integration.Desktop.Tests.ps1'
+
+# Android
+pwsh -Command 'Invoke-Pester ./Integration.Android.Tests.ps1'
 ```
 
-Replace the test file name for Android as needed.
+When iterating on a single test, filter by its name instead of rerunning the whole suite:
+
+```bash
+pwsh -Command 'Invoke-Pester ./Integration.Desktop.Tests.ps1 -FullNameFilter "*crash*"'
+```
+
+The full suite can take longer than the default command timeout — run it in the background and monitor its output, or raise the timeout accordingly.
 
 ### 6. Check results
 

--- a/.claude/skills/ue-unit-test/SKILL.md
+++ b/.claude/skills/ue-unit-test/SKILL.md
@@ -5,17 +5,17 @@ description: Run Sentry unit tests via Unreal automation
 
 Run Sentry unit tests via Unreal Engine automation framework.
 
-Prerequisite: the project must be built first. If unsure whether it's been built, ask the user. If not built, suggest running `/ue-build` first.
+Prerequisite: the project must be built first (a compile-only editor build is sufficient). If unsure whether it's been built, ask the user. If not built, suggest running `/ue-build` first.
 
 1. Check the `UNREAL_ENGINE_ROOT` environment variable (use PowerShell `.NET` method on Windows: `[System.Environment]::GetEnvironmentVariable('UNREAL_ENGINE_ROOT')`). If unset or the path doesn't exist, ask the user for the engine path.
 
-2. Determine the engine version by reading the `EngineAssociation` field in `sample/SentryPlayground.uproject` (e.g., `"EngineAssociation": "5.7"` - UE5, `"EngineAssociation": "4.27"` - UE4). Select the editor binary based on host OS and engine version:
+2. Determine the engine version by reading the `EngineAssociation` field in `sample/SentryPlayground.uproject` (e.g., `"EngineAssociation": "5.7"` - UE5, `"EngineAssociation": "4.27"` - UE4). Select the headless editor binary based on host OS and engine version:
 
-| Host OS | UE5 binary path                          | UE4 binary path                       |
-|---------|------------------------------------------|---------------------------------------|
-| Windows | `Engine/Binaries/Win64/UnrealEditor.exe` | `Engine/Binaries/Win64/UE4Editor.exe` |
-| macOS   | `Engine/Binaries/Mac/UnrealEditor`       | `Engine/Binaries/Mac/UE4Editor`       |
-| Linux   | `Engine/Binaries/Linux/UnrealEditor`     | `Engine/Binaries/Linux/UE4Editor`     |
+| Host OS | UE5 binary path                              | UE4 binary path                           |
+|---------|----------------------------------------------|-------------------------------------------|
+| Windows | `Engine/Binaries/Win64/UnrealEditor-Cmd.exe` | `Engine/Binaries/Win64/UE4Editor-Cmd.exe` |
+| macOS   | `Engine/Binaries/Mac/UnrealEditor-Cmd`       | `Engine/Binaries/Mac/UE4Editor-Cmd`       |
+| Linux   | `Engine/Binaries/Linux/UnrealEditor-Cmd`     | `Engine/Binaries/Linux/UE4Editor-Cmd`     |
 
 3. Resolve the repo root and run the automation command:
 
@@ -23,7 +23,7 @@ Prerequisite: the project must be built first. If unsure whether it's been built
 REPO=$(git rev-parse --show-toplevel)
 
 # Windows UE5
-"$UNREAL_ENGINE_ROOT/Engine/Binaries/Win64/UnrealEditor.exe" \
+"$UNREAL_ENGINE_ROOT/Engine/Binaries/Win64/UnrealEditor-Cmd.exe" \
     "$REPO/sample/SentryPlayground.uproject" \
     -ReportExportPath="$REPO/sample/Saved/Automation" \
     -ExecCmds="Automation RunTests Sentry;quit" \
@@ -31,7 +31,15 @@ REPO=$(git rev-parse --show-toplevel)
     -Unattended -NoPause -NoSplash -NullRHI
 
 # macOS UE5
-"$UNREAL_ENGINE_ROOT/Engine/Binaries/Mac/UnrealEditor" \
+"$UNREAL_ENGINE_ROOT/Engine/Binaries/Mac/UnrealEditor-Cmd" \
+    "$REPO/sample/SentryPlayground.uproject" \
+    -ReportExportPath="$REPO/sample/Saved/Automation" \
+    -ExecCmds="Automation RunTests Sentry;quit" \
+    -TestExit="Automation Test Queue Empty" \
+    -Unattended -NoPause -NoSplash -NullRHI
+
+# Linux UE5
+"$UNREAL_ENGINE_ROOT/Engine/Binaries/Linux/UnrealEditor-Cmd" \
     "$REPO/sample/SentryPlayground.uproject" \
     -ReportExportPath="$REPO/sample/Saved/Automation" \
     -ExecCmds="Automation RunTests Sentry;quit" \
@@ -39,4 +47,11 @@ REPO=$(git rev-parse --show-toplevel)
     -Unattended -NoPause -NoSplash -NullRHI
 ```
 
-4. Report that test results are written to `sample/Saved/Automation/`.
+The test run can take longer than the default command timeout — run it in the background and monitor its output, or raise the timeout accordingly.
+
+4. Report the results. The editor's exit code is not a reliable pass/fail signal for automation runs — read the report at `sample/Saved/Automation/index.json` instead:
+
+   - Summarize the number of passed and failed tests (`succeeded` / `failed` counts).
+   - For each failed test, report its full name and the error messages from its report entries.
+
+   If the report is missing or the run crashed, check `sample/Saved/Logs/` for the root cause.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ Supported Unreal Engine versions are listed in `scripts/packaging/engine-version
 
 - Source files require copyright notice: `Copyright (c) YYYY Sentry. All Rights Reserved.` (for `YYYY` use file creation year)
 - Use file naming pattern `{Platform}SentryXxx.cpp` for platform implementations (e.g., AndroidSentrySubsystem.cpp)
-- Use `.clang-format`
+- Run clang-format on changed C++ files before committing: `git diff --name-only --diff-filter=d $(git merge-base main HEAD) -- 'plugin-dev/Source/**/*.h' 'plugin-dev/Source/**/*.cpp' | xargs clang-format -i`
 - No BOM (Byte Order Mark) in source files
 - Files must end with a single empty line (newline at EOF)
 - Avoid giving a `UENUM` and a `USTRUCT`/`UCLASS` the same base name after prefix stripping (e.g., `ESentryFoo` + `FSentryFoo` both become `SentryFoo` in Python). If unavoidable, add `meta = (ScriptName = "...")` to the `UENUM` to resolve the collision.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -288,8 +288,3 @@ On Windows, when checking env vars via PowerShell through the Bash tool, use the
 - [sentry-android-gradle-plugin](https://github.com/getsentry/sentry-android-gradle-plugin): uploading Android debug symbols
 - [app-runner](https://github.com/getsentry/app-runner): PowerShell module used in integration tests
 - [sentry-docs](https://github.com/getsentry/sentry-docs): documentation sources for Sentry products
-
-## Maintaining This Document
-
-- When completing a task that reveals new patterns, conventions, best practices, or solutions to recurring issues not yet documented here, suggest adding these insights to `CLAUDE.md`.
-- When using compaction (which condenses context by summarizing older messages), make sure to re-read `CLAUDE.md` afterward to keep it fully available in context.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -182,7 +182,7 @@ Supported Unreal Engine versions are listed in `scripts/packaging/engine-version
 
 ### Common Instructions
 
-- Before implementating new plugin features that wrap existing native SDK functionality, examine the relevant SDK's API (`sentry-native`, `sentry-cocoa`, or `sentry-java`) to understand its usage, check platform availability, and identify interop requirements (JNI for Android, Objective-C++ for Apple). Refer to `Native SDK API Lookup Order` in Quick References for where to find SDK APIs.
+- Before implementing new plugin features that wrap existing native SDK functionality, examine the relevant SDK's API (`sentry-native`, `sentry-cocoa`, or `sentry-java`) to understand its usage, check platform availability, and identify interop requirements (JNI for Android, Objective-C++ for Apple). Refer to `Native SDK API Lookup Order` in Quick References for where to find SDK APIs.
 
 - When introducing a new public API that becomes part of the common interface, ensure that a corresponding stub is added to its `Null` implementation to avoid compilation errors on unsupported platforms.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -173,10 +173,9 @@ To work with the Unreal project, it has to be properly set up (symlink plugin so
 # Initialize (first-time setup - downloads SDK dependencies via GitHub CLI, CI provides pre-built binaries)
 pwsh ./scripts/init-win.ps1      # Windows
 ./scripts/init.sh                # macOS/Linux
-
-# Build platform SDKs and other dependencies locally (optional - useful when testing unreleased changes)
-pwsh ./scripts/build-deps.ps1 -All
 ```
+
+To build platform SDKs and other dependencies locally (optional - useful when testing unreleased changes), use the `/build-deps` skill.
 
 Supported Unreal Engine versions are listed in `scripts/packaging/engine-versions.txt`. When using an engine built from source, the `.uproject` file will contain a GUID instead of a version number in the `EngineAssociation` field.
 
@@ -204,6 +203,7 @@ Build and test workflows are available as skills:
 - `/ue-build` - Build sample project for a target platform
 - `/ue-unit-test` - Run Sentry unit tests
 - `/ue-integration-test` - Run integration tests
+- `/build-deps` - Build plugin SDK dependencies locally and refresh ThirdParty binaries
 
 ### Security
 


### PR DESCRIPTION
This PR updates the Claude Code guidance (`CLAUDE.md`) and project skills (`.claude/skills/`) to make day-to-day agent-assisted development faster and more reliable.

### `/ue-build`

- Added a compile-only mode (now the default) that invokes `UnrealBuildTool` directly on the `SentryPlaygroundEditor` target. This is much faster than a full `BuildCookRun` when the goal is simply verifying that code compiles or preparing for unit tests. The full package build remains available for packaging and integration-test scenarios.
- Added a Linux `BuildCookRun` example.
- Added execution notes:
  - Run builds in the background, as they exceed the default command timeout.
  - Where to find `UBT`/`UAT` logs if a build fails.

### `/ue-unit-test`

- Switched to the headless `UnrealEditor-Cmd` / `UE4Editor-Cmd` binaries, which stream logs to stdout and avoid GUI/focus side effects during automation runs.
- Results are now reported by parsing `sample/Saved/Automation/index.json` (pass/fail counts and failure details) instead of relying on the editor's exit code, which is not a reliable signal.
- Added a Linux command example.
- Added a note about running long test sessions in the background.

### `/ue-integration-test`

- Added explicit run commands for both Desktop and Android test suites.
- Added a single-test iteration example using Pester's `-FullNameFilter`.
- Added a note about running the full suite in the background.

### `/build-deps` (new skill)

- Extracted the local dependency build instructions (`build-deps.ps1`) from `CLAUDE.md` into a dedicated skill.
- Documented per-SDK flags (`-Native`, `-Cocoa`, `-Java`, `-CrashReporter`), path parameters, and env-var fallbacks, including platform constraints.
- Added Linux-specific notes for sentry-native: clang with libc++ is required, preferring the engine-bundled clang toolchain over the host one to match the compiler version Unreal uses.
- Added a post-build cleanup step: remove `plugin-dev/Binaries` and `plugin-dev/Intermediate` after a deps rebuild, since `UnrealBuildTool` does not reliably detect ThirdParty binary changes.

### `CLAUDE.md`

- Added an instruction to run `clang-format` on changed C++ files before committing by diffing against the merge base with `main`, ensuring files touched in earlier branch commits are also formatted (matching the lint CI behavior).
- Replaced the inline `build-deps.ps1` instructions in Project Setup with a pointer to the new `/build-deps` skill and listed it under Project Build & Testing.
- Removed the redundant "Maintaining This Document" section (its compaction guidance is now handled automatically by the harness).
- Fixed a typo (`implementating`).

#skip-changelog