### PR TITLE
Include breadcrumbs in crash session replays on Apple platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Include the crash event's breadcrumbs in crash session replays on Apple platforms (Cocoa backend), so breadcrumbs from the replay window show up on the replay timeline ([#TBD](https://github.com/getsentry/sentry-unreal/pull/TBD))
+
 ### Fixes
 
 - Decrease max session replay clip duration to 20 seconds to prevent replays from being rejected due to the server-side 10 MiB size limit, which could be exceeded at high rendering resolutions ([#1478](https://github.com/getsentry/sentry-unreal/pull/1478))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Include the crash event's breadcrumbs in crash session replays on Apple platforms (Cocoa backend), so breadcrumbs from the replay window show up on the replay timeline ([#TBD](https://github.com/getsentry/sentry-unreal/pull/TBD))
+- Include the crash event's breadcrumbs in crash session replays on Apple platforms (Cocoa backend), so breadcrumbs from the replay window show up on the replay timeline ([#1480](https://github.com/getsentry/sentry-unreal/pull/1480))
 
 ### Fixes
 

--- a/integration-test/CMakeLists.txt
+++ b/integration-test/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
     app-runner
     GIT_REPOSITORY https://github.com/getsentry/app-runner.git
-    GIT_TAG 8b464825b58ccf8b59b8ebd39961fb64e668bbd3
+    GIT_TAG 6dac008e53292dc2df043ed4bcfa4c6f3c1fa075
 )
 
 FetchContent_MakeAvailable(app-runner)

--- a/integration-test/CMakeLists.txt
+++ b/integration-test/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
     app-runner
     GIT_REPOSITORY https://github.com/getsentry/app-runner.git
-    GIT_TAG 6dac008e53292dc2df043ed4bcfa4c6f3c1fa075
+    GIT_TAG 89d9bb53a3a9cb1b9229de24fa2a2ddf3f65cd88
 )
 
 FetchContent_MakeAvailable(app-runner)

--- a/integration-test/CMakeLists.txt
+++ b/integration-test/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
     app-runner
     GIT_REPOSITORY https://github.com/getsentry/app-runner.git
-    GIT_TAG 8be06e220d490e527b810f6d073872025bf491b3
+    GIT_TAG 8b464825b58ccf8b59b8ebd39961fb64e668bbd3
 )
 
 FetchContent_MakeAvailable(app-runner)

--- a/integration-test/CMakeLists.txt
+++ b/integration-test/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
     app-runner
     GIT_REPOSITORY https://github.com/getsentry/app-runner.git
-    GIT_TAG 89d9bb53a3a9cb1b9229de24fa2a2ddf3f65cd88
+    GIT_TAG 4526c9cfbea3ed1c702a7c590ad4d0d220f936ff
 )
 
 FetchContent_MakeAvailable(app-runner)

--- a/integration-test/Integration.Desktop.Tests.ps1
+++ b/integration-test/Integration.Desktop.Tests.ps1
@@ -567,6 +567,20 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
                     Write-Host "Failed to fetch replay from Sentry: $_" -ForegroundColor Red
                 }
             }
