### PR TITLE
Add app-hang tracking via NDK game-thread heartbeat on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add app-hang tracking via NDK game-thread heartbeat on Android ([#1497](https://github.com/getsentry/sentry-unreal/pull/1497))
+
 ### Fixes
 
 - Remove legacy session replay file attachment in favor of Session Replay envelope ([#1493](https://github.com/getsentry/sentry-unreal/pull/1493))

--- a/integration-test/Integration.Android.Tests.ps1
+++ b/integration-test/Integration.Android.Tests.ps1
@@ -198,6 +198,16 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
         $global:AndroidTracingResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $tracingIntentArgs
 
         Write-Host "Tracing test exit code: $($global:AndroidTracingResult.ExitCode)" -ForegroundColor Cyan
+
+        # ==========================================
+        # RUN 7: Hang test - captures app-hang event
+        # ==========================================
+
+        Write-Host "Running hang-capture test on $Platform..." -ForegroundColor Yellow
+        $hangIntentArgs = "-e cmdline -hang-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableHangTracking=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:UseNativeHangTracking=True"
+        $global:AndroidHangResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $hangIntentArgs
+
+        Write-Host "Hang test exit code: $($global:AndroidHangResult.ExitCode)" -ForegroundColor Cyan
     }
 
     AfterAll {
@@ -731,6 +741,80 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             $childSpan = $script:TransactionEvent.spans | Where-Object { $_.op -eq 'e2e.child' }
             $grandchildSpan = $script:TransactionEvent.spans | Where-Object { $_.op -eq 'e2e.grandchild' }
             $grandchildSpan.parent_span_id | Should -Be $childSpan.span_id
+        }
+    }
+
+    Context "Hang Tracking Tests" {
+        BeforeAll {
+            $script:HangResult = $global:AndroidHangResult
+            $script:HangEvent = $null
+
+            # Parse hang event ID from output (format: EVENT_CAPTURED: <guid>)
+            $eventIds = Get-EventIds -AppOutput $script:HangResult.Output -ExpectedCount 1
+
+            if ($eventIds -and $eventIds.Count -gt 0) {
+                Write-Host "Hang ID captured: $($eventIds[0])" -ForegroundColor Cyan
+                $hangId = $eventIds[0]
+
+                # Fetch hang event using the test.hang_id tag (event was uploaded in-session)
+                try {
+                    $script:HangEvent = Get-SentryTestEvent -TagName 'test.hang_id' -TagValue "$hangId"
+                    Write-Host "Hang event fetched from Sentry successfully" -ForegroundColor Green
+                }
+                catch {
+                    Write-Host "Failed to fetch hang event from Sentry: $_" -ForegroundColor Red
+                }
+            }
+            else {
+                Write-Host "Warning: No hang event ID found in output" -ForegroundColor Yellow
+            }
+        }
+
+        It "Should output event ID" {
+            $eventIds = Get-EventIds -AppOutput $script:HangResult.Output -ExpectedCount 1
+            $eventIds | Should -Not -BeNullOrEmpty
+            $eventIds.Count | Should -Be 1
+        }
+
+        It "Should output TEST_RESULT with success" {
+            $testResultLine = $script:HangResult.Output | Where-Object { $_ -match 'TEST_RESULT:' }
+            $testResultLine | Should -Not -BeNullOrEmpty
+            $testResultLine | Should -Match '"success"\s*:\s*true'
+        }
+
+        It "Should capture hang event in Sentry" {
+            $script:HangEvent | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have correct event type and platform" {
+            $script:HangEvent.type | Should -Be 'error'
+            $script:HangEvent.platform | Should -Be 'native'
+        }
+
+        It "Should have exception with expected type and value" {
+            $script:HangEvent.exception | Should -Not -BeNullOrEmpty
+            $script:HangEvent.exception.values | Should -Not -BeNullOrEmpty
+            $exception = $script:HangEvent.exception.values[0]
+            $exception.type | Should -Be 'AppHang'
+            $exception.value | Should -Match 'App hung for at least \d+ ms'
+        }
+
+        It "Should have AppHang mechanism" {
+            $exception = $script:HangEvent.exception.values[0]
+            $exception.mechanism.type | Should -Be 'AppHang'
+        }
+
+        It "Should have stack trace" {
+            $exception = $script:HangEvent.exception.values[0]
+            $exception.stacktrace | Should -Not -BeNullOrEmpty
+            $exception.stacktrace.frames | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have test.hang_id tag for correlation" {
+            $tags = $script:HangEvent.tags
+            $hangIdTag = $tags | Where-Object { $_.key -eq 'test.hang_id' }
+            $hangIdTag | Should -Not -BeNullOrEmpty
+            $hangIdTag.value | Should -Not -BeNullOrEmpty
         }
     }
 }

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -35,6 +35,8 @@
 #include "Serialization/JsonSerializer.h"
 #include "Utils/SentryScreenshotUtils.h"
 
+#include <dlfcn.h>
+
 FAndroidSentrySubsystem::FAndroidSentrySubsystem()
 {
 	SentryJavaClasses::InitJavaClassRefsCache();
@@ -55,6 +57,8 @@ void FAndroidSentrySubsystem::InitWithSettings(const USentrySettings* settings, 
 
 	isScreenshotAttachmentEnabled = settings->AttachScreenshot;
 
+	bNdkAppHangTracking = settings->EnableHangTracking && settings->UseNativeHangTracking;
+
 	TSharedPtr<FJsonObject> SettingsJson = MakeShareable(new FJsonObject);
 	SettingsJson->SetStringField(TEXT("dsn"), settings->Dsn);
 	SettingsJson->SetStringField(TEXT("release"), settings->GetEffectiveRelease());
@@ -73,6 +77,8 @@ void FAndroidSentrySubsystem::InitWithSettings(const USentrySettings* settings, 
 	SettingsJson->SetBoolField(TEXT("sendDefaultPii"), settings->SendDefaultPii);
 	SettingsJson->SetBoolField(TEXT("enableAnrTracking"), settings->EnableAppNotRespondingTracking);
 	SettingsJson->SetNumberField(TEXT("anrTimeoutMillis"), settings->AppNotRespondingTimeout * 1000.0f);
+	SettingsJson->SetBoolField(TEXT("enableNdkAppHangTracking"), bNdkAppHangTracking);
+	SettingsJson->SetNumberField(TEXT("ndkAppHangTimeoutMillis"), settings->HangTimeoutDuration * 1000.0f);
 	SettingsJson->SetBoolField(TEXT("enableNdk"), settings->AndroidCrashBackend != ESentryAndroidCrashBackend::TombstoneOnly);
 	SettingsJson->SetBoolField(TEXT("enableTombstone"),
 		settings->AndroidCrashBackend == ESentryAndroidCrashBackend::TombstoneOnly || settings->AndroidCrashBackend == ESentryAndroidCrashBackend::TombstoneMergedWithNdk);
@@ -123,6 +129,14 @@ void FAndroidSentrySubsystem::InitWithSettings(const USentrySettings* settings, 
 			TryCaptureScreenshot();
 		});
 	}
+
+	if (IsEnabled() && bNdkAppHangTracking)
+	{
+		// OnEndFrame is broadcast on the game thread, so the first heartbeat latches it as the
+		// monitored thread and every subsequent frame refreshes the heartbeat sentry-native watches
+		// for staleness before capturing an app-hang event.
+		OnEndFrameDelegateHandle = FCoreDelegates::OnEndFrame.AddRaw(this, &FAndroidSentrySubsystem::PumpAppHangHeartbeat);
+	}
 }
 
 void FAndroidSentrySubsystem::Close()
@@ -131,6 +145,12 @@ void FAndroidSentrySubsystem::Close()
 	{
 		FCoreDelegates::OnHandleSystemError.Remove(OnHandleSystemErrorDelegateHandle);
 		OnHandleSystemErrorDelegateHandle.Reset();
+	}
+
+	if (OnEndFrameDelegateHandle.IsValid())
+	{
+		FCoreDelegates::OnEndFrame.Remove(OnEndFrameDelegateHandle);
+		OnEndFrameDelegateHandle.Reset();
 	}
 
 	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::Sentry, "flush", "(J)V", (jlong)3000);
