### PR TITLE
feat(state-replay): experimental state-based session replay

### DIFF
--- a/plugin-dev/Source/Sentry/Private/StateReplay/SentryStateReplaySettings.cpp
+++ b/plugin-dev/Source/Sentry/Private/StateReplay/SentryStateReplaySettings.cpp
@@ -1,0 +1,13 @@
+// Copyright (c) 2026 Sentry. All Rights Reserved.
+
+#include "SentryStateReplaySettings.h"
+
+USentryStateReplaySettings::USentryStateReplaySettings()
+	: bEnabled(false)
+	, bAutoStart(true)
+	, SampleRateHz(10)
+	, bCaptureUI(true)
+	, OutputSubdir(TEXT("StateReplays"))
+	, FlushIntervalSeconds(1.0f)
+{
+}

--- a/plugin-dev/Source/Sentry/Private/StateReplay/SentryStateReplaySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/StateReplay/SentryStateReplaySubsystem.cpp
@@ -1,0 +1,695 @@
+// Copyright (c) 2026 Sentry. All Rights Reserved.
+
+#include "SentryStateReplaySubsystem.h"
+
+#include "SentryStateReplaySettings.h"
+
+#include "Blueprint/SlateBlueprintLibrary.h"
+#include "Blueprint/UserWidget.h"
+#include "Blueprint/WidgetLayoutLibrary.h"
+#include "Blueprint/WidgetTree.h"
+#include "Camera/PlayerCameraManager.h"
+#include "Components/EditableText.h"
+#include "Components/EditableTextBox.h"
+#include "Components/ProgressBar.h"
+#include "Components/TextBlock.h"
+#include "Components/Widget.h"
+#include "Containers/StringConv.h"
+#include "Engine/GameInstance.h"
+#include "Engine/World.h"
+#include "Framework/Application/IInputProcessor.h"
+#include "Framework/Application/SlateApplication.h"
+#include "GameFramework/Pawn.h"
+#include "GameFramework/PlayerController.h"
+#include "HAL/FileManager.h"
+#include "HAL/PlatformTime.h"
+#include "Input/Events.h"
+#include "Kismet/GameplayStatics.h"
+#include "Misc/App.h"
+#include "Misc/DateTime.h"
+#include "Misc/EngineVersion.h"
+#include "Misc/Paths.h"
+#include "Misc/ScopeLock.h"
+#include "UObject/UObjectIterator.h"
+
+DEFINE_LOG_CATEGORY_STATIC(LogSentryStateReplay, Log, All);
+
+/**
+ * Slate-level input pre-processor. Sees every pointer press before UMG routes
+ * it, so clicks on Blueprint menu buttons are captured even while gameplay is
+ * paused and the PlayerController receives no input. Never consumes events.
+ */
+class FSentryStateReplayInputProcessor : public IInputProcessor
+{
+public:
+	explicit FSentryStateReplayInputProcessor(USentryStateReplaySubsystem* InOwner)
+		: Owner(InOwner)
+	{
+	}
+
+	virtual void Tick(const float, FSlateApplication&, TSharedRef<ICursor>) override {}
+
+	virtual bool HandleMouseButtonDownEvent(FSlateApplication&, const FPointerEvent& MouseEvent) override
+	{
+		if (USentryStateReplaySubsystem* Sub = Owner.Get())
+		{
+			Sub->OnUIClick(MouseEvent.GetScreenSpacePosition(), MouseEvent.GetEffectingButton().ToString());
+		}
+		return false;
+	}
+
+	virtual const TCHAR* GetDebugName() const override { return TEXT("SentryStateReplay"); }
+
+private:
+	TWeakObjectPtr<USentryStateReplaySubsystem> Owner;
+};
+
+namespace
+{
+FString EscapeJson(const FString& In)
+{
+	FString Out;
+	Out.Reserve(In.Len() + 8);
+	for (const TCHAR Ch : In)
+	{
+		switch (Ch)
+		{
+		case '\"':
+			Out += TEXT("\\\"");
+			break;
+		case '\\':
+			Out += TEXT("\\\\");
+			break;
+		case '\n':
+			Out += TEXT("\\n");
+			break;
+		case '\r':
+			Out += TEXT("\\r");
+			break;
+		case '\t':
+			Out += TEXT("\\t");
+			break;
+		default:
+			if (Ch < 0x20)
+			{
+				Out += FString::Printf(TEXT("\\u%04x"), static_cast<int32>(Ch));
+			}
+			else
+			{
+				Out.AppendChar(Ch);
+			}
+		}
+	}
+	return Out;
+}
+
+FString Vec3(const FVector& V)
+{
+	return FString::Printf(TEXT("[%.2f,%.2f,%.2f]"), V.X, V.Y, V.Z);
+}
+
+FString Rot3(const FRotator& R)
+{
+	return FString::Printf(TEXT("[%.2f,%.2f,%.2f]"), R.Pitch, R.Yaw, R.Roll);
+}
+
+FString JsonObjFromMap(const TMap<FString, FString>& Data)
+{
+	FString Out = TEXT("{");
+	bool bFirst = true;
+	for (const TPair<FString, FString>& Pair : Data)
+	{
+		if (!bFirst)
+		{
+			Out += TEXT(",");
+		}
+		bFirst = false;
+		Out += FString::Printf(TEXT("\"%s\":\"%s\""), *EscapeJson(Pair.Key), *EscapeJson(Pair.Value));
+	}
+	Out += TEXT("}");
+	return Out;
+}
+
+// Extracts displayed text for the common text-bearing widget types.
+FString WidgetText(const UWidget* Widget)
+{
+	if (const UTextBlock* Tb = Cast<UTextBlock>(Widget))
+	{
+		return Tb->GetText().ToString();
+	}
+	if (const UEditableTextBox* Etb = Cast<UEditableTextBox>(Widget))
+	{
+		return Etb->GetText().ToString();
+	}
+	if (const UEditableText* Et = Cast<UEditableText>(Widget))
+	{
+		return Et->GetText().ToString();
+	}
+	return FString();
+}
+
+bool IsWidgetVisible(ESlateVisibility Vis)
+{
+	return Vis != ESlateVisibility::Collapsed && Vis != ESlateVisibility::Hidden;
+}
+} // namespace
+
+USentryStateReplaySubsystem* USentryStateReplaySubsystem::Get(const UObject* WorldContextObject)
+{
+	if (const UGameInstance* GameInstance = UGameplayStatics::GetGameInstance(WorldContextObject))
+	{
+		return GameInstance->GetSubsystem<USentryStateReplaySubsystem>();
+	}
+	return nullptr;
+}
+
+void USentryStateReplaySubsystem::Initialize(FSubsystemCollectionBase& Collection)
+{
+	Super::Initialize(Collection);
+
+	const USentryStateReplaySettings* Settings = GetDefault<USentryStateReplaySettings>();
+	bEnabled = Settings->bEnabled;
+	bAutoStart = Settings->bAutoStart;
+	bCaptureUI = Settings->bCaptureUI;
+	SampleRateHz = FMath::Clamp(Settings->SampleRateHz, 1, 120);
+	OutputSubdir = Settings->OutputSubdir.IsEmpty() ? TEXT("StateReplays") : Settings->OutputSubdir;
+	FlushIntervalSeconds = FMath::Max(0.1f, Settings->FlushIntervalSeconds);
+
+	if (!bEnabled)
+	{
+		return;
+	}
+
+	const float Period = 1.0f / static_cast<float>(SampleRateHz);
+	TickerHandle = FTSTicker::GetCoreTicker().AddTicker(
+		FTickerDelegate::CreateUObject(this, &USentryStateReplaySubsystem::Tick), Period);
+
+	UE_LOG(LogSentryStateReplay, Log, TEXT("State replay enabled (%d Hz, auto-start=%d)"), SampleRateHz, bAutoStart ? 1 : 0);
+}
+
+void USentryStateReplaySubsystem::Deinitialize()
+{
+	StopSession();
+
+	if (TickerHandle.IsValid())
+	{
+		FTSTicker::GetCoreTicker().RemoveTicker(TickerHandle);
+		TickerHandle.Reset();
+	}
+
+	Super::Deinitialize();
+}
+
+UWorld* USentryStateReplaySubsystem::ResolveGameWorld() const
+{
+	const UGameInstance* GameInstance = GetGameInstance();
+	return GameInstance ? GameInstance->GetWorld() : nullptr;
+}
+
+double USentryStateReplaySubsystem::Now() const
+{
+	return FPlatformTime::Seconds() - SessionStartSeconds;
+}
+
+bool USentryStateReplaySubsystem::Tick(float DeltaTime)
+{
+	UWorld* World = ResolveGameWorld();
+	if (!World)
+	{
+		return true;
+	}
+
+	if (!bSessionActive)
+	{
+		if (bAutoStart && World->GetFirstPlayerController() != nullptr)
+		{
+			StartSession(TEXT("auto"));
+		}
+		return true;
+	}
+
+	const FString MapName = World->RemovePIEPrefix(World->GetMapName());
+	if (MapName != CurrentMapName)
+	{
+		CurrentMapName = MapName;
+		AddEvent(TEXT("world"), TEXT("map_changed"), { { TEXT("map"), MapName } });
+	}
+
+	SampleFrame(World, Now());
+
+	const double NowSeconds = FPlatformTime::Seconds();
+	if (NowSeconds - LastFlushSeconds >= FlushIntervalSeconds)
+	{
+		FScopeLock Lock(&WriterLock);
+		if (FileWriter)
+		{
+			FileWriter->Flush();
+		}
+		LastFlushSeconds = NowSeconds;
+	}
+
+	return true;
+}
+
+void USentryStateReplaySubsystem::SampleFrame(UWorld* World, double SessionTime)
+{
+	FString Frame = FString::Printf(TEXT("{\"type\":\"frame\",\"t\":%.3f"), SessionTime);
+
+	const float FrameDelta = FApp::GetDeltaTime();
+	Frame += FString::Printf(TEXT(",\"perf\":{\"fps\":%.1f,\"ms\":%.2f}"),
+		FrameDelta > 0.f ? 1.f / FrameDelta : 0.f, FrameDelta * 1000.f);
+
+	if (const APlayerController* PC = World->GetFirstPlayerController())
+	{
+		if (const APawn* Pawn = PC->GetPawn())
+		{
+			Frame += FString::Printf(TEXT(",\"player\":{\"loc\":%s,\"rot\":%s}"),
+				*Vec3(Pawn->GetActorLocation()), *Rot3(Pawn->GetActorRotation()));
+		}
+
+		if (const APlayerCameraManager* Cam = PC->PlayerCameraManager)
+		{
+			Frame += FString::Printf(TEXT(",\"camera\":{\"loc\":%s,\"rot\":%s,\"fov\":%.1f}"),
+				*Vec3(Cam->GetCameraLocation()), *Rot3(Cam->GetCameraRotation()), Cam->GetFOVAngle());
+		}
+	}
+
+	// Tracked actors: prune dead weak refs (emitting a despawn) and serialize the rest.
+	int32 AliveEntities = 0;
+	TMap<FString, int32> TagCounts;
+	{
+		FString Actors;
+		bool bFirst = true;
+		for (int32 Index = TrackedActors.Num() - 1; Index >= 0; --Index)
+		{
+			const FTrackedActor& Tracked = TrackedActors[Index];
+			const AActor* Actor = Tracked.Actor.Get();
+			if (!Actor)
+			{
+				AddEvent(TEXT("actor"), TEXT("despawn"), { { TEXT("id"), Tracked.Id }, { TEXT("tag"), Tracked.Tag } });
+				TrackedActors.RemoveAt(Index);
+				continue;
+			}
+
+			++AliveEntities;
+			TagCounts.FindOrAdd(Tracked.Tag)++;
+
+			if (!bFirst)
+			{
+				Actors += TEXT(",");
+			}
+			bFirst = false;
+			Actors += FString::Printf(TEXT("{\"id\":\"%s\",\"tag\":\"%s\",\"loc\":%s,\"rot\":%s}"),
+				*EscapeJson(Tracked.Id), *EscapeJson(Tracked.Tag),
+				*Vec3(Actor->GetActorLocation()), *Rot3(Actor->GetActorRotation()));
+		}
+		if (!Actors.IsEmpty())
+		{
+			Frame += FString::Printf(TEXT(",\"actors\":[%s]"), *Actors);
+		}
+	}
+
+	// Game-state channel: auto entity counts + any user-provided SetState values.
+	{
+		FString StateJson;
+		bool bFirst = true;
+		auto AddNum = [&StateJson, &bFirst](const FString& Key, double Value)
+		{
+			StateJson += FString::Printf(TEXT("%s\"%s\":%g"), bFirst ? TEXT("") : TEXT(","), *EscapeJson(Key), Value);
+			bFirst = false;
+		};
+		AddNum(TEXT("entities"), AliveEntities);
+		for (const TPair<FString, int32>& KV : TagCounts)
+		{
+			AddNum(KV.Key, KV.Value);
+		}
+		for (const TPair<FString, float>& KV : NumericState)
+		{
+			AddNum(KV.Key, KV.Value);
+		}
+		for (const TPair<FString, FString>& KV : TextState)
+		{
+			StateJson += FString::Printf(TEXT("%s\"%s\":\"%s\""), bFirst ? TEXT("") : TEXT(","), *EscapeJson(KV.Key), *EscapeJson(KV.Value));
+			bFirst = false;
+		}
+		Frame += FString::Printf(TEXT(",\"state\":{%s}"), *StateJson);
+	}
+
+	if (bCaptureUI && FSlateApplication::IsInitialized())
+	{
+		const FVector2D ViewportSize = UWidgetLayoutLibrary::GetViewportSize(World);
+		Frame += FString::Printf(TEXT(",\"viewport\":[%.0f,%.0f]"), ViewportSize.X, ViewportSize.Y);
+
+		const double VW = FMath::Max(1.0, ViewportSize.X);
+		const double VH = FMath::Max(1.0, ViewportSize.Y);
+
+		FVector2D CursorPx, Unused;
+		USlateBlueprintLibrary::AbsoluteToViewport(World, FSlateApplication::Get().GetCursorPos(), CursorPx, Unused);
+		Frame += FString::Printf(TEXT(",\"mouse\":[%.4f,%.4f]"), CursorPx.X / VW, CursorPx.Y / VH);
+
+		// Detect top-level widget open/close for the event timeline.
+		TSet<FString> Tops;
+		for (TObjectIterator<UUserWidget> It; It; ++It)
+		{
+			const UUserWidget* Widget = *It;
+			if (IsValid(Widget) && Widget->GetWorld() == World && Widget->IsInViewport())
+			{
+				Tops.Add(Widget->GetClass()->GetName());
+			}
+		}
+		for (const FString& W : Tops)
+		{
+			if (!ActiveTopWidgets.Contains(W))
+			{
+				AddEvent(TEXT("ui"), TEXT("open"), { { TEXT("widget"), W } });
+			}
+		}
+		for (const FString& W : ActiveTopWidgets)
+		{
+			if (!Tops.Contains(W))
+			{
+				AddEvent(TEXT("ui"), TEXT("close"), { { TEXT("widget"), W } });
+			}
+		}
+		ActiveTopWidgets = MoveTemp(Tops);
+
+		FString UiArray;
+		CaptureUI(World, UiArray);
+		if (!UiArray.IsEmpty())
+		{
+			Frame += FString::Printf(TEXT(",\"ui\":[%s]"), *UiArray);
+		}
+	}
+
+	Frame += TEXT("}");
+	WriteLine(Frame);
+}
+
+void USentryStateReplaySubsystem::CaptureUI(UWorld* World, FString& Out)
+{
+	Out.Reset();
+
+	const FVector2D ViewportSize = UWidgetLayoutLibrary::GetViewportSize(World);
+	const double VW = FMath::Max(1.0, ViewportSize.X);
+	const double VH = FMath::Max(1.0, ViewportSize.Y);
+
+	constexpr int32 MaxWidgets = 256;
+	int32 Count = 0;
+	bool bFirst = true;
+
+	for (TObjectIterator<UUserWidget> It; It; ++It)
+	{
+		UUserWidget* Root = *It;
+		if (!IsValid(Root) || Root->GetWorld() != World || !Root->IsInViewport() || !Root->WidgetTree)
+		{
+			continue;
+		}
+
+		const FString RootName = Root->GetClass()->GetName();
+		Root->WidgetTree->ForEachWidget([&](UWidget* Widget)
+		{
+			if (!Widget || Count >= MaxWidgets || !IsWidgetVisible(Widget->GetVisibility()))
+			{
+				return;
+			}
+
+			const FGeometry& Geometry = Widget->GetCachedGeometry();
+			const FVector2D LocalSize = Geometry.GetLocalSize();
+			if (LocalSize.X < 1.0 || LocalSize.Y < 1.0)
+			{
+				return;
+			}
+
+			FVector2D TopLeftPx, BottomRightPx, Unused;
+			USlateBlueprintLibrary::AbsoluteToViewport(World, Geometry.LocalToAbsolute(FVector2D::ZeroVector), TopLeftPx, Unused);
+			USlateBlueprintLibrary::AbsoluteToViewport(World, Geometry.LocalToAbsolute(LocalSize), BottomRightPx, Unused);
+
+			const double NX = TopLeftPx.X / VW;
+			const double NY = TopLeftPx.Y / VH;
+			const double NW = (BottomRightPx.X - TopLeftPx.X) / VW;
+			const double NH = (BottomRightPx.Y - TopLeftPx.Y) / VH;
+
+			if (!bFirst)
+			{
+				Out += TEXT(",");
+			}
+			bFirst = false;
+
+			Out += FString::Printf(TEXT("{\"n\":\"%s/%s\",\"t\":\"%s\",\"r\":[%.4f,%.4f,%.4f,%.4f]"),
+				*EscapeJson(RootName), *EscapeJson(Widget->GetName()), *EscapeJson(Widget->GetClass()->GetName()),
+				NX, NY, NW, NH);
+
+			const FString Text = WidgetText(Widget);
+			if (!Text.IsEmpty())
+			{
+				Out += FString::Printf(TEXT(",\"text\":\"%s\""), *EscapeJson(Text.Left(120)));
+			}
+			if (Widget->IsHovered())
+			{
+				Out += TEXT(",\"hover\":1");
+			}
+			if (!Widget->GetIsEnabled())
+			{
+				Out += TEXT(",\"disabled\":1");
+			}
+			if (const UProgressBar* ProgressBar = Cast<UProgressBar>(Widget))
+			{
+				Out += FString::Printf(TEXT(",\"pct\":%.3f"), ProgressBar->GetPercent());
+			}
+			Out += TEXT("}");
+
+			++Count;
+		});
+	}
+}
+
+FString USentryStateReplaySubsystem::ResolveWidgetAt(const FVector2D& ScreenPos, UWorld* World) const
+{
+	FString Best;
+	double BestArea = TNumericLimits<double>::Max();
+
+	for (TObjectIterator<UUserWidget> It; It; ++It)
+	{
+		UUserWidget* Root = *It;
+		if (!IsValid(Root) || Root->GetWorld() != World || !Root->IsInViewport() || !Root->WidgetTree)
+		{
+			continue;
+		}
+
+		const FString RootName = Root->GetClass()->GetName();
+		Root->WidgetTree->ForEachWidget([&](UWidget* Widget)
+		{
+			if (!Widget)
+			{
+				return;
+			}
+			const ESlateVisibility Vis = Widget->GetVisibility();
+			if (!IsWidgetVisible(Vis) || Vis == ESlateVisibility::HitTestInvisible)
+			{
+				return;
+			}
+			const FGeometry& Geometry = Widget->GetCachedGeometry();
+			const FVector2D LocalSize = Geometry.GetLocalSize();
+			if (LocalSize.X < 1.0 || LocalSize.Y < 1.0)
+			{
+				return;
+			}
+			if (Geometry.IsUnderLocation(ScreenPos))
+			{
+				const double Area = LocalSize.X * LocalSize.Y;
+				if (Area < BestArea)
+				{
+					BestArea = Area;
+					Best = RootName + TEXT("/") + Widget->GetName();
+				}
+			}
+		});
+	}
+
+	return Best;
+}
+
+void USentryStateReplaySubsystem::OnUIClick(const FVector2D& ScreenPos, const FString& Button)
+{
+	if (!bSessionActive)
+	{
+		return;
+	}
+	UWorld* World = ResolveGameWorld();
+	if (!World)
+	{
+		return;
+	}
+
+	const FString Widget = ResolveWidgetAt(ScreenPos, World);
+
+	FVector2D Px, Unused;
+	USlateBlueprintLibrary::AbsoluteToViewport(World, ScreenPos, Px, Unused);
+	const FVector2D ViewportSize = UWidgetLayoutLibrary::GetViewportSize(World);
+	const float VW = FMath::Max(1.0f, static_cast<float>(ViewportSize.X));
+	const float VH = FMath::Max(1.0f, static_cast<float>(ViewportSize.Y));
+
+	AddEvent(TEXT("ui"), TEXT("click"), {
+											{ TEXT("widget"), Widget.IsEmpty() ? TEXT("(world)") : Widget },
+											{ TEXT("button"), Button },
+											{ TEXT("x"), FString::Printf(TEXT("%.4f"), Px.X / VW) },
+											{ TEXT("y"), FString::Printf(TEXT("%.4f"), Px.Y / VH) },
+										});
+}
+
+void USentryStateReplaySubsystem::StartSession(const FString& Label)
+{
+	if (bSessionActive)
+	{
+		return;
+	}
+
+	const FDateTime NowUtc = FDateTime::UtcNow();
+	const FString Stamp = NowUtc.ToString(TEXT("%Y%m%d-%H%M%S"));
+	const FString SafeLabel = Label.IsEmpty() ? TEXT("session") : Label;
+	const FString FileName = FString::Printf(TEXT("session-%s-%s.jsonl"), *Stamp, *SafeLabel);
+
+	SessionFilePath = FPaths::Combine(FPaths::ProjectSavedDir(), OutputSubdir, FileName);
+	IFileManager::Get().MakeDirectory(*FPaths::GetPath(SessionFilePath), true);
+
+	{
+		FScopeLock Lock(&WriterLock);
+		FileWriter.Reset(IFileManager::Get().CreateFileWriter(*SessionFilePath, FILEWRITE_EvenIfReadOnly));
+	}
+	if (!FileWriter)
+	{
+		UE_LOG(LogSentryStateReplay, Warning, TEXT("State replay: failed to open %s"), *SessionFilePath);
+		return;
+	}
+
+	SessionStartSeconds = FPlatformTime::Seconds();
+	LastFlushSeconds = SessionStartSeconds;
+	bSessionActive = true;
+	ActiveTopWidgets.Reset();
+
+	UWorld* World = ResolveGameWorld();
+	CurrentMapName = World ? World->RemovePIEPrefix(World->GetMapName()) : FString();
+
+	const FString Header = FString::Printf(
+		TEXT("{\"type\":\"header\",\"schema\":2,\"sdk\":\"sentry-unreal-state-replay\",\"version\":\"0.2.0\",")
+			TEXT("\"session\":\"%s\",\"startedAtUnix\":%lld,\"startedAtIso\":\"%s\",\"game\":\"%s\",\"map\":\"%s\",")
+				TEXT("\"engine\":\"%s\",\"sampleRateHz\":%d,\"units\":\"cm\",\"coordinateSystem\":\"unreal-left-handed-z-up\",")
+					TEXT("\"rotationOrder\":\"pitch_yaw_roll_deg\",\"uiCoords\":\"viewport-normalized-0-1\"}"),
+		*EscapeJson(SafeLabel), NowUtc.ToUnixTimestamp(), *NowUtc.ToIso8601(),
+		*EscapeJson(FApp::GetProjectName()), *EscapeJson(CurrentMapName),
+		*EscapeJson(FEngineVersion::Current().ToString()), SampleRateHz);
+
+	{
+		FScopeLock Lock(&WriterLock);
+		WriteLineUnlocked(Header);
+	}
+
+	if (FSlateApplication::IsInitialized())
+	{
+		InputProcessor = MakeShared<FSentryStateReplayInputProcessor>(this);
+		FSlateApplication::Get().RegisterInputPreProcessor(InputProcessor);
+	}
+
+	UE_LOG(LogSentryStateReplay, Log, TEXT("State replay session started: %s"), *SessionFilePath);
+}
+
+void USentryStateReplaySubsystem::StopSession()
+{
+	if (!bSessionActive)
+	{
+		return;
+	}
+	bSessionActive = false;
+
+	if (InputProcessor.IsValid())
+	{
+		if (FSlateApplication::IsInitialized())
+		{
+			FSlateApplication::Get().UnregisterInputPreProcessor(InputProcessor);
+		}
+		InputProcessor.Reset();
+	}
+
+	FScopeLock Lock(&WriterLock);
+	if (FileWriter)
+	{
+		FileWriter->Flush();
+		FileWriter->Close();
+		FileWriter.Reset();
+	}
+	TrackedActors.Reset();
+	NumericState.Reset();
+	TextState.Reset();
+
+	UE_LOG(LogSentryStateReplay, Log, TEXT("State replay session stopped: %s"), *SessionFilePath);
+}
+
+void USentryStateReplaySubsystem::AddEvent(const FString& Category, const FString& Name, const TMap<FString, FString>& Data)
+{
+	if (!bSessionActive)
+	{
+		return;
+	}
+
+	const FString Line = FString::Printf(
+		TEXT("{\"type\":\"event\",\"t\":%.3f,\"category\":\"%s\",\"name\":\"%s\",\"data\":%s}"),
+		Now(), *EscapeJson(Category), *EscapeJson(Name), *JsonObjFromMap(Data));
+	WriteLine(Line);
+}
+
+void USentryStateReplaySubsystem::AddTrackedActor(AActor* Actor, const FString& Id, const FString& Tag)
+{
+	if (!IsValid(Actor))
+	{
+		return;
+	}
+	for (const FTrackedActor& Existing : TrackedActors)
+	{
+		if (Existing.Actor.Get() == Actor)
+		{
+			return;
+		}
+	}
+	TrackedActors.Add(FTrackedActor{ Actor, Id, Tag });
+	AddEvent(TEXT("actor"), TEXT("spawn"), { { TEXT("id"), Id }, { TEXT("tag"), Tag } });
+}
+
+void USentryStateReplaySubsystem::RemoveTrackedActor(AActor* Actor)
+{
+	for (int32 Index = 0; Index < TrackedActors.Num(); ++Index)
+	{
+		if (TrackedActors[Index].Actor.Get() == Actor)
+		{
+			TrackedActors.RemoveAt(Index);
+			return;
+		}
+	}
+}
+
+void USentryStateReplaySubsystem::SetState(const FString& Key, float Value)
+{
+	NumericState.Add(Key, Value);
+}
+
+void USentryStateReplaySubsystem::SetStateString(const FString& Key, const FString& Value)
+{
+	TextState.Add(Key, Value);
+}
+
+void USentryStateReplaySubsystem::WriteLine(const FString& Line)
+{
+	FScopeLock Lock(&WriterLock);
+	WriteLineUnlocked(Line);
+}
+
+void USentryStateReplaySubsystem::WriteLineUnlocked(const FString& Line)
+{
+	if (!FileWriter)
+	{
+		return;
+	}
+	FTCHARToUTF8 Utf8(*Line);
+	FileWriter->Serialize(const_cast<ANSICHAR*>(reinterpret_cast<const ANSICHAR*>(Utf8.Get())), Utf8.Length());
+	uint8 Newline = '\n';
+	FileWriter->Serialize(&Newline, 1);
+}

