### PR TITLE
Grant execute permissions to bundled crash handler binaries (Linux/Mac)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Decrease max session replay clip duration to 20 seconds to prevent replays from being rejected due to the server-side 10 MiB size limit, which could be exceeded at high rendering resolutions ([#1478](https://github.com/getsentry/sentry-unreal/pull/1478))
+- Grant execute permissions to bundled crash handler binaries (Linux/Mac) ([#1486](https://github.com/getsentry/sentry-unreal/pull/1486))
 
 ### Dependencies
 

--- a/plugin-dev/Scripts/post-build-steps-linux.sh
+++ b/plugin-dev/Scripts/post-build-steps-linux.sh
@@ -8,9 +8,21 @@ PROJECT_FILE="$5"
 PLUGIN_DIR="$6"
 ENGINE_DIR="$7"
 
-# Grant execute permissions to sentry-cli binary (FAB version of the plugin doesn't preserve file permissions)
+# Grant execute permissions to bundled binaries (some plugin distribution methods don't preserve file permissions)
 if [ -f "$PLUGIN_DIR/Source/ThirdParty/CLI/sentry-cli-Linux-x86_64" ]; then
   chmod +x "$PLUGIN_DIR/Source/ThirdParty/CLI/sentry-cli-Linux-x86_64"
+fi
+
+if [ -f "$PLUGIN_DIR/Binaries/$TARGET_PLATFORM/crashpad_handler" ]; then
+  chmod +x "$PLUGIN_DIR/Binaries/$TARGET_PLATFORM/crashpad_handler"
+fi
+
+if [ -f "$PLUGIN_DIR/Binaries/$TARGET_PLATFORM/sentry-crash" ]; then
+  chmod +x "$PLUGIN_DIR/Binaries/$TARGET_PLATFORM/sentry-crash"
+fi
+
+if [ -f "$PLUGIN_DIR/Binaries/$TARGET_PLATFORM/Sentry.CrashReporter" ]; then
+  chmod +x "$PLUGIN_DIR/Binaries/$TARGET_PLATFORM/Sentry.CrashReporter"
 fi
 
 # Call Python script for debug symbol upload

--- a/plugin-dev/Scripts/post-build-steps-mac.sh
+++ b/plugin-dev/Scripts/post-build-steps-mac.sh
@@ -14,9 +14,17 @@ if [ "$TARGET_PLATFORM" = "Mac" ] && [ ! -f "$PLUGIN_DIR/Binaries/Mac/SentryObjC
   cp "$PLUGIN_DIR/Source/ThirdParty/Mac/Cocoa/bin/SentryObjC.dylib" "$PLUGIN_DIR/Binaries/Mac/SentryObjC.dylib"
 fi
 
-# Grant execute permissions to sentry-cli binary (FAB version of the plugin doesn't preserve file permissions)
+# Grant execute permissions to bundled binaries (some plugin distribution methods don't preserve file permissions)
 if [ -f "$PLUGIN_DIR/Source/ThirdParty/CLI/sentry-cli-Darwin-universal" ]; then
   chmod +x "$PLUGIN_DIR/Source/ThirdParty/CLI/sentry-cli-Darwin-universal"
+fi
+
+if [ -f "$PLUGIN_DIR/Binaries/$TARGET_PLATFORM/sentry-crash" ]; then
+  chmod +x "$PLUGIN_DIR/Binaries/$TARGET_PLATFORM/sentry-crash"
+fi
+
+if [ -f "$PLUGIN_DIR/Binaries/$TARGET_PLATFORM/Sentry.CrashReporter.app/Contents/MacOS/Sentry.CrashReporter" ]; then
+  chmod +x "$PLUGIN_DIR/Binaries/$TARGET_PLATFORM/Sentry.CrashReporter.app/Contents/MacOS/Sentry.CrashReporter"
 fi
 
 # Call Python script for debug symbol upload


### PR DESCRIPTION
This PR adds `execute` permissions to the crash handler binaries (`crashpad_handler`, `sentry-crash`) and the external crash reporter staged into the plugin's `Binaries` directory during the Linux and Mac post-build steps.

Some plugin distribution methods (e.g. committing the plugin to VCS from Windows, FAB packaging) don't preserve Unix file permissions, causing the SDK to fail at startup with `posix_spawn ... Permission denied` when it tries to launch the crash handler (see [Troubleshooting](https://docs.sentry.io/platforms/unreal/troubleshooting/#app-freezes-on-startup-on-linux) docs page).

Closes #1485