### PR TITLE
Remove legacy session replay file attachment in favor of Session Replay envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Remove legacy session replay file attachment in favor of Session Replay envelope ([#1493](https://github.com/getsentry/sentry-unreal/pull/1493))
+
 ### Dependencies
 
 - Bump CLI from v3.6.1 to v3.6.2 ([#1491](https://github.com/getsentry/sentry-unreal/pull/1491))

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -125,12 +125,10 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 				}
 				if (settings->AttachSessionReplay)
 				{
-					// If a replay was captured during the previous app run upload it to Sentry.
-					UploadSessionReplayForEvent(MakeShareable(new FAppleSentryId(event.eventId)), prevSessionReplayPath);
-
+					// Deliver the previous run's replay as a structured envelope so it shows
+					// up in the Session Replay product page.
 					if (FPaths::FileExists(prevSessionReplayPath) && FPaths::FileExists(prevSessionReplaySidecarPath))
 					{
-						// Send the structured replay envelope for the crash.
 						FAppleSentryReplayEnvelope::CaptureForCrashEvent(event, prevSessionReplayPath, prevSessionReplaySidecarPath);
 					}
 
@@ -779,17 +777,6 @@ void FAppleSentrySubsystem::UploadGameLogForEvent(TSharedPtr<ISentryId> eventId,
 #if !NO_LOGGING
 	UploadAttachmentForEvent(eventId, logFilePath, SentryFileUtils::GetGameLogName());
 #endif
-}
-
-void FAppleSentrySubsystem::UploadSessionReplayForEvent(TSharedPtr<ISentryId> eventId, const FString& replayPath) const
-{
-	if (replayPath.IsEmpty())
-	{
-		// Recorder only produces a file after the first keyframe so if a crash happens early and nothing is written to disk (empty path) skip the upload
-		return;
-	}
-
-	UploadAttachmentForEvent(eventId, replayPath, TEXT("session-replay.mp4"), false);
 }
 
 FString FAppleSentrySubsystem::GetScreenshotPath() const

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -68,7 +68,6 @@ protected:
 
 	void UploadScreenshotForEvent(TSharedPtr<ISentryId> eventId, const FString& screenshotPath) const;
 	void UploadGameLogForEvent(TSharedPtr<ISentryId> eventId, const FString& logFilePath) const;
-	void UploadSessionReplayForEvent(TSharedPtr<ISentryId> eventId, const FString& replayPath) const;
 
 	virtual FString GetScreenshotPath() const;
 	virtual FString GetLatestScreenshot() const;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -309,16 +309,6 @@ sentry_value_t FGenericPlatformSentrySubsystem::OnBeforeMetric(sentry_value_t me
 
 sentry_value_t FGenericPlatformSentrySubsystem::OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure)
 {
-#ifdef USE_SENTRY_SESSION_REPLAY
-	if (SessionReplay && SessionReplay->HasSnapshotOnDisk())
-	{
-		TSharedPtr<ISentryAttachment> ReplayAttachment =
-			MakeShareable(new FGenericPlatformSentryAttachment(SessionReplay->GetAttachmentPath(), TEXT("session-replay.mp4"), TEXT("video/mp4")));
-
-		AddFileAttachment(ReplayAttachment);
-	}
-#endif
-
 	if (isScreenshotAttachmentEnabled && !IsOutOfProcessScreenshotEnabled() && !IsRunningCommandlet())
 	{
 		if (IsScreenshotSupported())

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -314,7 +314,7 @@ struct FSentrySessionReplayOptions
 	float FragmentSeconds = 0.5f;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General",
-		Meta = (DisplayName = "Rotation interval (seconds)", ToolTip = "How often the on-disk attachment file is refreshed by atomic rename.",
+		Meta = (DisplayName = "Rotation interval (seconds)", ToolTip = "How often the on-disk replay clip is refreshed by atomic rename.",
 			ClampMin = 0.25f, ClampMax = 5.0f))
 	float RotationIntervalSeconds = 1.0f;
 
@@ -560,12 +560,12 @@ class SENTRY_API USentrySettings : public UObject
 	bool UseNativeHangTracking;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Session Replay",
-		Meta = (DisplayName = "Enable session replay (experimental)", ToolTip = "Captures gameplay video and attaches it to crash reports. On desktop platforms (Windows/Mac/Linux), requires the AVCodecsCore plugin plus a codec plugin matching the GPU vendor (NVCodecs for NVIDIA on Windows/Linux, AMFCodecs for AMD on Windows, VTCodecs on Mac) and rebuild after changing. On Xbox, development kits only. On Android, a 30s clip sampled at 1 frame/second.",
+		Meta = (DisplayName = "Enable session replay (experimental)", ToolTip = "Captures a short gameplay video leading up to a crash and sends it to Sentry's Session Replay. On desktop platforms (Windows/Mac/Linux), requires the AVCodecsCore plugin plus a codec plugin matching the GPU vendor (NVCodecs for NVIDIA on Windows/Linux, AMFCodecs for AMD on Windows, VTCodecs on Mac) and rebuild after changing. On Xbox, development kits only. On Android, a 30s clip sampled at 1 frame/second.",
 			ConfigRestartRequired = true))
 	bool AttachSessionReplay;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Session Replay",
-		Meta = (DisplayName = "Replay duration (ms)", ToolTip = "Requested duration of the retroactive replay window. On desktop platforms (Windows/Mac/Linux) this is the rolling clip length kept on disk for crash attachment; on Xbox the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). Ignored on Android, where the SDK determines the duration. Capped at 20 seconds: Sentry rejects replay videos larger than 10 MiB, and longer clips risk exceeding that limit.",
+		Meta = (DisplayName = "Replay duration (ms)", ToolTip = "Requested duration of the retroactive replay window. On desktop platforms (Windows/Mac/Linux) this is the rolling clip length kept on disk for the crash replay; on Xbox the requested length of the OS-captured clip (which may be shorter if not enough frames are buffered). Ignored on Android, where the SDK determines the duration. Capped at 20 seconds: Sentry rejects replay videos larger than 10 MiB, and longer clips risk exceeding that limit.",
 			EditCondition = "AttachSessionReplay", ClampMin = "1000", ClampMax = "20000"))
 	uint32 SessionReplayDurationMs;
 


### PR DESCRIPTION
This PR removes the legacy path that uploaded the session replay clip as a raw `.mp4` file attachment on the crash event, now that the Session Replay product integration is fully functional across platforms.

Both paths were shipping the same recording in two different forms:

- Native platforms (Windows/Linux/Mac): the plugin attached the staged `.mp4` in the `on_crash` hook (`GenericPlatformSentrySubsystem::OnCrash`), while the native SDK's replay envelope pipeline (`sentry__session_replay_flush_pending`) also consumed the same clip.
- Cocoa (macOS/iOS): `AppleSentrySubsystem` both called `UploadSessionReplayForEvent` (file attachment) and `FAppleSentryReplayEnvelope::CaptureForCrashEvent` (envelope).

Beyond being redundant, the two mechanisms actively conflicted on the crashpad backend - the envelope pipeline consumes and deletes the staged `replay-<id>.mp4` while assembling the crash report. Since crashpad copies file attachments out-of-process at dump time (after the in-process `on_crash` hook and after the envelope flush already deleted the file) the file attachment was silently dropped (attachment couldn't be opened, skipping). So on crashpad the legacy path didn't even work; the envelope is the reliable delivery path.

Documentation:
- https://github.com/getsentry/sentry-docs/pull/18810

Related items:
- https://github.com/getsentry/sentry-unreal/pull/1445
- https://github.com/getsentry/sentry-unreal/pull/1468