--- a/plugin-dev/Source/Sentry/Public/SentryStateReplaySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentryStateReplaySettings.h
@@ -1,0 +1,61 @@
+// Copyright (c) 2026 Sentry. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Engine/DeveloperSettings.h"
+
+#include "SentryStateReplaySettings.generated.h"
+
+/**
+ * Settings for the experimental state-based session replay.
+ *
+ * Unlike the video-based session replay, this samples a compact, structured
+ * snapshot of gameplay state (player/camera transforms, active UI, tracked
+ * actors, gameplay events) every frame and streams it to a local newline-
+ * delimited JSON (JSONL) file. The format is trivially parseable by tools,
+ * AI agents, and the bundled local player.
+ *
+ * This v0 is a local, developer-facing capture; it does not upload anything.
+ */
+UCLASS(Config = Engine, DefaultConfig, meta = (DisplayName = "Sentry State Replay"))
+class SENTRY_API USentryStateReplaySettings : public UDeveloperSettings
+{
+	GENERATED_BODY()
+
+public:
+	USentryStateReplaySettings();
+
+	virtual FName GetCategoryName() const override { return TEXT("Plugins"); }
+
+	/** Master switch for local state-replay capture. */
+	UPROPERTY(Config, EditAnywhere, Category = "State Replay",
+		Meta = (DisplayName = "Enable state replay (experimental)",
+			ToolTip = "Stream a structured snapshot of gameplay state to a local JSONL file for debugging and AI-assisted analysis."))
+	bool bEnabled;
+
+	/** Start a session automatically as soon as a local player exists. */
+	UPROPERTY(Config, EditAnywhere, Category = "State Replay",
+		Meta = (DisplayName = "Auto-start session", EditCondition = "bEnabled"))
+	bool bAutoStart;
+
+	/** How many state samples to record per second. */
+	UPROPERTY(Config, EditAnywhere, Category = "State Replay",
+		Meta = (DisplayName = "Sample rate (Hz)", EditCondition = "bEnabled", ClampMin = "1", ClampMax = "120"))
+	int32 SampleRateHz;
+
+	/** Capture the set of active UMG user widgets in each frame. */
+	UPROPERTY(Config, EditAnywhere, Category = "State Replay",
+		Meta = (DisplayName = "Capture UI widgets", EditCondition = "bEnabled"))
+	bool bCaptureUI;
+
+	/** Directory (relative to the project's Saved dir) where sessions are written. */
+	UPROPERTY(Config, EditAnywhere, Category = "State Replay",
+		Meta = (DisplayName = "Output subdirectory", EditCondition = "bEnabled"))
+	FString OutputSubdir;
+
+	/** How often (seconds) the JSONL file is flushed to disk. */
+	UPROPERTY(Config, EditAnywhere, Category = "State Replay",
+		Meta = (DisplayName = "Flush interval (seconds)", EditCondition = "bEnabled", ClampMin = "0.1", ClampMax = "10.0", AdvancedDisplay))
+	float FlushIntervalSeconds;
+};

