### PR TITLE
chore: Migrate known limitations from README to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,31 +43,9 @@ The SDK compiles with three latest engine versions.
 
 ## Known Limitations
 
-- On all platforms captured crashes are uploaded to Sentry only after relaunching the crashed app since the in-process handler cannot do this within the same session. The only exceptions are Windows and Linux for which the out-of-process crashpad handler is used and crashes are uploaded immediately.
-
-- To automatically capture crashes in Windows game builds that were made using engine versions prior to UE 5.2, the [Crash Reporter has to be configured](https://docs.sentry.io/platforms/unreal/setup-crashreport/) or engine source code [modifications](https://github.com/EpicGames/UnrealEngine/pull/7976) must be applied.
+- To automatically capture crashes in Windows game builds that were made using engine versions prior to UE 5.2, the [Crash Reporter has to be configured](https://docs.sentry.io/platforms/unreal/setup-crashreport/) or engine source code [modifications](https://github.com/EpicGames/UnrealEngine/pull/7976) must be applied (make sure to check the PRs linked there as well).
   
-- Using UGS binaries requires tagging of files to ensure the crashpad_handler.exe is present. For inclusion in build graph, you'd want something like this: 
-```
-<Tag Files="#EditorBinaries$(EditorPlatform)" Filter="*.target" With="#TargetReceipts"/>
-<TagReceipt Files="#TargetReceipts" RuntimeDependencies="true" With="#RuntimeDependencies"/>
-<Tag Files="#RuntimeDependencies" Filter="sentry.dll;crashpad_handler.exe" With="#BinariesToArchive$(EditorPlatform)"/>
- ```
-
-- In UE 5.2 or newer game log attached to crashes captured with `sentry-native` integration instead of [crash reporter](https://docs.sentry.io/platforms/unreal/setup-crashreport/) could be truncated. This is caused by current `crashpad` behavior which sends crashes to Sentry right away while UE is still about to write some bits of information to the log file.
-
-- Only crash events captured on Android contain the full callstack. Non-fatal events that were captured manually won't include the native C++ portion of the stack trace.
-
-- Callbacks that are registered as hooks (such as `BeforeSendHandler`) will not be invoked during garbage collection.
-
-- It may be required to upgrade the C++ standard library (`libstdc++`) on older Linux distributions (such as Ubuntu 18.04 and 20.04) to ensure crashpad handler proper functionality within the deployment environment. In addition, crashpad handler requires `libcurl` to be available at runtime. This can be achieved with something like this:
-```
-sudo apt-get update
-sudo add-apt-repository ppa:ubuntu-toolchain-r/test
-sudo apt-get install -y libstdc++6 libcurl4
-```
-
-- Plugin supports Linux arm64 platform for UE 5.0+ and Windows arm64 for UE 5.2+.
+- Callbacks that are registered as hooks (such as `BeforeSendHandler`) will not be invoked during garbage collection or while objects are being post-loaded.
 
 - Fast-fail crash capturing is currently supported only in packaged game builds. When a fast-fail crash occurs the `HandleBeforeSend` hook will not be invoked and any custom event pre-processing will be skipped.
 


### PR DESCRIPTION
This PR updates the Known Limitations section in `README.md` by removing items that were migrated to the official Unreal SDK documentation:

- Crash upload timing (events sent on next app launch) - moved to the Troubleshooting page
- UGS binaries tagging for crash handler executables - moved to the Troubleshooting page (with the stale `sentry.dll` reference replaced by the current runtime dependencies)
- `libstdc++`/`libcurl` requirements on older Linux distributions - moved to the Troubleshooting page
- Truncated game log attached to crash events - moved to an alert on the `AttachGameLog` option
- Android callstack limitation for non-fatal events - moved to an alert on the `AttachStacktrace` option
- arm64 engine version support - moved to the Install section of the docs index page

It also updates the remaining items:

- The engine source modification bullet now points out that PRs linked from the referenced UE pull request should be checked as well
- The hooks bullet now mentions that callbacks are skipped during the object post-load phase in addition to garbage collection (matching `SentryCallbackUtils::IsCallbackSafeToRun`)

## Related items
- getsentry/sentry-docs#18691

#skip-changelog