@@ -333,18 +353,21 @@ TSharedPtr<ISentryId> FAndroidSentrySubsystem::CaptureEnsure(const FString& type
 
 TSharedPtr<ISentryId> FAndroidSentrySubsystem::CaptureHang(uint32 HungThreadId)
 {
-	// Hang tracking is handled by the native Android SDK via built-in ANR detection (see EnableAppNotRespondingTracking setting)
+	// Hangs are self-captured by the native SDKs: the JVM ANR watchdog (see EnableAppNotRespondingTracking)
+	// and, when enabled, the sentry-native NDK app-hang watchdog fed by PumpAppHangHeartbeat.
 	return nullptr;
 }
 
 bool FAndroidSentrySubsystem::IsHangTrackingSupported() const
 {
+	// The engine FThreadHeartBeat watcher (FSentryHangWatcher) is never used on Android — CaptureHang is a
+	// no-op here. Keep this false so the top-level subsystem does not create that watcher.
 	return false;
 }
 
 bool FAndroidSentrySubsystem::IsNativeHangTrackingEnabled() const
 {
-	return false;
+	return bNdkAppHangTracking;
 }
 
 void FAndroidSentrySubsystem::CaptureFeedback(TSharedPtr<ISentryFeedback> feedback)
@@ -524,4 +547,28 @@ FString FAndroidSentrySubsystem::TryCaptureScreenshot() const
 	}
 
 	return ScreenshotPath;