--- a/plugin-dev/Source/Sentry/Public/SentryStateReplaySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentryStateReplaySubsystem.h
@@ -1,0 +1,127 @@
+// Copyright (c) 2026 Sentry. All Rights Reserved.
+
+#pragma once
+
+#include "Containers/Ticker.h"
+#include "CoreMinimal.h"
+#include "Subsystems/GameInstanceSubsystem.h"
+#include "UObject/WeakObjectPtr.h"
+
+#include "SentryStateReplaySubsystem.generated.h"
+
+class AActor;
+class UWorld;
+class FSentryStateReplayInputProcessor;
+
+/**
+ * Records a local, state-based session replay.
+ *
+ * Each session is a newline-delimited JSON (JSONL) file: a single `header`
+ * line followed by `frame` lines (sampled at the configured rate) and `event`
+ * lines (pushed by gameplay code or the UI capture). Frames auto-capture the
+ * local pawn transform, camera point-of-view, active UMG widgets, the cursor
+ * position, and any actors registered via AddTrackedActor.
+ *
+ * UI interaction is captured at the Slate level via an input pre-processor, so
+ * clicks on Blueprint (UMG) menu buttons are recorded even while gameplay is
+ * paused and the PlayerController receives no input.
+ *
+ * The subsystem is engine-agnostic (pure Unreal APIs) and does not touch the
+ * crash pipeline; it is a developer/AI debugging tool that runs entirely
+ * locally. Product integration (crash-attachment, upload) is intentionally
+ * out of scope for this version.
+ */
+UCLASS()
+class SENTRY_API USentryStateReplaySubsystem : public UGameInstanceSubsystem
+{
+	GENERATED_BODY()
+
+public:
+	/** Convenience accessor from any object with a world context. */
+	static USentryStateReplaySubsystem* Get(const UObject* WorldContextObject);
+
+	// UGameInstanceSubsystem
+	virtual void Initialize(FSubsystemCollectionBase& Collection) override;
+	virtual void Deinitialize() override;
+
+	/** Begins a new capture session, writing to a fresh JSONL file. No-op if already recording. */
+	UFUNCTION(BlueprintCallable, Category = "Sentry|State Replay")
+	void StartSession(const FString& Label);
+
+	/** Ends the current session and flushes the file. */
+	UFUNCTION(BlueprintCallable, Category = "Sentry|State Replay")
+	void StopSession();
+
+	UFUNCTION(BlueprintPure, Category = "Sentry|State Replay")
+	bool IsRecording() const { return bSessionActive; }
+
+	/** Absolute path of the JSONL file for the active (or most recent) session. */
+	UFUNCTION(BlueprintPure, Category = "Sentry|State Replay")
+	FString GetSessionFilePath() const { return SessionFilePath; }
+
+	/** Records a semantic gameplay event (e.g. "combat"/"turret_fire") into the stream. */
+	UFUNCTION(BlueprintCallable, Category = "Sentry|State Replay")
+	void AddEvent(const FString& Category, const FString& Name, const TMap<FString, FString>& Data);
+
+	/** Starts sampling an actor's transform into every frame under a stable id/tag. */
+	UFUNCTION(BlueprintCallable, Category = "Sentry|State Replay")
+	void AddTrackedActor(AActor* Actor, const FString& Id, const FString& Tag);
+
+	/** Stops sampling a previously tracked actor. */
+	UFUNCTION(BlueprintCallable, Category = "Sentry|State Replay")
+	void RemoveTrackedActor(AActor* Actor);
+
+	/** Sets a numeric game-state channel sampled into every frame's `state` (e.g. "score", "wave", "health"). */
+	UFUNCTION(BlueprintCallable, Category = "Sentry|State Replay")
+	void SetState(const FString& Key, float Value);
+
+	/** Sets a string game-state channel sampled into every frame's `state`. */
+	UFUNCTION(BlueprintCallable, Category = "Sentry|State Replay")
+	void SetStateString(const FString& Key, const FString& Value);
+
+	/** Called by the Slate input pre-processor on a mouse-button press (any widget, incl. UMG). */
+	void OnUIClick(const FVector2D& ScreenPos, const FString& Button);
+
+private:
+	struct FTrackedActor
+	{
+		TWeakObjectPtr<AActor> Actor;
+		FString Id;
+		FString Tag;
+	};
+
+	bool Tick(float DeltaTime);
+	UWorld* ResolveGameWorld() const;
+	void SampleFrame(UWorld* World, double SessionTime);
+	void CaptureUI(UWorld* World, FString& OutUiArray);
+	FString ResolveWidgetAt(const FVector2D& ScreenPos, UWorld* World) const;
+	void WriteLine(const FString& Line);
+	void WriteLineUnlocked(const FString& Line);
+	double Now() const;
+
+	// Config snapshot (read once at Initialize)
+	bool bEnabled = false;
+	bool bAutoStart = true;
+	bool bCaptureUI = true;
+	int32 SampleRateHz = 10;
+	FString OutputSubdir;
+	float FlushIntervalSeconds = 1.0f;
+
+	// Runtime state (game thread)
+	FTSTicker::FDelegateHandle TickerHandle;
+	bool bSessionActive = false;
+	double SessionStartSeconds = 0.0;
+	double LastFlushSeconds = 0.0;
+	FString SessionFilePath;
+	FString CurrentMapName;
+	TArray<FTrackedActor> TrackedActors;
+	TMap<FString, float> NumericState;
+	TMap<FString, FString> TextState;
+	TSet<FString> ActiveTopWidgets;
+	TSharedPtr<FSentryStateReplayInputProcessor> InputProcessor;
+
+	// Guards the file writer + event/tracked mutations (writes may arrive from
+	// gameplay code; sampling runs on the game-thread ticker).
+	FCriticalSection WriterLock;
+	TUniquePtr<FArchive> FileWriter;
+};

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -39,8 +39,11 @@ public class Sentry : ModuleRules
 				"Projects",
 				"Json",
 				"JsonUtilities",