+
+            # Fetch the replay's rrweb recording to verify embedded breadcrumbs
+            $script:ReplayRecordingEvents = $null
+            if ($script:ReplayEvent) {
+                try {
+                    $segments = Get-SentryTestReplayRecordingSegments -ReplayId $script:ReplayId
+                    # Flatten the per-segment event lists into a single rrweb event list
+                    $script:ReplayRecordingEvents = @($segments | ForEach-Object { $_ })
+                    Write-Host "Replay recording fetched from Sentry successfully" -ForegroundColor Green
+                }
+                catch {
+                    Write-Host "Failed to fetch replay recording from Sentry: $_" -ForegroundColor Red
+                }
+            }
         }
 
         It "Should have non-zero exit code" {
@@ -605,6 +619,30 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
         It "Should have expected platform" {
             $expectedPlatform = if ($Platform -eq 'MacOS' -and -not $script:IsNativeBackend) { 'cocoa' } else { 'native' }
             $script:ReplayEvent.platform | Should -Be $expectedPlatform
+        }
+
+        It "Should embed test breadcrumbs in replay recording" {
+            $script:ReplayRecordingEvents | Should -Not -BeNullOrEmpty
+
+            # Breadcrumbs are rrweb custom events (type 5) tagged `breadcrumb`
+            $crumbs = @($script:ReplayRecordingEvents | Where-Object { $_.type -eq 5 -and $_.data.tag -eq 'breadcrumb' })
+            $crumbs.Count | Should -BeGreaterOrEqual 2
+
+            $messages = @($crumbs | ForEach-Object { $_.data.payload.message })
+            $messages | Should -Contain 'Replay test breadcrumb'
+            $messages | Should -Contain 'Replay test breadcrumb with data'
+        }
+
+        It "Should have well-formed breadcrumb payloads in replay recording" {
+            $crumbs = @($script:ReplayRecordingEvents | Where-Object { $_.type -eq 5 -and $_.data.tag -eq 'breadcrumb' -and $_.data.payload.category -eq 'replay.test' })
+            $crumbs.Count | Should -BeGreaterOrEqual 2
+
+            foreach ($crumb in $crumbs) {
+                # The outer rrweb timestamp is in milliseconds, the payload timestamp in seconds
+                [math]::Abs($crumb.timestamp - $crumb.data.payload.timestamp * 1000) | Should -BeLessThan 1
+                $crumb.data.payload.type | Should -Be 'default'
+                $crumb.data.payload.level | Should -BeIn @('info', 'warning')
+            }
         }
     }
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
@@ -11,6 +11,8 @@
 #include "Convenience/AppleSentryInclude.h"
 #include "Convenience/AppleSentryMacro.h"
 
+#include "Infrastructure/AppleSentryConverters.h"
+
 #include "JsonObjectConverter.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
@@ -134,7 +136,51 @@ NSDictionary* BuildReplayEvent(SentryObjCEvent* event, const FSentryReplayInfo& 
 	return SanitizeForJson(dict);
 }
 
-NSData* BuildReplayRecording(const FSentryReplayInfo& info, double startSec, uint64 videoSizeBytes)
+// Convert the crash event's breadcrumbs that fall inside the replay window into
+// rrweb `breadcrumb` events (custom event type 5) so they show up on the replay
+// timeline. The breadcrumbs array is chronological and every in-window crumb lies
+// at or after the meta/video events' timestamp, so appending the result to the
+// recording keeps it sorted.
+NSArray* BuildBreadcrumbEvents(NSArray<SentryObjCBreadcrumb*>* breadcrumbs, double startSec, double endSec)
+{
+	NSMutableArray* events = [NSMutableArray array];
+	for (SentryObjCBreadcrumb* crumb in breadcrumbs)
+	{
+		if (crumb.timestamp == nil)
+		{
+			continue;
+		}
+		const double crumbSec = [crumb.timestamp timeIntervalSince1970];
+		if (crumbSec < startSec || crumbSec > endSec)
+		{
+			continue;
+		}
+
+		NSMutableDictionary* payload = [NSMutableDictionary dictionary];
+		payload[@"type"] = crumb.type.length > 0 ? crumb.type : @"default";
+		// the rrweb payload timestamp is in seconds, the outer one in milliseconds
+		payload[@"timestamp"] = @(crumbSec);
+		payload[@"level"] = FAppleSentryConverters::SentryLevelToString(crumb.level);
+		if (crumb.category)
+			payload[@"category"] = crumb.category;
+		if (crumb.message)
+			payload[@"message"] = crumb.message;
+		if (crumb.data)
+			payload[@"data"] = SanitizeForJson(crumb.data);
+
+		[events addObject:@{
+			@"type" : @5,
+			@"timestamp" : @(crumbSec * 1000.0),
+			@"data" : @{
+				@"tag" : @"breadcrumb",
+				@"payload" : payload
+			}
+		}];
+	}
+	return events;
+}
+
+NSData* BuildReplayRecording(const FSentryReplayInfo& info, double startSec, double endSec, uint64 videoSizeBytes, NSArray<SentryObjCBreadcrumb*>* breadcrumbs)
 {
 	const double timestampMs = startSec * 1000.0;
 
@@ -170,8 +216,11 @@ NSData* BuildReplayRecording(const FSentryReplayInfo& info, double startSec, uin
 		}
 	};
 
+	NSMutableArray* events = [NSMutableArray arrayWithObjects:metaEvent, videoEvent, nil];
+	[events addObjectsFromArray:BuildBreadcrumbEvents(breadcrumbs, startSec, endSec)];
+
 	NSError* error = nil;
