### PR TITLE
Resolve startup crash on Meta Quest during Sentry init (UE 5.7+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Decrease max session replay clip duration to 20 seconds to prevent replays from being rejected due to the server-side 10 MiB size limit, which could be exceeded at high rendering resolutions ([#1478](https://github.com/getsentry/sentry-unreal/pull/1478))
 - Grant execute permissions to bundled crash handler binaries (Linux/Mac) ([#1486](https://github.com/getsentry/sentry-unreal/pull/1486))
+- Resolve startup crash on Meta Quest during Sentry init (UE 5.7+) ([#1487](https://github.com/getsentry/sentry-unreal/pull/1487))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaObjectWrapper.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaObjectWrapper.cpp
@@ -21,7 +21,7 @@ FSentryJavaObjectWrapper::FSentryJavaObjectWrapper(FSentryJavaClass ClassData, c
 
 	va_list Params;
 	va_start(Params, CtorSignature);
-	auto LocalObject = NewScopedJavaObject(JEnv, JEnv->NewObjectV(Class, Constructor, Params));
+	auto LocalObject = NewSentryScopedJavaObject(JEnv, JEnv->NewObjectV(Class, Constructor, Params));
 	va_end(Params);
 	VerifyException();
 	check(LocalObject);
@@ -82,10 +82,10 @@ jobject FSentryJavaObjectWrapper::GetJObject() const
 	return Object;
 }
 
-FScopedJavaObject<jstring> FSentryJavaObjectWrapper::GetJString(const FString& String)
+FSentryScopedJavaObject<jstring> FSentryJavaObjectWrapper::GetJString(const FString& String)
 {
 	JNIEnv* JEnv = AndroidJavaEnv::GetJavaEnv();
-	return FJavaHelper::ToJavaString(JEnv, String);
+	return NewSentryScopedJavaObject(JEnv, JEnv->NewStringUTF(TCHAR_TO_UTF8(*String)));
 }
 
 bool FSentryJavaObjectWrapper::IsInstanceOf(FSentryJavaClass ClassData, jobject JavaClassInstance)
@@ -241,7 +241,7 @@ FString FSentryJavaObjectWrapper::CallMethodInternal<FString>(FSentryJavaMethod 
 }
 
 template<>
-FScopedJavaObject<jobject> FSentryJavaObjectWrapper::CallObjectMethodInternal<jobject>(FSentryJavaMethod Method, va_list Params) const
+FSentryScopedJavaObject<jobject> FSentryJavaObjectWrapper::CallObjectMethodInternal<jobject>(FSentryJavaMethod Method, va_list Params) const
 {
 	VerifyMethodCall(Method);
 	JNIEnv* JEnv = AndroidJavaEnv::GetJavaEnv();
@@ -252,11 +252,11 @@ FScopedJavaObject<jobject> FSentryJavaObjectWrapper::CallObjectMethodInternal<jo
 			: JEnv->CallStaticObjectMethodV(Class, Method.Method, Params);
 
 	VerifyException();
-	return NewScopedJavaObject(JEnv, RetVal);
+	return NewSentryScopedJavaObject(JEnv, RetVal);
 }
 
 template<>
-FScopedJavaObject<jobjectArray> FSentryJavaObjectWrapper::CallObjectMethodInternal<jobjectArray>(FSentryJavaMethod Method, va_list Params) const
+FSentryScopedJavaObject<jobjectArray> FSentryJavaObjectWrapper::CallObjectMethodInternal<jobjectArray>(FSentryJavaMethod Method, va_list Params) const
 {
 	VerifyMethodCall(Method);
 	JNIEnv* JEnv = AndroidJavaEnv::GetJavaEnv();
@@ -267,5 +267,5 @@ FScopedJavaObject<jobjectArray> FSentryJavaObjectWrapper::CallObjectMethodIntern
 			: JEnv->CallStaticObjectMethodV(Class, Method.Method, Params);
 
 	VerifyException();
-	return NewScopedJavaObject(JEnv, (jobjectArray)RetVal);
+	return NewSentryScopedJavaObject(JEnv, (jobjectArray)RetVal);
 }

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaObjectWrapper.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaObjectWrapper.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "AndroidSentryDataTypes.h"
+#include "AndroidSentryScopedJavaObject.h"
 
 #include "Android/AndroidJavaEnv.h"
 
@@ -25,20 +26,20 @@ public:
 	template<typename ReturnType>
 	ReturnType CallMethod(FSentryJavaMethod Method, ...) const;
 	template<typename ReturnType>
-	FScopedJavaObject<ReturnType> CallObjectMethod(FSentryJavaMethod Method, ...) const;
+	FSentryScopedJavaObject<ReturnType> CallObjectMethod(FSentryJavaMethod Method, ...) const;
 
 	template<typename ReturnType>
 	static ReturnType CallStaticMethod(FSentryJavaClass ClassData, FSentryJavaMethod Method, ...);
 	template<typename ReturnType>
 	static ReturnType CallStaticMethod(FSentryJavaClass ClassData, const char* MethodName, const char* FunctionSignature, ...);
 	template<typename ReturnType>
-	static FScopedJavaObject<ReturnType> CallStaticObjectMethod(FSentryJavaClass ClassData, FSentryJavaMethod Method, ...);
+	static FSentryScopedJavaObject<ReturnType> CallStaticObjectMethod(FSentryJavaClass ClassData, FSentryJavaMethod Method, ...);
 	template<typename ReturnType>
-	static FScopedJavaObject<ReturnType> CallStaticObjectMethod(FSentryJavaClass ClassData, const char* MethodName, const char* FunctionSignature, ...);
+	static FSentryScopedJavaObject<ReturnType> CallStaticObjectMethod(FSentryJavaClass ClassData, const char* MethodName, const char* FunctionSignature, ...);
 
 	jobject GetJObject() const;
 
-	static FScopedJavaObject<jstring> GetJString(const FString& String);
+	static FSentryScopedJavaObject<jstring> GetJString(const FString& String);
 
 	static bool IsInstanceOf(FSentryJavaClass ClassData, jobject JavaClassInstance);
 
@@ -49,7 +50,7 @@ private:
 	template<typename ReturnType>
 	ReturnType CallMethodInternal(FSentryJavaMethod Method, va_list Params) const;
 	template<typename ReturnType>
-	FScopedJavaObject<ReturnType> CallObjectMethodInternal(FSentryJavaMethod Method, va_list Params) const;
+	FSentryScopedJavaObject<ReturnType> CallObjectMethodInternal(FSentryJavaMethod Method, va_list Params) const;
 
 protected:
 	jobject Object;
@@ -67,11 +68,11 @@ ReturnType FSentryJavaObjectWrapper::CallMethod(FSentryJavaMethod Method, ...) c
 }
 
 template<typename ReturnType>
-FScopedJavaObject<ReturnType> FSentryJavaObjectWrapper::CallObjectMethod(FSentryJavaMethod Method, ...) const
+FSentryScopedJavaObject<ReturnType> FSentryJavaObjectWrapper::CallObjectMethod(FSentryJavaMethod Method, ...) const
 {
 	va_list Params;
 	va_start(Params, Method);
-	FScopedJavaObject<ReturnType> RetVal = CallObjectMethodInternal<ReturnType>(Method, Params);
+	FSentryScopedJavaObject<ReturnType> RetVal = CallObjectMethodInternal<ReturnType>(Method, Params);
 	va_end(Params);
 	return RetVal;
 }
@@ -103,24 +104,24 @@ ReturnType FSentryJavaObjectWrapper::CallStaticMethod(FSentryJavaClass ClassData
 }
 
 template<typename ReturnType>
-FScopedJavaObject<ReturnType> FSentryJavaObjectWrapper::CallStaticObjectMethod(FSentryJavaClass ClassData, FSentryJavaMethod Method, ...)
+FSentryScopedJavaObject<ReturnType> FSentryJavaObjectWrapper::CallStaticObjectMethod(FSentryJavaClass ClassData, FSentryJavaMethod Method, ...)
 {
 	FSentryJavaObjectWrapper StaticInst(ClassData);
 	va_list Params;
 	va_start(Params, Method);
-	FScopedJavaObject<ReturnType> RetVal = StaticInst.CallObjectMethodInternal<ReturnType>(Method, Params);
+	FSentryScopedJavaObject<ReturnType> RetVal = StaticInst.CallObjectMethodInternal<ReturnType>(Method, Params);
 	va_end(Params);
 	return RetVal;
 }
 
 template<typename ReturnType>
-FScopedJavaObject<ReturnType> FSentryJavaObjectWrapper::CallStaticObjectMethod(FSentryJavaClass ClassData, const char* MethodName, const char* FunctionSignature, ...)
+FSentryScopedJavaObject<ReturnType> FSentryJavaObjectWrapper::CallStaticObjectMethod(FSentryJavaClass ClassData, const char* MethodName, const char* FunctionSignature, ...)
 {
 	FSentryJavaObjectWrapper StaticInst(ClassData);
 	FSentryJavaMethod Method = GetStaticMethod(ClassData, MethodName, FunctionSignature);
 	va_list Params;
 	va_start(Params, FunctionSignature);
-	FScopedJavaObject<ReturnType> RetVal = StaticInst.CallObjectMethodInternal<ReturnType>(Method, Params);
+	FSentryScopedJavaObject<ReturnType> RetVal = StaticInst.CallObjectMethodInternal<ReturnType>(Method, Params);
 	va_end(Params);
 	return RetVal;
 }
@@ -150,7 +151,7 @@ template<>
 FString FSentryJavaObjectWrapper::CallMethodInternal<FString>(FSentryJavaMethod Method, va_list Params) const;
 
 template<>
-FScopedJavaObject<jobject> FSentryJavaObjectWrapper::CallObjectMethodInternal<jobject>(FSentryJavaMethod Method, va_list Params) const;
+FSentryScopedJavaObject<jobject> FSentryJavaObjectWrapper::CallObjectMethodInternal<jobject>(FSentryJavaMethod Method, va_list Params) const;
 
 template<>
-FScopedJavaObject<jobjectArray> FSentryJavaObjectWrapper::CallObjectMethodInternal<jobjectArray>(FSentryJavaMethod Method, va_list Params) const;
+FSentryScopedJavaObject<jobjectArray> FSentryJavaObjectWrapper::CallObjectMethodInternal<jobjectArray>(FSentryJavaMethod Method, va_list Params) const;

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryScopedJavaObject.h
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryScopedJavaObject.h
@@ -1,0 +1,72 @@
+// Copyright (c) 2025 Sentry. All Rights Reserved.
+
+#pragma once
+
+#include "Android/AndroidJavaEnv.h"
+
+// Plugin-owned RAII wrapper for Java local references.
+//
+// Mirrors the implementation of FScopedJavaObject in Unreal Engine versions prior to 5.7.
+template<typename T>
+class FSentryScopedJavaObject
+{
+public:
+	FSentryScopedJavaObject() = default;
+
+	FSentryScopedJavaObject(JNIEnv* InEnv, T InObjRef)
+		: Env(InEnv)
+		, ObjRef(InObjRef)
+	{
+	}
+
+	FSentryScopedJavaObject(FSentryScopedJavaObject&& Other)
+		: Env(Other.Env)
+		, ObjRef(Other.ObjRef)
+	{
+		Other.Env = nullptr;
+		Other.ObjRef = nullptr;
+	}
+
+	FSentryScopedJavaObject(const FSentryScopedJavaObject&) = delete;
+
+	~FSentryScopedJavaObject()
+	{
+		if (Env && ObjRef)
+		{
+			Env->DeleteLocalRef(ObjRef);
+		}
+	}
+
+	FSentryScopedJavaObject& operator=(FSentryScopedJavaObject&& Other)
+	{
+		if (this != &Other)
+		{
+			if (Env && ObjRef)
+			{
+				Env->DeleteLocalRef(ObjRef);
+			}
+
+			Env = Other.Env;
+			ObjRef = Other.ObjRef;
+			Other.Env = nullptr;
+			Other.ObjRef = nullptr;
+		}
+		return *this;
+	}
+
+	FSentryScopedJavaObject& operator=(const FSentryScopedJavaObject&) = delete;
+
+	T operator*() const { return ObjRef; }
+
+	operator bool() const { return ObjRef != nullptr; }
+
+private:
+	JNIEnv* Env = nullptr;
+	T ObjRef = nullptr;
+};
+
+template<typename T>
+FSentryScopedJavaObject<T> NewSentryScopedJavaObject(JNIEnv* InEnv, T InObjRef)
+{
+	return FSentryScopedJavaObject<T>(InEnv, InObjRef);
+}

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -52,6 +52,7 @@ Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaClasses.cpp
 Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaClasses.h
 Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaObjectWrapper.cpp
 Source/Sentry/Private/Android/Infrastructure/AndroidSentryJavaObjectWrapper.h
+Source/Sentry/Private/Android/Infrastructure/AndroidSentryScopedJavaObject.h
 Source/Sentry/Private/Android/Java/SentryBridgeJava.java
 Source/Sentry/Private/Android/Jni/AndroidSentryJni.cpp
 Source/Sentry/Private/Apple/AppleSentryAttachment.cpp


### PR DESCRIPTION
This PR adds a plugin-owned RAII wrapper for Java local references (`FSentryScopedJavaObject`) and switches the Android backend over to it.

In UE 5.7 Epic rewrote the Android JNI layer, so the engine's `FScopedJavaObject` no longer stores the `JNIEnv*` it was created with and its destructor now resolves the environment lazily through the inline `thread_local UE::Jni::Env` (`AndroidJavaEnv.h`). The `(JNIEnv*, T)` constructor that `NewScopedJavaObject` and `FJavaHelper::ToJavaString` route through silently ignores the env input param.

When that destructor is inlined into plugin code, the thread-local read may return an invalid `JNIEnv*` (e.g. on Meta's Horizon OS), so cleaning up any temporary Java object segfaults in `DeleteLocalRef` - right after Sentry has otherwise initialized successfully.

Closes #1484

## Key changes

- `FSentryScopedJavaObject<T>` stores the `JNIEnv*` it was created with and deletes the local ref through it - the pre-5.7 contract, now owned by the plugin instead of relying on engine internals. `GetJString` builds the string directly via `NewStringUTF(TCHAR_TO_UTF8(...))` (identical to the engine's `ToJavaString`).
- All engine scoped-object usage in the Android backend was audited and is fully contained to `AndroidSentryJavaObjectWrapper`; every other JNI site already uses an explicit env (`GetJavaEnv()`, `FStringFromLocalRef`) or is owned by the JVM call frame, so nothing else needed to change.