### PR TITLE
perf(native): maximize telemetry buffers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Decrease max session replay clip duration to 20 seconds to prevent replays from being rejected due to the server-side 10 MiB size limit, which could be exceeded at high rendering resolutions ([#1478](https://github.com/getsentry/sentry-unreal/pull/1478))
+- Maximize telemetry buffers for native platforms to minimize queue overflows ([#1483](https://github.com/getsentry/sentry-unreal/pull/1483))
 
 ### Dependencies
 

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -269,7 +269,7 @@ function buildSentryNative()
     Push-Location -Path $NativePath
     try
     {
-        cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF
+        cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10
         cmake --build "build" --target sentry --config RelWithDebInfo --parallel
         cmake --build "build" --target crashpad_handler --config RelWithDebInfo --parallel
         cmake --install "build" --prefix "install" --config RelWithDebInfo
@@ -295,7 +295,7 @@ function buildSentryNative()
     Push-Location -Path $NativePath
     try
     {
-        cmake -B "build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF
+        cmake -B "build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10
         cmake --build "build_native" --target sentry --config RelWithDebInfo --parallel
         cmake --build "build_native" --target sentry-crash --config RelWithDebInfo --parallel
         cmake --install "build_native" --prefix "install_native" --config RelWithDebInfo
@@ -332,7 +332,7 @@ function buildSentryNativeMac()
     Push-Location -Path $NativePath
     try
     {
-        cmake -B "build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
+        cmake -B "build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 `
             -D CMAKE_BUILD_TYPE=RelWithDebInfo -D "CMAKE_OSX_ARCHITECTURES=x86_64;arm64" -D CMAKE_OSX_DEPLOYMENT_TARGET=13.0
         cmake --build "build_native" --target sentry --parallel
         cmake --build "build_native" --target sentry-crash --parallel
@@ -398,14 +398,14 @@ function buildSentryNativeLinux()
     try
     {
         # Static libs with libc++
-        cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
+        cmake -B "build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 `
             -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$clangC -D CMAKE_CXX_COMPILER=$clangCxx `
             -D CMAKE_C_FLAGS="$libcxxCFlags" -D CMAKE_CXX_FLAGS="$libcxxCxxFlags" -D CMAKE_EXE_LINKER_FLAGS="$libcxxLinkFlags" -D HAVE_COPY_FILE_RANGE=0
         cmake --build "build" --target sentry --parallel
         cmake --install "build" --prefix "install"
 
         # crashpad_handler executable with libstdc++ (no transport needed)
-        cmake -B "build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
+        cmake -B "build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 `
             -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$clangC -D CMAKE_CXX_COMPILER=$clangCxx `
             -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++" -D HAVE_COPY_FILE_RANGE=0
         cmake --build "build_crashpad_handler" --target sentry --parallel
@@ -435,14 +435,14 @@ function buildSentryNativeLinux()
     try
     {
         # Static libs with libc++
-        cmake -B "build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
+        cmake -B "build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 `
             -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$clangC -D CMAKE_CXX_COMPILER=$clangCxx `
             -D CMAKE_C_FLAGS="$libcxxCFlags" -D CMAKE_CXX_FLAGS="$libcxxCxxFlags" -D CMAKE_EXE_LINKER_FLAGS="$libcxxLinkFlags" -D HAVE_COPY_FILE_RANGE=0
         cmake --build "build_native" --target sentry --parallel
         cmake --install "build_native" --prefix "install_native"
 
         # sentry-crash executable with libstdc++ (needs transport to send crash envelopes)
-        cmake -B "build_native_crash" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF `
+        cmake -B "build_native_crash" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 `
             -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=$clangC -D CMAKE_CXX_COMPILER=$clangCxx `
             -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++" -D HAVE_COPY_FILE_RANGE=0
         cmake --build "build_native_crash" --target sentry-crash --parallel

--- a/scripts/build-linux-crashpad.sh
+++ b/scripts/build-linux-crashpad.sh
@@ -7,14 +7,14 @@ export sentryArtifactsDestination=$2
 rm -rf "${sentryArtifactsDestination}/"*
 
 # Build sentry-native using clang and libc++ for static libs
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang-13 -D CMAKE_CXX_COMPILER="clang++-13" -D CMAKE_CXX_FLAGS="-stdlib=libc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" \
     -D HAVE_COPY_FILE_RANGE=0
 cmake --build "${sentryNativeRoot}/build" --target sentry --parallel
 cmake --install "${sentryNativeRoot}/build" --prefix "${sentryNativeRoot}/install"
 
 # Build sentry-native using clang and libstdc++ for crashpad executable
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang-13 -D CMAKE_CXX_COMPILER="clang++-13" -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++" \
     -D HAVE_COPY_FILE_RANGE=0
 cmake --build "${sentryNativeRoot}/build_crashpad_handler" --target sentry --parallel

--- a/scripts/build-linux-native.sh
+++ b/scripts/build-linux-native.sh
@@ -7,7 +7,7 @@ export sentryArtifactsDestination=$2
 rm -rf "${sentryArtifactsDestination}/"*
 
 # Build sentry-native using clang and libc++ for static libs
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang-13 -D CMAKE_CXX_COMPILER="clang++-13" -D CMAKE_CXX_FLAGS="-stdlib=libc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libc++" \
     -D HAVE_COPY_FILE_RANGE=0
 cmake --build "${sentryNativeRoot}/build_native" --target sentry --parallel
@@ -15,7 +15,7 @@ cmake --install "${sentryNativeRoot}/build_native" --prefix "${sentryNativeRoot}
 
 # Build sentry-native using clang and libstdc++ for sentry-crash executable
 # Unlike crashpad_handler, sentry-crash needs transport (curl) to send crash envelopes
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native_crash" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native_crash" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang-13 -D CMAKE_CXX_COMPILER="clang++-13" -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++" \
     -D HAVE_COPY_FILE_RANGE=0
 cmake --build "${sentryNativeRoot}/build_native_crash" --target sentry-crash --parallel

--- a/scripts/build-linuxarm64-crashpad.sh
+++ b/scripts/build-linuxarm64-crashpad.sh
@@ -7,7 +7,7 @@ export sentryArtifactsDestination=$2
 rm -rf "${sentryArtifactsDestination}/"*
 
 # Build sentry-native using clang and libc++ for static libs
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang-13 -D CMAKE_CXX_COMPILER="clang++-13" \
     -D CMAKE_C_FLAGS="-mno-outline-atomics" -D CMAKE_CXX_FLAGS="-stdlib=libc++ -mno-outline-atomics" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -mno-outline-atomics" \
     -D HAVE_COPY_FILE_RANGE=0
@@ -15,7 +15,7 @@ cmake --build "${sentryNativeRoot}/build" --target sentry --parallel
 cmake --install "${sentryNativeRoot}/build" --prefix "${sentryNativeRoot}/install"
 
 # Build sentry-native using clang and libstdc++ for crashpad executable
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_crashpad_handler" -D SENTRY_BACKEND=crashpad -D SENTRY_TRANSPORT=none -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang-13 -D CMAKE_CXX_COMPILER="clang++-13" \
     -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++" \
     -D HAVE_COPY_FILE_RANGE=0

--- a/scripts/build-linuxarm64-native.sh
+++ b/scripts/build-linuxarm64-native.sh
@@ -7,7 +7,7 @@ export sentryArtifactsDestination=$2
 rm -rf "${sentryArtifactsDestination}/"*
 
 # Build sentry-native using clang and libc++ for static libs
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang-13 -D CMAKE_CXX_COMPILER="clang++-13" \
     -D CMAKE_C_FLAGS="-mno-outline-atomics" -D CMAKE_CXX_FLAGS="-stdlib=libc++ -mno-outline-atomics" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libc++ -mno-outline-atomics" \
     -D HAVE_COPY_FILE_RANGE=0
@@ -16,7 +16,7 @@ cmake --install "${sentryNativeRoot}/build_native" --prefix "${sentryNativeRoot}
 
 # Build sentry-native using clang and libstdc++ for sentry-crash executable
 # Unlike crashpad_handler, sentry-crash needs transport (curl) to send crash envelopes
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native_crash" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native_crash" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_C_COMPILER=clang-13 -D CMAKE_CXX_COMPILER="clang++-13" \
     -D CMAKE_CXX_FLAGS="-stdlib=libstdc++" -D CMAKE_EXE_LINKER_FLAGS="-stdlib=libstdc++" \
     -D HAVE_COPY_FILE_RANGE=0

--- a/scripts/build-mac-native.sh
+++ b/scripts/build-mac-native.sh
@@ -7,7 +7,7 @@ export sentryArtifactsDestination=$2
 rm -rf "${sentryArtifactsDestination}/"*
 
 # Build sentry-native with native backend for macOS (universal binary: x86_64 + arm64)
-cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF \
+cmake -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10 \
     -D CMAKE_BUILD_TYPE=RelWithDebInfo -D CMAKE_OSX_ARCHITECTURES="x86_64;arm64" -D CMAKE_OSX_DEPLOYMENT_TARGET=13.0
 cmake --build "${sentryNativeRoot}/build_native" --target sentry --parallel
 cmake --build "${sentryNativeRoot}/build_native" --target sentry-crash --parallel

--- a/scripts/build-win64-crashpad.sh
+++ b/scripts/build-win64-crashpad.sh
@@ -7,7 +7,7 @@ export sentryArtifactsDestination=$2
 rm -rf "${sentryArtifactsDestination}/"*
 
 # Force CMake to use the VS2019 toolset (`-T v142`) to maintain native libraries compatibility with older Unreal Engine versions (4.27–5.1)
-cmake -G "Visual Studio 17 2022" -T v142 -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF
+cmake -G "Visual Studio 17 2022" -T v142 -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10
 cmake --build "${sentryNativeRoot}/build" --target sentry --config RelWithDebInfo --parallel
 cmake --build "${sentryNativeRoot}/build" --target crashpad_handler --config RelWithDebInfo --parallel
 cmake --install "${sentryNativeRoot}/build" --prefix "${sentryNativeRoot}/install" --config RelWithDebInfo

--- a/scripts/build-win64-native.sh
+++ b/scripts/build-win64-native.sh
@@ -7,7 +7,7 @@ export sentryArtifactsDestination=$2
 rm -rf "${sentryArtifactsDestination}/"*
 
 # Force CMake to use the VS2019 toolset (`-T v142`) to maintain native libraries compatibility with older Unreal Engine versions (4.27–5.1)
-cmake -G "Visual Studio 17 2022" -T v142 -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF
+cmake -G "Visual Studio 17 2022" -T v142 -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10
 cmake --build "${sentryNativeRoot}/build_native" --target sentry --config RelWithDebInfo --parallel
 cmake --build "${sentryNativeRoot}/build_native" --target sentry-crash --config RelWithDebInfo --parallel
 cmake --install "${sentryNativeRoot}/build_native" --prefix "${sentryNativeRoot}/install_native" --config RelWithDebInfo

--- a/scripts/build-winarm64-crashpad.sh
+++ b/scripts/build-winarm64-crashpad.sh
@@ -6,7 +6,7 @@ export sentryArtifactsDestination=$2
 
 rm -rf "${sentryArtifactsDestination}/"*
 
-cmake -G "Visual Studio 17 2022" -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF
+cmake -G "Visual Studio 17 2022" -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build" -D SENTRY_BACKEND=crashpad -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10
 cmake --build "${sentryNativeRoot}/build" --target sentry --config RelWithDebInfo --parallel
 cmake --build "${sentryNativeRoot}/build" --target crashpad_handler --config RelWithDebInfo --parallel
 cmake --install "${sentryNativeRoot}/build" --prefix "${sentryNativeRoot}/install" --config RelWithDebInfo

--- a/scripts/build-winarm64-native.sh
+++ b/scripts/build-winarm64-native.sh
@@ -6,7 +6,7 @@ export sentryArtifactsDestination=$2
 
 rm -rf "${sentryArtifactsDestination}/"*
 
-cmake -G "Visual Studio 17 2022" -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF
+cmake -G "Visual Studio 17 2022" -S "${sentryNativeRoot}" -B "${sentryNativeRoot}/build_native" -D SENTRY_BACKEND=native -D SENTRY_SDK_NAME=sentry.native.unreal -D SENTRY_BUILD_SHARED_LIBS=OFF -D SENTRY_BATCHER_BUFFER_COUNT=10
 cmake --build "${sentryNativeRoot}/build_native" --target sentry --config RelWithDebInfo --parallel
 cmake --build "${sentryNativeRoot}/build_native" --target sentry-crash --config RelWithDebInfo --parallel
 cmake --install "${sentryNativeRoot}/build_native" --prefix "${sentryNativeRoot}/install_native" --config RelWithDebInfo


### PR DESCRIPTION
Configure sentry-native with 10x100 telemetry buffers to add capacity for `UE_LOG` bursts of up to [1,000 queued items](https://develop.sentry.dev/sdk/telemetry/logs/#buffering).

Depends on:
- https://github.com/getsentry/sentry-native/pull/1867
