### PR TITLE
Fix logs and metrics not being linked with NDK crashes on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Link structured logs and metrics with captured native crashes on Android ([#1475](https://github.com/getsentry/sentry-unreal/pull/1475))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v9.20.0 to v9.21.0 ([#1471](https://github.com/getsentry/sentry-unreal/pull/1471))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Link structured logs and metrics with captured native crashes on Android ([#1475](https://github.com/getsentry/sentry-unreal/pull/1475))
+- Fix structured logs and metrics not being linked with captured native crashes on Android ([#1475](https://github.com/getsentry/sentry-unreal/pull/1475))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -43,6 +43,7 @@ import io.sentry.SentryLogLevel;
 import io.sentry.SentryMetricsEvent;
 import io.sentry.JsonUnknown;
 import io.sentry.metrics.SentryMetricsParameters;
+import io.sentry.util.TracingUtils;
 
 public class SentryBridgeJava {
 	public static native void onConfigureScope(long callbackAddr, IScope scope);
@@ -139,6 +140,10 @@ public class SentryBridgeJava {
 				}
 			}
 		});
+
+		// Force a new trace so the Java and NDK layers share the same trace_id. Otherwise each layer
+		// keeps its own randomly generated one, and native crashes can't be correlated with logs/metrics.
+		TracingUtils.startNewTrace(Sentry.getCurrentScopes());
 	}
 
 	public static void addBreadcrumb(final String message, final String category, final String type, final HashMap<String, String> data, final SentryLevel level) {


### PR DESCRIPTION
This PR fixes structured logs and metrics not being correlated with captured C++ native crashes on Android.

Logs and metrics are stamped with the `trace_id` from the Java scope's propagation context, while native crash events captured by the NDK carry the trace from sentry-native's scope. Each layer generates its own random `trace_id` at `init`, and the sync between them (`NdkScopeObserver.setTrace`) only fires when the propagation context changes. Normally `sentry-java` bootstraps this via `ActivityLifecycleIntegration.onActivityCreated` -> `TracingUtils.startNewTrace`, but in Unreal games the activity is created before the SDK initializes, so that callback never fires and the two layers keep mismatched trace IDs for the entire session. As a result, native crashes and the logs/metrics emitted around them ended up on different traces and couldn't be linked in Sentry.

The fix forces a new trace right after `SentryAndroid.init` returns, mirroring what the SDK's own activity lifecycle integration would have done. Setting the new propagation context notifies the NDK scope observer, which pushes the same `trace_id`/`span_id` down to sentry-native, so subsequent logs, metrics, and native crash events all share one trace. Later trace rotations by the SDK (activity recreation, `ContinueTrace`, scope-bound transactions) keep re-syncing as before.