### PR TITLE
Decrease max session replay clip duration to avoid size limit issue on high-res

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- Decrease max session replay clip duration to 20 seconds to prevent replays from being rejected due to the server-side 10 MiB size limit, which could be exceeded at high rendering resolutions ([#1478](https://github.com/getsentry/sentry-unreal/pull/1478))
+
 ## 1.16.1
 
 ### Fixes

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -565,8 +565,8 @@ class SENTRY_API USentrySettings : public UObject
 	bool AttachSessionReplay;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Session Replay",
-		Meta = (DisplayName = "Replay duration (ms)", ToolTip = "Requested duration of the retroactive replay window. On desktop platforms (Windows/Mac/Linux) this is the rolling clip length kept on disk for crash attachment; on Xbox the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). Ignored on Android, where the SDK determines the duration.",
-			EditCondition = "AttachSessionReplay", ClampMin = "1000", ClampMax = "60000"))
+		Meta = (DisplayName = "Replay duration (ms)", ToolTip = "Requested duration of the retroactive replay window. On desktop platforms (Windows/Mac/Linux) this is the rolling clip length kept on disk for crash attachment; on Xbox the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). Ignored on Android, where the SDK determines the duration. Capped at 20 seconds: Sentry rejects replay videos larger than 10 MiB, and longer clips risk exceeding that limit.",
+			EditCondition = "AttachSessionReplay", ClampMin = "1000", ClampMax = "20000"))
 	uint32 SessionReplayDurationMs;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Session Replay",


### PR DESCRIPTION
This PR lowers the maximum allowed session replay clip duration (`SessionReplayDurationMs`) from 60 to 20 seconds to prevent issues with session replays being rejected due to Sentry's 10 MiB replay size cap, which can happen with default recording settings at high rendering resolutions. Since replays are delivered as part of crash handling, an oversized clip is dropped server-side with no client-visible error, leaving users without their replays and no hint as to why.

Measured clip sizes (default settings: 2000 kbps target, 30 fps, 0.5s keyframe interval) using [Unreal Demo](https://github.com/getsentry/unreal-tower):

| Scenario | Window | Clip size |
|---|---|---|
| 4K | 60s | **24.7 MB - rejected** |
| 4K | 30s | **12.5 MB - rejected** |
| 4K | 20s | 8.4 MB |

At 4K the encoder overshoots its target bitrate by ~65% (each frame hits the encoder's quality floor, so rate control can't hold the 2000 kbps budget), which is why the previous 60s maximum can produce undeliverable replays. With the 20s cap, the measured 4K worst case stays under the limit with ~2 MiB headroom.

Note that raising `BitrateKbps` or `Framerate` above the defaults still requires reducing the duration correspondingly; a docs update covering the size limit and these trade-offs is submitted separately in getsentry/sentry-docs#18742.