-				"HTTP"
-				// ... add private dependencies that you statically link with here ...	
+				"HTTP",
+				"UMG",
+				"DeveloperSettings",
+				"InputCore"
+				// ... add private dependencies that you statically link with here ...
 			}
 		);
 

--- a/tools/state-replay-player/.gitignore
+++ b/tools/state-replay-player/.gitignore
@@ -1,0 +1,3 @@
+# Vendored three.js (used for the 3D view). Fetched on demand — not committed.
+# The viewer falls back to a 2D top-down view when it is absent.
+three.min.js

--- a/tools/state-replay-player/README.md
+++ b/tools/state-replay-player/README.md
@@ -1,0 +1,95 @@
+# Sentry State Replay — local player (v0, experimental)
+
+State-based session replay for Unreal: instead of recording video, the SDK
+samples a compact, structured snapshot of gameplay state each frame and streams
+it to a local **newline-delimited JSON (JSONL)** file. It's cheap enough to run
+continuously in dev, trivially parseable by tools and AI agents, and replayable
+in the bundled offline viewer.
+
+This is a **local developer/debugging tool**. It does not upload anything and
+does not touch the crash pipeline (that's a later phase).
+
+## SDK feature
+
+- `USentryStateReplaySettings` (Project Settings → Plugins → *Sentry State Replay*)
+- `USentryStateReplaySubsystem` (`UGameInstanceSubsystem`) — samples the local
+  pawn transform, camera POV, active UMG widgets, and any tracked actors.
+
+Enable via config:
+
+```ini
+[/Script/Sentry.SentryStateReplaySettings]
+bEnabled=True
+bAutoStart=True
+SampleRateHz=15
+bCaptureUI=True
+OutputSubdir=StateReplays
+```
+
+Sessions are written to `<Project>/Saved/<OutputSubdir>/session-<utc>-<label>.jsonl`.
+
+### API (C++ / Blueprint)
+
+```cpp
+if (auto* SR = USentryStateReplaySubsystem::Get(this))
+{
+    SR->StartSession(TEXT("boss_fight"));        // if not auto-starting
+    SR->AddTrackedActor(Enemy, Enemy->GetName(), TEXT("enemy"));
+    SR->AddEvent(TEXT("combat"), TEXT("turret_fire"), { {TEXT("turret"), TEXT("1")} });
+    SR->StopSession();
+}
+```
+
+`AddTrackedActor` streams that actor's transform into every frame; the subsystem
+auto-emits an `actor/despawn` event when the actor is destroyed.
+
+## JSONL format (schema 1)
+
+One `header` line, then interleaved `frame` (sampled) and `event` (pushed) lines.
+
+```jsonc
+{"type":"header","schema":1,"game":"SentryTower","map":"Main","engine":"5.8...","sampleRateHz":15,"units":"cm","coordinateSystem":"unreal-left-handed-z-up","rotationOrder":"pitch_yaw_roll_deg", ...}
+{"type":"frame","t":0.84,"player":{"loc":[x,y,z],"rot":[pitch,yaw,roll]},"camera":{"loc":[...],"rot":[...],"fov":90.0},"actors":[{"id":"Enemy_0","tag":"enemy","loc":[...],"rot":[...]}],"ui":["W_HUD_C"]}
+{"type":"event","t":0.80,"category":"actor","name":"spawn","data":{"id":"Enemy_0","tag":"enemy"}}
+```
+
+Units are centimeters; rotations are degrees `[pitch, yaw, roll]`; the coordinate
+system is Unreal's left-handed, Z-up.
+
+## Local player
+
+Open `index.html` in any browser (no server) and drop a `session-*.jsonl` file
+onto it — or use the file picker. A product-style dashboard driven by one shared
+timeline (play / scrub / speed / keyboard):
+
+- **World** — 3D reconstruction with low-poly stand-in assets (tower, enemies),
+  ground grid, camera-frustum gizmo, motion trails, orbit controls, and a
+  **POV** button that reproduces the player's captured camera. Falls back to a
+  2D top-down view if WebGL/three.js is unavailable.
+- **Game screen** — letterboxed UMG reconstruction: widget rects colored by
+  type, text in place, hover/disabled state, progress-bar fills, live cursor,
+  click pings.
+- **Event timeline** — gameplay + UI events (click to seek).
+- **Telemetry** — FPS / entity-count sparklines + event ticks (click to seek).
+- **✨ AI digest** — one-click deterministic session summary to copy to an agent.
+
+```bash
+open tools/state-replay-player/index.html
+```
+
+For a one-click, self-contained view (three.js + session inlined, auto-renders):
+
+```bash
+./tools/state-replay-player/bake-view.sh [path/to/session.jsonl]
+```
+
+### 3D view dependency
+
+The 3D world uses [three.js](https://threejs.org). It is **not committed**
+(`.gitignore`d); fetch it once next to `index.html` — the viewer degrades to the
+2D top-down view without it:
+
+```bash
+curl -fsSL -o tools/state-replay-player/three.min.js \
+  https://unpkg.com/three@0.160.0/build/three.min.js
+```

--- a/tools/state-replay-player/bake-view.sh
+++ b/tools/state-replay-player/bake-view.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Bake a state-replay JSONL session into a self-contained, auto-rendering HTML
+# (three.js + session inlined) and open it.
+# Usage: ./bake-view.sh [path/to/session.jsonl]   (defaults to newest in <demo>/Saved/StateReplays)
+set -euo pipefail
+HERE="$(cd "$(dirname "$0")" && pwd)"
+DEFAULT_DIR="$HOME/unreal/Saved/StateReplays"
+SESSION="${1:-$(ls -t "$DEFAULT_DIR"/*.jsonl 2>/dev/null | head -1)}"
+[ -n "${SESSION:-}" ] && [ -f "$SESSION" ] || { echo "No session found. Pass a .jsonl path."; exit 1; }
+OUT="${SESSION%.jsonl}-view.html"
+python3 - "$HERE/index.html" "$SESSION" "$OUT" "$HERE/three.min.js" <<'PY'
+import sys, os
+viewer, session, out = sys.argv[1:4]
+threejs = sys.argv[4] if len(sys.argv) > 4 else None
+html = open(viewer, encoding='utf-8').read()
+if threejs and os.path.exists(threejs):
+    tj = open(threejs, encoding='utf-8').read().replace('</', '<\\/')
+    html = html.replace('<script src="three.min.js"></script>', '<script>'+tj+'</script>', 1)
+data = open(session, encoding='utf-8').read().replace('</', '<\\/')
+embed = '<script type="application/jsonl" id="embedded-session">\n'+data+'\n</script>\n<script>\n"use strict";'
+html = html.replace('<script>\n"use strict";', embed, 1)
+open(out, 'w', encoding='utf-8').write(html)
+print("baked:", out, round(os.path.getsize(out)/1024), "KB")
+PY
+open "$OUT" 2>/dev/null || echo "Open manually: $OUT"

--- a/tools/state-replay-player/index.html
+++ b/tools/state-replay-player/index.html
@@ -1,0 +1,455 @@
+<!DOCTYPE html>
+<!-- Copyright (c) 2026 Sentry. All Rights Reserved. -->
+<!--
+  Sentry State Replay — local player
+
+  Offline viewer for the JSONL sessions produced by the Unreal SDK's
+  USentryStateReplaySubsystem. Drag a session-*.jsonl file onto the window.
+
+  Panes (one shared timeline):
+    • World      — 3D reconstruction with low-poly stand-in assets (tower,
+                   enemies), ground grid, camera frustum, trails, orbit + a
+                   "player POV" mode that reproduces the in-game camera.
+                   Falls back to a 2D top-down view if WebGL/three.js is absent.
+    • Game screen — UMG UI reconstruction (rects, text, hover/disabled,
+                   progress %, live cursor, click pings).
+    • Events     — gameplay + UI event timeline (click to seek).
+    • Telemetry  — FPS / entity-count sparklines + event ticks (click to seek).
+    • AI digest  — one-click deterministic session summary for humans or agents.
+
+  three.js (if present next to this file, or inlined by bake-view.sh) powers 3D.
+-->
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Sentry State Replay — Local Player</title>
+<script src="three.min.js"></script>
+<style>
+  :root { --bg:#14141e; --panel:#222236; --panel2:#2c2c46; --ink:#e7e7f0; --muted:#9a9ab5;
+          --accent:#7b6ef6; --player:#4ad991; --camera:#57b6ff; --grid:#2c2c44; --line:#0c0c14; }
+  * { box-sizing:border-box; }
+  html,body { margin:0; height:100%; font:13px/1.45 -apple-system,Segoe UI,Roboto,sans-serif;
+              background:var(--bg); color:var(--ink); overflow:hidden; }
+  #app { display:grid; grid-template-rows:auto 1fr auto auto; height:100%; }
+  header { display:flex; gap:16px; align-items:center; padding:8px 14px; background:var(--panel); border-bottom:1px solid var(--line); }
+  header h1 { font-size:14px; margin:0; font-weight:600; white-space:nowrap; }
+  header h1 span { color:var(--accent); }
+  #meta { color:var(--muted); font-size:12px; display:flex; gap:14px; flex-wrap:wrap; align-items:center; }
+  #meta b { color:var(--ink); font-weight:600; }
+  .grow { flex:1; }
+
+  #main { display:grid; grid-template-columns:1.5fr 1fr; min-height:0; }
+  #rightCol { display:grid; grid-template-rows:1.15fr 1fr; min-height:0; min-width:0; }
+  .pane { display:flex; flex-direction:column; min-height:0; min-width:0; border-left:1px solid var(--line); }
+  #worldPane { border-left:0; }
+  #eventsPane { border-top:1px solid var(--line); }
+  .pane-h { padding:6px 12px; font-size:11px; text-transform:uppercase; letter-spacing:.7px; color:var(--muted);
+            background:var(--panel); border-bottom:1px solid var(--line); display:flex; justify-content:space-between; align-items:center; gap:10px; }
+  .pane-h .dot { width:8px; height:8px; border-radius:50%; display:inline-block; margin-right:7px; vertical-align:middle; }
+  .pane-h .r { color:var(--muted); text-transform:none; letter-spacing:0; font-size:11px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; max-width:50%; }
+  .tg { display:flex; gap:6px; }
+  .tg button { background:var(--panel2); border:1px solid #3a3a5a; color:var(--muted); padding:2px 9px; font-size:11px; border-radius:5px; cursor:pointer; }
+  .tg button.on { background:var(--accent); color:#fff; border-color:var(--accent); }
+  .cwrap { position:relative; flex:1; min-height:0; }
+  canvas.fill { position:absolute; inset:0; width:100%; height:100%; display:block; }
+
+  #events { flex:1; overflow:auto; min-height:0; }
+  .ev { padding:4px 12px; border-bottom:1px solid #1e1e30; display:flex; gap:8px; align-items:baseline; cursor:pointer; }
+  .ev:hover { background:#26263e; }
+  .ev .t { color:var(--muted); font-variant-numeric:tabular-nums; min-width:52px; }
+  .ev .cat { color:var(--accent); font-weight:600; }
+  .ev .data { color:var(--muted); font-size:11px; }
+  .ev.recent { background:#2a2a46; }
+  .ev.ui .cat { color:#ffd54a; } .ev.combat .cat { color:#ff8a6a; }
+
+  #telemetry { height:76px; background:var(--panel); border-top:1px solid var(--line); position:relative; }
+  #telemetry canvas { position:absolute; inset:0; width:100%; height:100%; cursor:pointer; }
+
+  footer { display:flex; gap:12px; align-items:center; padding:8px 14px; background:var(--panel); border-top:1px solid var(--line); }
+  button.act { background:var(--accent); color:#fff; border:0; border-radius:6px; padding:6px 14px; font-size:13px; cursor:pointer; }
+  button.ghost { background:var(--panel2); color:var(--ink); border:1px solid #3a3a5a; border-radius:6px; padding:6px 12px; font-size:13px; cursor:pointer; }
+  #scrub { flex:1; accent-color:var(--accent); }
+  #clock { font-variant-numeric:tabular-nums; color:var(--muted); min-width:118px; text-align:right; }
+  select { background:var(--panel2); color:var(--ink); border:1px solid #3a3a5a; border-radius:6px; padding:5px; }
+  input[type=file] { color:var(--muted); font-size:12px; }
+
+  #drop { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; flex-direction:column;
+          gap:8px; color:var(--muted); text-align:center; pointer-events:none; padding:20px; }
+  #drop .big { font-size:16px; color:var(--ink); } #drop.hide { display:none; }
+  .legend { position:absolute; left:10px; bottom:10px; background:#0009; border:1px solid #333; border-radius:8px; padding:8px 10px; font-size:11px; color:var(--muted); pointer-events:none; }
+  .legend i { display:inline-block; width:9px; height:9px; border-radius:50%; margin-right:6px; vertical-align:middle; }
+  .hint3d { position:absolute; right:10px; bottom:10px; background:#0009; border:1px solid #333; border-radius:8px; padding:6px 9px; font-size:10px; color:var(--muted); pointer-events:none; }
+
+  #modal { position:fixed; inset:0; background:#000a; display:none; align-items:center; justify-content:center; z-index:20; }
+  #modal.show { display:flex; }
+  #digest { background:var(--panel); border:1px solid #3a3a5a; border-radius:12px; width:min(680px,92vw); max-height:82vh; display:flex; flex-direction:column; }
+  #digest .h { padding:12px 16px; border-bottom:1px solid var(--line); display:flex; justify-content:space-between; align-items:center; }
+  #digest .h b { color:var(--accent); }
+  #digest pre { margin:0; padding:16px; overflow:auto; white-space:pre-wrap; font:12px/1.5 ui-monospace,Menlo,monospace; color:var(--ink); }
+  #digest .f { padding:10px 16px; border-top:1px solid var(--line); display:flex; gap:10px; justify-content:flex-end; }
+</style>
+</head>
+<body>
+<div id="app">
+  <header>
+    <h1>Sentry <span>State Replay</span></h1>
+    <div id="meta"><input type="file" id="file" accept=".jsonl,.json,.txt" /></div>
+    <div class="grow"></div>
+    <button class="ghost" id="aiBtn" title="Generate a session summary for humans or AI agents">✨ AI digest</button>
+  </header>
+
+  <div id="main">
+    <section class="pane" id="worldPane">
+      <div class="pane-h">
+        <span><i class="dot" style="background:var(--player)"></i>World · reconstruction</span>
+        <span class="tg">
+          <button id="m3d" class="on">3D</button><button id="m2d">2D</button>
+          <button id="mpov" title="See the scene from the player's captured camera">POV</button>
+        </span>
+      </div>
+      <div class="cwrap">
+        <canvas id="world3d" class="fill"></canvas>
+        <canvas id="world2d" class="fill" style="display:none"></canvas>
+        <div class="legend">
+          <div><i style="background:var(--player)"></i>player/tower &nbsp; <i style="background:var(--camera)"></i>camera</div>
+          <div id="legendTags"></div>
+        </div>
+        <div class="hint3d" id="hint3d">drag: orbit · wheel: zoom · right-drag: pan</div>
+        <div id="drop"><div class="big">Drop a <code>session-*.jsonl</code> file here</div>
+          <div>or use the file picker &nbsp;·&nbsp; from <code>&lt;Project&gt;/Saved/StateReplays/</code></div></div>
+      </div>
+    </section>
+
+    <div id="rightCol">
+      <section class="pane" id="screenPane">
+        <div class="pane-h"><span><i class="dot" style="background:#ffd54a"></i>Game screen · UI</span><span class="r" id="uiActive">—</span></div>
+        <div class="cwrap"><canvas id="screen" class="fill"></canvas></div>
+      </section>
+      <section class="pane" id="eventsPane">
+        <div class="pane-h"><span><i class="dot" style="background:var(--accent)"></i>Event timeline</span><span class="r" id="evCount"></span></div>
+        <div id="events"></div>
+      </section>
+    </div>
+  </div>
+
+  <div id="telemetry"><canvas id="tel"></canvas></div>
+
+  <footer>
+    <button class="act" id="play">▶ Play</button>
+    <input type="range" id="scrub" min="0" max="1000" value="0" />
+    <select id="speed"><option value="0.25">0.25×</option><option value="0.5">0.5×</option>
+      <option value="1" selected>1×</option><option value="2">2×</option><option value="4">4×</option></select>
+    <div id="clock">0.00 / 0.00 s</div>
+  </footer>
+</div>
+
+<div id="modal"><div id="digest">
+  <div class="h"><span>✨ <b>Session digest</b> — for humans & AI agents</span><button class="ghost" id="digestClose">✕</button></div>
+  <pre id="digestText"></pre>
+  <div class="f"><button class="ghost" id="digestCopy">Copy</button></div>
+</div></div>
+
+<script>
+"use strict";
+const DPR = window.devicePixelRatio || 1;
+const D2R = Math.PI/180;
+const S = { header:null, frames:[], events:[], tMax:0, tMin:0, bounds:null, tags:new Map(),
+            cur:0, playing:false, last:0, mode:'3d', pov:false };
+const $ = id => document.getElementById(id);
+const esc = s => String(s).replace(/[<>&"]/g, c=>({'<':'&lt;','>':'&gt;','&':'&amp;','"':'&quot;'}[c]));
+function getCss(v){ return getComputedStyle(document.documentElement).getPropertyValue(v).trim(); }
+function tagColor(tag){ if(S.tags.has(tag)) return S.tags.get(tag);
+  let h=0; for(const c of tag) h=(h*31+c.charCodeAt(0))&0xffff; const col=`hsl(${h%360} 70% 62%)`; S.tags.set(tag,col); return col; }
+function tagHex(tag){ const c=tagColor(tag); const m=c.match(/(\d+) (\d+)% (\d+)%/); if(!m) return 0xff5566;
+  return hslToHex(+m[1], +m[2]/100, +m[3]/100); }
+function hslToHex(h,s,l){ const a=s*Math.min(l,1-l); const f=n=>{const k=(n+h/30)%12; return l-a*Math.max(-1,Math.min(k-3,9-k,1));};
+  return (Math.round(f(0)*255)<<16)|(Math.round(f(8)*255)<<8)|Math.round(f(4)*255); }
+
+// ---------------- parse / load ----------------
+function parse(text){ const frames=[],events=[]; let header=null;
+  for(const raw of text.split(/\r?\n/)){ const line=raw.trim(); if(!line) continue;
+    let o; try{o=JSON.parse(line);}catch{continue;}
+    if(o.type==='header')header=o; else if(o.type==='frame')frames.push(o); else if(o.type==='event')events.push(o); }
+  frames.sort((a,b)=>a.t-b.t); events.sort((a,b)=>a.t-b.t); return {header,frames,events}; }
+function computeBounds(frames){ let a=Infinity,b=Infinity,c=-Infinity,d=-Infinity,any=false;
+  const acc=p=>{ if(!p)return; any=true; a=Math.min(a,p[0]);c=Math.max(c,p[0]);b=Math.min(b,p[1]);d=Math.max(d,p[1]); };
+  for(const f of frames){ if(f.player)acc(f.player.loc); if(f.camera)acc(f.camera.loc); if(f.actors)for(const x of f.actors)acc(x.loc); }
+  if(!any){a=-500;b=-500;c=500;d=500;} const pad=Math.max(100,0.08*Math.max(c-a,d-b));
+  return {minX:a-pad,minY:b-pad,maxX:c+pad,maxY:d+pad}; }
+function load(text){ const p=parse(text);
+  if(!p.frames.length&&!p.events.length){ alert('No frames/events found.'); return; }
+  S.header=p.header; S.frames=p.frames; S.events=p.events;
+  S.tMin=p.frames.length?p.frames[0].t:0;
+  S.tMax=Math.max(p.frames.length?p.frames[p.frames.length-1].t:0, p.events.length?p.events[p.events.length-1].t:0);
+  S.bounds=computeBounds(p.frames); S.cur=S.tMin; S.tags.clear(); lastEvCount=-1;
+  $('drop').classList.add('hide'); renderMeta(); buildLegend(); analyze();
+  if(THREE_OK) rebuildScene();
+  resize(); draw(); }
+function renderMeta(){ const h=S.header||{}, el=$('meta');
+  el.innerHTML=`<input type="file" id="file" accept=".jsonl,.json,.txt" />`; wireFile();
+  const b=[]; if(h.game)b.push(`<b>${esc(h.game)}</b>`); if(h.map)b.push(`map <b>${esc(h.map)}</b>`);
+  if(h.engine)b.push(`UE <b>${esc(h.engine)}</b>`); if(h.sampleRateHz)b.push(`<b>${h.sampleRateHz}</b>Hz`);
+  b.push(`<b>${S.frames.length}</b> frames`); b.push(`<b>${S.events.length}</b> events`); b.push(`<b>${S.tMax.toFixed(1)}</b>s`);
+  el.insertAdjacentHTML('beforeend', `<span>${b.join(' &nbsp;·&nbsp; ')}</span>`); $('evCount').textContent=`${S.events.length} events`; }
+function buildLegend(){ const tags=new Set(); for(const f of S.frames) if(f.actors) for(const a of f.actors) tags.add(a.tag||'actor');
+  $('legendTags').innerHTML=[...tags].map(t=>`<i style="background:${tagColor(t)}"></i>${esc(t)}`).join(' &nbsp; '); }
+function frameAt(t){ const F=S.frames; if(!F.length)return null; let lo=0,hi=F.length-1,ans=0;
+  while(lo<=hi){const m=(lo+hi)>>1; if(F[m].t<=t){ans=m;lo=m+1;}else hi=m-1;} return F[ans]; }
+
+// ---------------- coordinate mapping (UE cm, Z-up, LHS -> three, Y-up) ----------------
+const WS = 0.01; // cm -> units
+function ue2three(loc){ return new THREE.Vector3(loc[0]*WS, loc[2]*WS, -loc[1]*WS); }
+function ueForward(rot){ const p=rot[0]*D2R, y=rot[1]*D2R;
+  return new THREE.Vector3(Math.cos(p)*Math.cos(y), Math.sin(p), -Math.cos(p)*Math.sin(y)).normalize(); }
+
+// ---------------- three.js scene ----------------
+const THREE_OK = !!window.THREE;
+let R, scene, cam3, sceneCenter, orbit={az:0.7,el:0.85,rad:40,tx:0,ty:0,tz:0};
+let playerMesh, camGizmo, playerTrail, camTrail, gridHelper;
+const actorMeshes = new Map();
+function initThree(){
+  const c=$('world3d');
+  R=new THREE.WebGLRenderer({canvas:c, antialias:true}); R.setPixelRatio(DPR);
+  scene=new THREE.Scene(); scene.background=new THREE.Color(0x10101a);
+  cam3=new THREE.PerspectiveCamera(55,1,0.05,5000);
+  scene.add(new THREE.HemisphereLight(0xbfceff,0x20202c,1.1));
+  const dl=new THREE.DirectionalLight(0xffffff,1.4); dl.position.set(30,60,20); scene.add(dl);
+  playerTrail=mkLine(getCss('--player')); camTrail=mkLine(getCss('--camera'));
+  camGizmo=new THREE.LineSegments(new THREE.BufferGeometry(),
+            new THREE.LineBasicMaterial({color:0x57b6ff})); scene.add(camGizmo);
+  wireOrbit(c);
+}
+function mkLine(color){ const g=new THREE.BufferGeometry(); g.setAttribute('position',new THREE.BufferAttribute(new Float32Array(0),3));
+  const l=new THREE.Line(g,new THREE.LineBasicMaterial({color:new THREE.Color(color)})); scene.add(l); return l; }
+function mkTower(){ const g=new THREE.Group();
+  const body=new THREE.Mesh(new THREE.CylinderGeometry(2.2,3,5,6),new THREE.MeshStandardMaterial({color:0x2f8f5e,flatShading:true,roughness:.7}));
+  body.position.y=2.5; g.add(body);
+  const roof=new THREE.Mesh(new THREE.ConeGeometry(3.2,2.4,6),new THREE.MeshStandardMaterial({color:0x4ad991,flatShading:true}));
+  roof.position.y=6.2; g.add(roof); return g; }
+function mkEnemy(tag){ const m=new THREE.Mesh(new THREE.ConeGeometry(1.6,3.4,5),
+    new THREE.MeshStandardMaterial({color:tagHex(tag),flatShading:true,roughness:.6})); m.rotation.x=Math.PI; return m; }
+function rebuildScene(){
+  if(!scene) initThree();
+  for(const m of actorMeshes.values()) scene.remove(m); actorMeshes.clear();
+  if(playerMesh){ scene.remove(playerMesh); }
+  playerMesh=mkTower(); scene.add(playerMesh);
+  if(gridHelper) scene.remove(gridHelper);
+  const b=S.bounds, cx=(b.minX+b.maxX)/2*WS, cz=-(b.minY+b.maxY)/2*WS;
+  const ext=Math.max(b.maxX-b.minX,b.maxY-b.minY)*WS;
+  const gs=Math.ceil(ext*1.3/10)*10||60;
+  gridHelper=new THREE.GridHelper(gs, gs/ (gs>120?20:10), 0x40406a, 0x26263c);
+  gridHelper.position.set(cx,0,cz); scene.add(gridHelper);
+  sceneCenter=new THREE.Vector3(cx, ext*0.15, cz);
+  orbit.tx=sceneCenter.x; orbit.ty=sceneCenter.y; orbit.tz=sceneCenter.z; orbit.rad=Math.max(20,ext*1.15);
+}
+function updateFrustum(pos,fwd,fov,aspect){
+  const far=Math.max(6, orbit.rad*0.28), hh=Math.tan(fov*D2R/2)*far, hw=hh*aspect;
+  const up=new THREE.Vector3(0,1,0), right=new THREE.Vector3().crossVectors(fwd,up).normalize();
+  const cup=new THREE.Vector3().crossVectors(right,fwd).normalize();
+  const fc=pos.clone().add(fwd.clone().multiplyScalar(far));
+  const c=[ fc.clone().add(right.clone().multiplyScalar(hw)).add(cup.clone().multiplyScalar(hh)),
+            fc.clone().add(right.clone().multiplyScalar(-hw)).add(cup.clone().multiplyScalar(hh)),
+            fc.clone().add(right.clone().multiplyScalar(-hw)).add(cup.clone().multiplyScalar(-hh)),
+            fc.clone().add(right.clone().multiplyScalar(hw)).add(cup.clone().multiplyScalar(-hh)) ];
+  const segs=[pos,c[0], pos,c[1], pos,c[2], pos,c[3], c[0],c[1], c[1],c[2], c[2],c[3], c[3],c[0]];
+  const arr=new Float32Array(segs.length*3); segs.forEach((v,i)=>{arr[i*3]=v.x;arr[i*3+1]=v.y;arr[i*3+2]=v.z;});
+  camGizmo.geometry.setAttribute('position',new THREE.BufferAttribute(arr,3)); camGizmo.geometry.computeBoundingSphere();
+}
+function setTrail(line,getPt,t0,t1){ const pts=[];
+  for(const f of S.frames){ if(f.t<t0)continue; if(f.t>t1)break; const p=getPt(f); if(p) pts.push(ue2three(p)); }
+  const arr=new Float32Array(pts.length*3); pts.forEach((v,i)=>{arr[i*3]=v.x;arr[i*3+1]=v.y;arr[i*3+2]=v.z;});
+  line.geometry.setAttribute('position',new THREE.BufferAttribute(arr,3)); line.geometry.computeBoundingSphere(); }
+function render3D(f,t){
+  const c=$('world3d'), w=c.clientWidth*DPR|0, h=c.clientHeight*DPR|0;
+  if(c.width!==w||c.height!==h){ c.width=w;c.height=h; R.setSize(w,h,false); }
+  cam3.aspect=w/Math.max(1,h);
+  if(playerMesh){ if(f&&f.player){ playerMesh.visible=true; playerMesh.position.copy(ue2three(f.player.loc)); }
+    else playerMesh.visible=false; }
+  // actors: pool by id
+  const seen=new Set();
+  if(f&&f.actors) for(const a of f.actors){ let m=actorMeshes.get(a.id);
+    if(!m){ m=mkEnemy(a.tag||'actor'); scene.add(m); actorMeshes.set(a.id,m); }
+    m.visible=true; m.position.copy(ue2three(a.loc)); m.position.y+=1.7; seen.add(a.id); }
+  for(const [id,m] of actorMeshes){ if(!seen.has(id)) m.visible=false; }
+  setTrail(playerTrail,f2=>f2.player&&f2.player.loc, t-2.5, t);
+  setTrail(camTrail,f2=>f2.camera&&f2.camera.loc, t-2.5, t);
+  if(f&&f.camera){ camGizmo.visible=true; updateFrustum(ue2three(f.camera.loc), ueForward(f.camera.rot), f.camera.fov||70, cam3.aspect); }
+  else camGizmo.visible=false;
+  // camera placement
+  if(S.pov && f&&f.camera){ cam3.position.copy(ue2three(f.camera.loc)); cam3.up.set(0,1,0);
+    cam3.lookAt(ue2three(f.camera.loc).add(ueForward(f.camera.rot))); cam3.fov=f.camera.fov||70; }
+  else { const o=orbit; cam3.position.set(o.tx+o.rad*Math.cos(o.el)*Math.sin(o.az), o.ty+o.rad*Math.sin(o.el), o.tz+o.rad*Math.cos(o.el)*Math.cos(o.az));
+    cam3.up.set(0,1,0); cam3.lookAt(o.tx,o.ty,o.tz); cam3.fov=55; }
+  cam3.updateProjectionMatrix(); R.render(scene,cam3);
+}
+function wireOrbit(c){ let px=0,py=0,btn=-1;
+  c.addEventListener('pointerdown',e=>{btn=e.button;px=e.clientX;py=e.clientY;c.setPointerCapture(e.pointerId);});
+  c.addEventListener('pointerup',()=>btn=-1);
+  c.addEventListener('pointermove',e=>{ if(btn<0)return; const dx=e.clientX-px,dy=e.clientY-py; px=e.clientX;py=e.clientY;
+    if(btn===0&&!e.shiftKey){ orbit.az-=dx*0.006; orbit.el=Math.max(-1.4,Math.min(1.45,orbit.el+dy*0.006)); }
+    else { const k=orbit.rad*0.0016; orbit.tx+=-dx*k*Math.cos(orbit.az); orbit.tz+=dx*k*Math.sin(orbit.az); orbit.ty+=dy*k; }
+    if(!S.playing) draw(); });
+  c.addEventListener('wheel',e=>{ e.preventDefault(); orbit.rad=Math.max(4,Math.min(400,orbit.rad*(1+Math.sign(e.deltaY)*0.08))); if(!S.playing) draw(); },{passive:false});
+}
+
+// ---------------- 2D fallback (top-down) ----------------
+const w2=$('world2d'), w2c=w2.getContext('2d'); let TX=null;
+function updateTransform(){ const b=S.bounds,W=w2.width,H=w2.height;
+  const s=Math.min(W/(b.maxX-b.minX),H/(b.maxY-b.minY))*0.94, ox=(W-(b.maxX-b.minX)*s)/2, oy=(H-(b.maxY-b.minY)*s)/2;
+  TX={toX:x=>ox+(x-b.minX)*s,toY:y=>H-(oy+(y-b.minY)*s)}; }
+function render2D(f,t){ const X=x=>TX.toX(x),Y=y=>TX.toY(y);
+  w2c.clearRect(0,0,w2.width,w2.height); if(!S.bounds)return; updateTransform();
+  const b=S.bounds,step=Math.pow(10,Math.floor(Math.log10((b.maxX-b.minX)/8)))*2;
+  w2c.strokeStyle=getCss('--grid'); w2c.lineWidth=1; w2c.beginPath();
+  for(let x=Math.ceil(b.minX/step)*step;x<b.maxX;x+=step){w2c.moveTo(X(x),Y(b.minY));w2c.lineTo(X(x),Y(b.maxY));}
+  for(let y=Math.ceil(b.minY/step)*step;y<b.maxY;y+=step){w2c.moveTo(X(b.minX),Y(y));w2c.lineTo(X(b.maxX),Y(y));} w2c.stroke();
+  const tr=(g,col,wd)=>{ w2c.strokeStyle=col;w2c.lineWidth=wd;w2c.globalAlpha=.5;w2c.beginPath();let st=false;
+    for(const fr of S.frames){if(fr.t<t-2.5)continue;if(fr.t>t)break;const p=g(fr);if(!p){st=false;continue;}
+    const px=X(p[0]),py=Y(p[1]);if(!st){w2c.moveTo(px,py);st=true;}else w2c.lineTo(px,py);}w2c.stroke();w2c.globalAlpha=1; };
+  tr(fr=>fr.player&&fr.player.loc,getCss('--player'),2); tr(fr=>fr.camera&&fr.camera.loc,getCss('--camera'),1.5);
+  const dot=(loc,col,r)=>{w2c.fillStyle=col;w2c.beginPath();w2c.arc(X(loc[0]),Y(loc[1]),r,0,7);w2c.fill();w2c.strokeStyle='#000';w2c.lineWidth=1;w2c.stroke();};
+  if(f){ if(f.actors)for(const a of f.actors)dot(a.loc,tagColor(a.tag||'actor'),5);
+    if(f.camera)dot(f.camera.loc,getCss('--camera'),5); if(f.player)dot(f.player.loc,getCss('--player'),7); }
+}
+
+// ---------------- game screen (UI) ----------------
+const sc=$('screen'), sctx=sc.getContext('2d');
+function styleFor(t){ t=(t||'').toLowerCase();
+  if(t.includes('button'))return{fill:'#6f63e6cc',stroke:'#8f86ff',c:false};
+  if(t.includes('progress'))return{fill:'#e0913955',stroke:'#f0a04a',c:false,bar:true};
+  if(t.includes('text'))return{fill:'#2e2e46aa',stroke:'#8888aa',c:false};
+  if(t.includes('image'))return{fill:'#2aa19844',stroke:'#3fd0c0',c:false};
+  if(/(panel|box|border|overlay|scale|grid|scroll|canvas)/.test(t))return{fill:'',stroke:'#3a3a5a',c:true};
+  return{fill:'#33334daa',stroke:'#6a6a8a',c:false}; }
+function drawScreen(f,t){ const W=sc.width,H=sc.height; sctx.clearRect(0,0,W,H);
+  const vp=(f&&f.viewport)||[16,9], aspect=(vp[0]||16)/(vp[1]||9), pad=16*DPR;
+  let mw=W-2*pad,mh=mw/aspect; if(mh>H-2*pad){mh=H-2*pad;mw=mh*aspect;} const mx=(W-mw)/2,my=(H-mh)/2;
+  sctx.fillStyle='#0a0a12';sctx.strokeStyle='#3a3a5a';sctx.lineWidth=1.5*DPR;sctx.fillRect(mx,my,mw,mh);sctx.strokeRect(mx,my,mw,mh);
+  const ui=f&&f.ui;
+  if(!ui||!ui.length||typeof ui[0]!=='object'){ sctx.fillStyle='#55556f';sctx.font=`${13*DPR}px sans-serif`;sctx.textAlign='center';
+    sctx.fillText(f?'no UI captured here':'—',W/2,H/2);sctx.textAlign='left'; return; }
+  sctx.save();sctx.beginPath();sctx.rect(mx,my,mw,mh);sctx.clip();
+  const tX=n=>mx+n*mw,tY=n=>my+n*mh;
+  for(const w of ui){ const r=w.r; if(!r)continue; const x=tX(r[0]),y=tY(r[1]),ww=r[2]*mw,hh=r[3]*mh,st=styleFor(w.t);
+    sctx.globalAlpha=w.disabled?.4:1;
+    if(!st.c&&st.fill){ sctx.fillStyle=st.fill; sctx.fillRect(x,y,ww,hh); }
+    if(st.bar&&w.pct!=null){ sctx.fillStyle='#f0a04a'; sctx.fillRect(x,y,ww*Math.max(0,Math.min(1,w.pct)),hh); }
+    sctx.strokeStyle=w.hover?'#ffd54a':st.stroke; sctx.lineWidth=(w.hover?2:1)*DPR; sctx.strokeRect(x,y,ww,hh);
+    if(w.text){ sctx.save();sctx.beginPath();sctx.rect(x,y,ww,hh);sctx.clip();
+      sctx.fillStyle='#fff';sctx.font=`${Math.max(10*DPR,Math.min(hh*.6,15*DPR))}px sans-serif`;sctx.textBaseline='middle';
+      sctx.fillText(w.text,x+5*DPR,y+hh/2);sctx.restore(); }
+    sctx.globalAlpha=1; }
+  if(f.mouse){ const cx=tX(f.mouse[0]),cy=tY(f.mouse[1]); sctx.strokeStyle='#fff';sctx.lineWidth=1.5*DPR;sctx.beginPath();
+    sctx.arc(cx,cy,6*DPR,0,7);sctx.moveTo(cx-11*DPR,cy);sctx.lineTo(cx+11*DPR,cy);sctx.moveTo(cx,cy-11*DPR);sctx.lineTo(cx,cy+11*DPR);sctx.stroke(); }
+  for(const e of S.events){ if(e.category!=='ui'||e.name!=='click'||!e.data)continue; const dt=t-e.t; if(dt<0||dt>0.7)continue;
+    const cx=tX(parseFloat(e.data.x)||0),cy=tY(parseFloat(e.data.y)||0); sctx.strokeStyle=`rgba(255,110,110,${1-dt/0.7})`;sctx.lineWidth=2.5*DPR;
+    sctx.beginPath();sctx.arc(cx,cy,(5+dt*55)*DPR,0,7);sctx.stroke(); }
+  sctx.restore(); }
+
+// ---------------- telemetry strip ----------------
+const tel=$('tel'), tctx=tel.getContext('2d');
+const catColor={combat:'#ff8a6a',ui:'#ffd54a',actor:'#57b6ff',world:'#9a9ab5'};
+function drawTelemetry(t){ const W=tel.width,H=tel.height; tctx.clearRect(0,0,W,H); if(!S.frames.length)return;
+  const L=(S.tMax-S.tMin)||1, tx=tt=>(tt-S.tMin)/L*W;
+  const series=(get,col,label,fixed)=>{ let mn=Infinity,mx=-Infinity; for(const f of S.frames){const v=get(f); if(v==null)continue; mn=Math.min(mn,v);mx=Math.max(mx,v);}
+    if(mn===Infinity)return; if(mx===mn)mx=mn+1; const y=v=>H-6*DPR-(v-mn)/(mx-mn)*(H-16*DPR);
+    tctx.strokeStyle=col;tctx.lineWidth=1.5*DPR;tctx.beginPath();let st=false;
+    for(const f of S.frames){const v=get(f);if(v==null){st=false;continue;} const X=tx(f.t),Y=y(v); if(!st){tctx.moveTo(X,Y);st=true;}else tctx.lineTo(X,Y);} tctx.stroke();
+    const cf=frameAt(t), cur=cf?get(cf):null;
+    tctx.fillStyle=col;tctx.font=`${10*DPR}px sans-serif`;
+    tctx.fillText(`${label}${cur!=null?': '+cur.toFixed(fixed):''}`, 8*DPR+series._o, 12*DPR); series._o+=(label.length*7+52)*DPR; };
+  series._o=0;
+  series(f=>f.perf&&f.perf.fps,'#4ad991','FPS',0);
+  series(f=>f.state&&f.state.entities,'#57b6ff','entities',0);
+  // event ticks
+  for(const e of S.events){ const X=tx(e.t); tctx.strokeStyle=catColor[e.category]||'#888'; tctx.globalAlpha=.5; tctx.lineWidth=1;
+    tctx.beginPath();tctx.moveTo(X,H-4*DPR);tctx.lineTo(X,H-11*DPR);tctx.stroke(); } tctx.globalAlpha=1;
+  // playhead
+  const px=tx(t); tctx.strokeStyle='#fff';tctx.lineWidth=1*DPR;tctx.beginPath();tctx.moveTo(px,0);tctx.lineTo(px,H);tctx.stroke(); }
+$('tel').addEventListener('pointerdown',e=>{ const r=tel.getBoundingClientRect(); S.cur=S.tMin+(e.clientX-r.left)/r.width*(S.tMax-S.tMin); lastEvCount=-1; draw(); });
+
+// ---------------- panels ----------------
+let lastEvCount=-1;
+function updatePanels(f,t){ const ui=(f&&f.ui)||[]; let names=[];
+  if(ui.length&&typeof ui[0]==='object'){ const s=new Set(); for(const w of ui){const n=(w.n||'').split('/')[0]; if(n)s.add(n);} names=[...s]; } else names=ui;
+  $('uiActive').textContent=names.length?names.join(' · '):'—';
+  const upto=[]; for(const e of S.events){ if(e.t>t)break; upto.push(e); }
+  if(upto.length!==lastEvCount){ lastEvCount=upto.length; const box=$('events');
+    box.innerHTML=upto.slice(-500).map((e,i)=>{ const gi=upto.length-Math.min(500,upto.length)+i;
+      const recent=(t-e.t)<0.6?' recent':''; const data=e.data&&Object.keys(e.data).length?esc(JSON.stringify(e.data)):'';
+      return `<div class="ev ${esc(e.category)}${recent}" data-t="${e.t}"><span class="t">${e.t.toFixed(2)}s</span>`+
+             `<span><span class="cat">${esc(e.category)}</span> ${esc(e.name)} <span class="data">${data}</span></span></div>`; }).join('');
+    box.scrollTop=box.scrollHeight; } }
+$('events').addEventListener('click',e=>{ const el=e.target.closest('.ev'); if(!el)return; S.cur=parseFloat(el.dataset.t); lastEvCount=-1; draw(); });
+
+// ---------------- master draw ----------------
+function draw(){ const t=S.cur, f=frameAt(t);
+  if(S.mode==='3d'&&THREE_OK){ try{ render3D(f,t); }catch(err){ console.error(err); setMode('2d'); render2D(f,t); } }
+  else render2D(f,t);
+  drawScreen(f,t); drawTelemetry(t); updatePanels(f,t);
+  $('scrub').value=S.tMax>0?Math.round((t-S.tMin)/(S.tMax-S.tMin)*1000):0;
+  $('clock').textContent=`${(t-S.tMin).toFixed(2)} / ${(S.tMax-S.tMin).toFixed(2)} s`; }
+
+// ---------------- transport ----------------
+function tick(ts){ if(S.playing){ if(!S.last)S.last=ts; const dt=(ts-S.last)/1000*parseFloat($('speed').value); S.last=ts; S.cur+=dt;
+    if(S.cur>=S.tMax){S.cur=S.tMax;setPlaying(false);} } else S.last=0;
+  if(S.frames.length) draw(); requestAnimationFrame(tick); }
+function setPlaying(p){ S.playing=p; $('play').textContent=p?'❚❚ Pause':'▶ Play'; if(p&&S.cur>=S.tMax)S.cur=S.tMin; }
+function setMode(m){ S.mode=m; $('m3d').classList.toggle('on',m==='3d'); $('m2d').classList.toggle('on',m==='2d');
+  $('world3d').style.display=(m==='3d'&&THREE_OK)?'block':'none'; $('world2d').style.display=(m==='3d'&&THREE_OK)?'none':'block';
+  $('hint3d').style.display=(m==='3d'&&THREE_OK)?'block':'none'; resize(); draw(); }
+function sizeCanvas(c){ const r=c.parentElement.getBoundingClientRect(); c.width=Math.max(1,r.width*DPR); c.height=Math.max(1,r.height*DPR); }
+function resize(){ sizeCanvas(w2); sizeCanvas(sc); { const r=$('telemetry').getBoundingClientRect(); tel.width=r.width*DPR; tel.height=r.height*DPR; }
+  if(THREE_OK&&R){ const c=$('world3d'); c.width=c.clientWidth*DPR|0; c.height=c.clientHeight*DPR|0; R.setSize(c.width,c.height,false); }
+  if(S.frames.length) draw(); }
+function wireFile(){ const f=$('file'); if(f) f.onchange=e=>{const file=e.target.files[0]; if(file)file.text().then(load);}; }
+
+// ---------------- AI digest ----------------
+let ANA=null;
+function analyze(){ const F=S.frames, E=S.events; const h=S.header||{};
+  let fpsMin=Infinity,fpsSum=0,fpsN=0,fpsMinT=0, peakEnt=0,peakEntT=0;
+  for(const f of F){ if(f.perf&&f.perf.fps!=null){ fpsSum+=f.perf.fps;fpsN++; if(f.perf.fps<fpsMin){fpsMin=f.perf.fps;fpsMinT=f.t;} }
+    if(f.state&&f.state.entities!=null&&f.state.entities>peakEnt){peakEnt=f.state.entities;peakEntT=f.t;} }
+  const cats={}; for(const e of E){cats[e.category+'/'+e.name]=(cats[e.category+'/'+e.name]||0)+1;}
+  const clicks=E.filter(e=>e.category==='ui'&&e.name==='click').map(e=>({t:e.t,w:e.data&&e.data.widget}));
+  const menus=[...new Set(E.filter(e=>e.category==='ui'&&e.name==='open').map(e=>e.data&&e.data.widget))];
+  ANA={dur:S.tMax-S.tMin, frames:F.length, hz:h.sampleRateHz, game:h.game, map:h.map, engine:h.engine,
+       fpsAvg:fpsN?fpsSum/fpsN:null, fpsMin:isFinite(fpsMin)?fpsMin:null, fpsMinT, peakEnt, peakEntT, cats, clicks, menus}; }
+function digestText(){ if(!ANA)return'No session.'; const A=ANA, L=[];
+  L.push(`# ${A.game||'Session'} — state-replay digest`);
+  L.push(`map: ${A.map||'?'} · engine UE ${A.engine||'?'} · ${A.dur.toFixed(1)}s · ${A.frames} frames @ ${A.hz||'?'}Hz`);
+  L.push('');
+  L.push(`## Performance`);
+  L.push(`- FPS avg ${A.fpsAvg?A.fpsAvg.toFixed(1):'—'}, min ${A.fpsMin?A.fpsMin.toFixed(1):'—'}${A.fpsMin?` at ${A.fpsMinT.toFixed(1)}s`:''}`);
+  L.push(`- peak concurrent entities ${A.peakEnt} at ${A.peakEntT.toFixed(1)}s`);
+  L.push('');
+  L.push(`## Events`);
+  for(const k of Object.keys(A.cats).sort()) L.push(`- ${k}: ${A.cats[k]}`);
+  if(A.menus.length){ L.push(''); L.push(`## UI`); L.push(`- menus opened: ${A.menus.filter(Boolean).join(', ')||'—'}`);
+    if(A.clicks.length){ L.push(`- clicks:`); for(const c of A.clicks) L.push(`  - ${c.t.toFixed(1)}s → ${c.w||'?'}`); } }
+  L.push(''); L.push(`_Generated locally from the JSONL by the Sentry State Replay player._`);
+  return L.join('\n'); }
+$('aiBtn').onclick=()=>{ if(!S.frames.length){alert('Load a session first.');return;} $('digestText').textContent=digestText(); $('modal').classList.add('show'); };
+$('digestClose').onclick=()=>$('modal').classList.remove('show');
+$('digestCopy').onclick=()=>{ navigator.clipboard&&navigator.clipboard.writeText($('digestText').textContent); $('digestCopy').textContent='Copied ✓'; setTimeout(()=>$('digestCopy').textContent='Copy',1200); };
+$('modal').addEventListener('click',e=>{ if(e.target.id==='modal') $('modal').classList.remove('show'); });
+
+// ---------------- wiring ----------------
+$('play').onclick=()=>setPlaying(!S.playing);
+$('scrub').oninput=e=>{ S.cur=S.tMin+(e.target.value/1000)*(S.tMax-S.tMin); lastEvCount=-1; draw(); };
+$('m3d').onclick=()=>setMode('3d'); $('m2d').onclick=()=>setMode('2d');
+$('mpov').onclick=()=>{ S.pov=!S.pov; $('mpov').classList.toggle('on',S.pov); if(S.pov&&S.mode!=='3d')setMode('3d'); draw(); };
+window.addEventListener('keydown',e=>{ if(e.target.tagName==='INPUT')return;
+  if(e.code==='Space'){e.preventDefault();setPlaying(!S.playing);}
+  else if(e.code==='ArrowRight'){S.cur=Math.min(S.tMax,S.cur+ (e.shiftKey?1:0.1));lastEvCount=-1;draw();}
+  else if(e.code==='ArrowLeft'){S.cur=Math.max(S.tMin,S.cur-(e.shiftKey?1:0.1));lastEvCount=-1;draw();} });
+window.addEventListener('resize',resize);
+document.addEventListener('dragover',e=>e.preventDefault());
+document.addEventListener('drop',e=>{e.preventDefault();const f=e.dataTransfer.files[0];if(f)f.text().then(load);});
+if(!THREE_OK){ $('m3d').style.display='none'; $('m2d').classList.add('on'); S.mode='2d'; $('world3d').style.display='none'; $('world2d').style.display='block'; $('hint3d').style.display='none'; }
+wireFile(); resize(); requestAnimationFrame(tick);
+const _emb=document.getElementById('embedded-session'); if(_emb&&_emb.textContent.trim()) load(_emb.textContent);
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds `USentryStateReplaySubsystem`, a self-contained GameInstance subsystem that streams a structured, AI-parseable snapshot of gameplay state to a local JSONL file each frame — an alternative to the video-based session replay that is CPU -cheap, tiny, and queryable, and works where a GPU video encoder can't ship.

Per frame it auto-captures:
- local pawn transform + camera POV (loc/rot/fov)
- transforms of actors registered via AddTrackedActor (id/tag)
- the active UMG widget tree: normalized rects, text, hover/disabled, progress %
- perf (fps / frame-time) and a game-state channel (auto entity counts + a SetState/SetStateString API)

UI interaction is captured at the Slate level via an input pre-processor, so clicks on Blueprint menu buttons are recorded and resolved to widget names even while gameplay is paused. Gameplay code can push semantic events via AddEvent.

Ships a zero-dependency local player (tools/state-replay-player) that reconstructs the session in 3D with low-poly stand-in assets and a player-POV camera (2D top-down fallback), plus a UMG UI overlay, FPS/entity telemetry, a click-to-seek event timeline, and a one-click AI session digest.

Scope: local developer/AI-debugging tool. Does not touch the crash pipeline or upload anything (crash-attachment is a deliberate follow-up). Standalone subsystem — not part of the platform interface, so no Null stubs required.

Config: Project Settings -> Plugins -> "Sentry State Replay" (disabled by default).
Sentry.Build.cs: +UMG, +DeveloperSettings, +InputCore.