+}
+
+void FAndroidSentrySubsystem::PumpAppHangHeartbeat()
+{
+	if (!AppHangHeartbeatFunc)
+	{
+		// libsentry.so is loaded asynchronously by the Java SDK (io.sentry.ndk.SentryNdk), so resolve
+		// the symbol lazily against the already-loaded library rather than linking it at build time.
+		if (void* libsentryHandle = dlopen("libsentry.so", RTLD_NOLOAD | RTLD_NOW))
+		{
+			AppHangHeartbeatFunc = reinterpret_cast<void (*)()>(dlsym(libsentryHandle, "sentry_app_hang_heartbeat"));
+			dlclose(libsentryHandle);
+
+			if (AppHangHeartbeatFunc)
+			{
+				UE_LOG(LogSentrySdk, Log, TEXT("Resolved sentry_app_hang_heartbeat for NDK app-hang tracking."));
+			}
+		}
+	}
+
+	if (AppHangHeartbeatFunc)
+	{
+		AppHangHeartbeatFunc();
+	}
 }

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
@@ -62,9 +62,16 @@ public:
 	FString TryCaptureScreenshot() const;
 
 private:
+	void PumpAppHangHeartbeat();
+
+	void (*AppHangHeartbeatFunc)() = nullptr;
+
+	bool bNdkAppHangTracking = false;
+
 	bool isScreenshotAttachmentEnabled = false;
 
 	FDelegateHandle OnHandleSystemErrorDelegateHandle;
+	FDelegateHandle OnEndFrameDelegateHandle;
 };
 
 typedef FAndroidSentrySubsystem FPlatformSentrySubsystem;

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -86,6 +86,8 @@ public class SentryBridgeJava {
 					}
 					options.setAnrEnabled(settingJson.getBoolean("enableAnrTracking"));
 					options.setAnrTimeoutIntervalMillis(settingJson.getLong("anrTimeoutMillis"));
+					options.setEnableNdkAppHangTracking(settingJson.getBoolean("enableNdkAppHangTracking"));
+					options.setNdkAppHangTimeoutIntervalMillis(settingJson.getLong("ndkAppHangTimeoutMillis"));
                     options.setEnableNdk(settingJson.getBoolean("enableNdk"));
                     options.setTombstoneEnabled(settingJson.getBoolean("enableTombstone"));
 					options.getLogs().setEnabled(settingJson.getBoolean("enableStructuredLogging"));

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -555,7 +555,7 @@ class SENTRY_API USentrySettings : public UObject
 	float HangTimeoutDuration;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Native",
