### PR TITLE
chore: Fix plugin packaging workflow name in dependencies download scripts

### DIFF
--- a/scripts/download-sdks.ps1
+++ b/scripts/download-sdks.ps1
@@ -5,7 +5,7 @@ Write-Host "Downloading native SDKs from the latest CI pipeline"
 function findCiRun([string] $branch)
 {
     Write-Host "Looking for the latest successful CI run on branch '$branch'"
-    $jsonArray = gh run list --branch $branch --workflow package-plugin-workflow --json 'conclusion,databaseId' | ConvertFrom-Json
+    $jsonArray = gh run list --branch $branch --workflow CI --json 'conclusion,databaseId' | ConvertFrom-Json
     $id = $jsonArray | Where-Object 'conclusion' -EQ 'success' | Select-Object -First 1 -ExpandProperty 'databaseId'
     if ( "$id" -eq "" )
     {

--- a/scripts/download-sdks.sh
+++ b/scripts/download-sdks.sh
@@ -6,7 +6,7 @@ cd "$(dirname $0)/../plugin-dev/Source/ThirdParty"
 
 findCiRun() {
     echo "Looking for the latest successful CI run on branch '$1'" >/dev/stderr
-    id=$(gh run list --branch $1 --workflow package-plugin-workflow \
+    id=$(gh run list --branch $1 --workflow CI \
         --json 'conclusion,databaseId' --jq 'first(.[] | select(.conclusion == "success") | .databaseId)')
     if [[ "$id" == "" ]]; then
         echo "  ... no successful CI run found on $1" >/dev/stderr


### PR DESCRIPTION
This PR fixes the expected workflow name in `download-sdks.sh` and `download-sdks.ps1` scripts  - `package-plugin-workflow` changed to `CI` (regression introduced in https://github.com/getsentry/sentry-unreal/pull/1463).

#skip-changelog