-	NSData* eventsJson = [NSJSONSerialization dataWithJSONObject:@[ metaEvent, videoEvent ] options:0 error:&error];
+	NSData* eventsJson = [NSJSONSerialization dataWithJSONObject:events options:0 error:&error];
 	if (eventsJson == nil)
 	{
 		return nil;
@@ -237,7 +286,7 @@ bool FAppleSentryReplayEnvelope::CaptureForCrashEvent(SentryObjCEvent* event, co
 		return false;
 	}
 
-	NSData* replayRecording = BuildReplayRecording(info, startSec, video.length);
+	NSData* replayRecording = BuildReplayRecording(info, startSec, endSec, video.length, event != nil ? event.breadcrumbs : nil);
 	if (replayRecording == nil)
 	{
 		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to serialize replay recording"));

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
@@ -136,11 +136,6 @@ NSDictionary* BuildReplayEvent(SentryObjCEvent* event, const FSentryReplayInfo& 
 	return SanitizeForJson(dict);
 }
 
-// Convert the crash event's breadcrumbs that fall inside the replay window into
-// rrweb `breadcrumb` events (custom event type 5) so they show up on the replay
-// timeline. The breadcrumbs array is chronological and every in-window crumb lies
-// at or after the meta/video events' timestamp, so appending the result to the
-// recording keeps it sorted.
 NSArray* BuildBreadcrumbEvents(NSArray<SentryObjCBreadcrumb*>* breadcrumbs, double startSec, double endSec)
 {
 	NSMutableArray* events = [NSMutableArray array];

--- a/plugin-dev/Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.cpp
@@ -535,6 +535,25 @@ SentryObjCLevel FAppleSentryConverters::StringToSentryLevel(NSString* string)
 	return nativeLevel;
 }
 
+NSString* FAppleSentryConverters::SentryLevelToString(SentryObjCLevel level)
+{
+	switch (level)
+	{
+	case SentryObjCLevelDebug:
+		return @"debug";
+	case SentryObjCLevelInfo:
+		return @"info";
+	case SentryObjCLevelWarning:
+		return @"warning";
+	case SentryObjCLevelError:
+		return @"error";
+	case SentryObjCLevelFatal:
+		return @"fatal";
+	default:
+		return @"none";
+	}
+}
+
 FSentryVariant FAppleSentryConverters::SentryAttributeToVariant(SentryObjCAttribute* attribute)
 {
 	if (!attribute)

--- a/plugin-dev/Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/Infrastructure/AppleSentryConverters.h
@@ -42,6 +42,7 @@ public:
 
 	/** Other conversions */
 	static SentryObjCLevel StringToSentryLevel(NSString* string);
+	static NSString* SentryLevelToString(SentryObjCLevel level);
 	static FSentryVariant SentryAttributeToVariant(SentryObjCAttribute* attribute);
 	static FSentryVariant SentryAttributeContentToVariant(SentryObjCAttributeContent* content);
 };

--- a/sample/Source/SentryPlayground/IntegrationTests/SentryReplayTest.cpp
+++ b/sample/Source/SentryPlayground/IntegrationTests/SentryReplayTest.cpp
@@ -100,6 +100,8 @@ void FSentryReplayTest::Run()
 	Subsystem->AddBreadcrumbWithParams(TEXT("Replay test breadcrumb with data"), TEXT("replay.test"), TEXT("default"),
 		{ { TEXT("key"), FSentryVariant(TEXT("value")) } }, ESentryLevel::Warning);
 
+	FPlatformProcess::Sleep(1.0f);
+
 	// Because we don't get the real crash event ID, create a fake one and set it as a tag
 	// This tag is then used by integration test script in CI to fetch the event
 	FString EventId = FGuid::NewGuid().ToString(EGuidFormats::DigitsWithHyphens);

--- a/sample/Source/SentryPlayground/IntegrationTests/SentryReplayTest.cpp
+++ b/sample/Source/SentryPlayground/IntegrationTests/SentryReplayTest.cpp
@@ -40,8 +40,8 @@ FString GetReplaysDir(const USentrySettings* Settings)
 #endif
 
 	const FString DatabaseParentPath = Settings->DatabaseLocation == ESentryDatabaseLocation::ProjectDirectory
-		? FPaths::ProjectDir()
-		: FPaths::ProjectUserDir();
+										   ? FPaths::ProjectDir()
+										   : FPaths::ProjectUserDir();
 
 	return FPaths::ConvertRelativePathToFull(FPaths::Combine(DatabaseParentPath, TEXT(".sentry-native"), TEXT("replays")));
 }
@@ -78,8 +78,8 @@ void FSentryReplayTest::Run()
 
 	const FString Sidecar = FString::Printf(
 		TEXT("{\"replayId\":\"%s\",\"replayType\":\"buffer\",\"segmentId\":0,")
-		TEXT("\"startTimestampSec\":%.3f,\"endTimestampSec\":%.3f,")
-		TEXT("\"width\":%d,\"height\":%d,\"durationMs\":%d,\"sizeBytes\":%d,\"frameCount\":%d,\"frameRate\":%d}"),
+			TEXT("\"startTimestampSec\":%.3f,\"endTimestampSec\":%.3f,")
+				TEXT("\"width\":%d,\"height\":%d,\"durationMs\":%d,\"sizeBytes\":%d,\"frameCount\":%d,\"frameRate\":%d}"),
 		*ReplayId, StartTimestampSec, EndTimestampSec,
 		ClipWidth, ClipHeight, ClipDurationMs, ClipSizeBytes, ClipFrameCount, ClipFrameRate);
 
@@ -92,6 +92,13 @@ void FSentryReplayTest::Run()
 
 	// Link the staged replay to the crash event; when the recorder is active it does the same at init
 	Subsystem->SetContext(TEXT("replay"), { { TEXT("replay_id"), FSentryVariant(ReplayId) } });
+
+	// Add breadcrumbs shortly before the crash so they fall inside the replay window;
+	// the SDK is expected to embed them in the replay recording where the integration
+	// test script can verify them (message/category values are asserted in CI)
+	Subsystem->AddBreadcrumbWithParams(TEXT("Replay test breadcrumb"), TEXT("replay.test"), TEXT("default"), {}, ESentryLevel::Info);
+	Subsystem->AddBreadcrumbWithParams(TEXT("Replay test breadcrumb with data"), TEXT("replay.test"), TEXT("default"),
+		{ { TEXT("key"), FSentryVariant(TEXT("value")) } }, ESentryLevel::Warning);
 
 	// Because we don't get the real crash event ID, create a fake one and set it as a tag
 	// This tag is then used by integration test script in CI to fetch the event


### PR DESCRIPTION
This PR adds breadcrumbs to crash session replays on Native and Apple platforms: breadcrumbs carried by the crash event that fall inside the replay window are converted into rrweb `breadcrumb` custom events and embedded into the `replay_recording` payload built on relaunch, so they show up on the replay timeline. Together with getsentry/sentry-native#1875 (which covers all sentry-native backends) this also brings breadcrumb-enriched crash replays to all desktop platforms.

[Example replay](https://sentry-sdks.sentry.io/explore/replays/997a9a3744ee52e6c5b1b9a5a142cfa7/?playlistEnd=2026-07-16T13:44:00&playlistStart=2026-07-15T13:44:00&project=4508816831873030&query=&referrer=replayList&t_main=breadcrumbs) with breadcrumbs included (Windows)
[Example replay](https://sentry-sdks.sentry.io/explore/replays/4067eeb6854a3860fe3f828505869dcc/?playlistEnd=2026-07-16T14:27:03&playlistStart=2026-07-16T13:27:03&project=4508816831873030&query=&referrer=replayList&t_main=breadcrumbs) with breadcrumbs included (macOS)

### Key changes

- `AppleSentryReplayEnvelope`: new `BuildBreadcrumbEvents` helper converts the crash event's breadcrumbs (already persisted at crash time and restored by the Cocoa SDK on relaunch) into rrweb type-5 events with `tag: "breadcrumb"` - outer timestamps in ms, payload timestamps in seconds, `data` sanitized for JSON; `BuildReplayRecording` appends them after the meta/video events.
- `FAppleSentryConverters::SentryLevelToString`: new converter mapping `SentryLevel` to its canonical string name (inverse of the existing `StringToSentryLevel`).
- The replay integration test now adds a couple of breadcrumbs right before crashing, and the desktop test suite fetches the replay's rrweb recording from Sentry to assert they were embedded with the expected payloads. This covers both the Cocoa path (macOS) and the sentry-native path (Windows/Linux) in CI.

### Related items
- https://github.com/getsentry/sentry-native/pull/1875
- https://github.com/getsentry/app-runner/pull/54