-		Meta = (DisplayName = "Use native hang tracking", ToolTip = "Detect hangs with the sentry-native SDK's built-in app-hang watchdog instead of Unreal Engine's FThreadHeartBeat-based watcher. Works with any crash handler backend (both Crashpad and Native). Supported on Windows, macOS and Linux; ignored on other platforms.",
+		Meta = (DisplayName = "Use native hang tracking", ToolTip = "Detect hangs with the sentry-native SDK's built-in app-hang watchdog instead of Unreal Engine's FThreadHeartBeat-based watcher. Works with any crash handler backend (both Crashpad and Native). Supported on Windows, macOS and Linux. On Android, routes through the NDK app-hang watchdog to monitor the game thread, running alongside (not replacing) the JVM ANR watchdog. Ignored on other platforms.",
 			EditCondition = "EnableHangTracking"))
 	bool UseNativeHangTracking;
 

--- a/sample/Source/SentryPlayground/IntegrationTests/SentryHangTest.cpp
+++ b/sample/Source/SentryPlayground/IntegrationTests/SentryHangTest.cpp
@@ -7,6 +7,7 @@
 
 #include "SentrySubsystem.h"
 
+#include "HAL/PlatformProcess.h"
 #include "Misc/CoreDelegates.h"
 #include "Misc/EngineVersionComparison.h"
 
@@ -50,6 +51,12 @@ void FSentryHangTest::Run()
 		*bHangTriggered = true;
 
 		USentryPlaygroundCrashUtils::Terminate(ESentryAppTerminationType::Hang);
+
+		// On Android the app-hang event is captured by the sentry-native watchdog and written to the
+		// outbox; give the SDK a moment to upload it in-session before flushing and exiting.
+#if PLATFORM_ANDROID
+		FPlatformProcess::Sleep(1.0f);
+#endif
 
 		Self->GetSubsystem()->Close();
 		Self->CompleteWithResult(true);


### PR DESCRIPTION
This PR adds app-hang detection on Android that monitors the Unreal game thread. Until now, Android only had the JVM ANR watchdog (`enableAnrTracking`), which watches the Android main/UI looper - a different thread from Unreal's game thread. A frozen game loop while the UI thread keeps pumping went undetected. This wires up sentry-native's in-process app-hang watchdog on Android (exposed to hybrid SDKs via [getsentry/sentry-java#5623](https://github.com/getsentry/sentry-java/pull/5623)), giving the same game-thread hang detection that is already available on Windows/macOS/Linux - with a native stack trace and consistent event shape across platforms.

The JVM ANR watchdog and the new NDK app-hang watchdog both stay active: they watch different threads and catch different failure modes (system ANR vs. frozen game loop).

## Key Changes

- `AndroidSentrySubsystem` - forwards `enableNdkAppHangTracking` / `ndkAppHangTimeoutMillis` to the Java layer, gated on `EnableHangTracking && UseNativeHangTracking`. Pumps `sentry_app_hang_heartbeat()` from `FCoreDelegates::OnEndFrame` (game thread latches itself as the monitored thread), resolving the symbol lazily via `dlopen("libsentry.so", RTLD_NOLOAD)` + `dlsym` against the library already loaded by the Java SDK. `IsNativeHangTrackingEnabled()` now reflects the feature; `IsHangTrackingSupported()` stays false so the engine `FThreadHeartBeat` watcher is never created on Android.
- `SentryBridgeJava` - applies `setEnableNdkAppHangTracking` / `setNdkAppHangTimeoutIntervalMillis` on `SentryAndroidOptions`.
- `SentrySettings` - reuses the existing hang-tracking settings (no new options); updated the `UseNativeHangTracking` tooltip to note Android coverage.

## Documentation

- https://github.com/getsentry/sentry-docs/pull/18828

## Related items

- https://github.com/getsentry/sentry-java/pull/5623
- https://github.com/getsentry/sentry-unity/pull/2745
- https://github.com/getsentry/sentry-unreal/pull/1427