### PR TITLE
Add overridable stack trace hook for non-fatal events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ### Features
 
-- Add an overridable stack trace hook so platform implementations can attach an engine-captured stack to non-fatal events ([#1502](https://github.com/getsentry/sentry-unreal/pull/1502))
 - Add app-hang tracking via NDK game-thread heartbeat on Android ([#1497](https://github.com/getsentry/sentry-unreal/pull/1497))
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Features
 
+- Add an overridable stack trace hook so platform implementations can attach an engine-captured stack to non-fatal events ([#1502](https://github.com/getsentry/sentry-unreal/pull/1502))
 - Add app-hang tracking via NDK game-thread heartbeat on Android ([#1497](https://github.com/getsentry/sentry-unreal/pull/1497))
 
 ### Fixes

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -459,6 +459,11 @@ void FGenericPlatformSentrySubsystem::SetEventTag(sentry_value_t event, const ch
 	sentry_value_set_by_key(eventTags, key, sentry_value_new_string(value));
 }
 
+void FGenericPlatformSentrySubsystem::AttachStackTrace(sentry_value_t target)
+{
+	sentry_value_set_stacktrace(target, nullptr, 0);
+}
+
 FGenericPlatformSentrySubsystem::FGenericPlatformSentrySubsystem()
 	: bUseNativeBackend(false)
 	, beforeSend(nullptr)
@@ -809,11 +814,6 @@ void FGenericPlatformSentrySubsystem::ClearAttachments()
 	}
 
 	attachments.Empty();
-}
-
-void FGenericPlatformSentrySubsystem::AttachStackTrace(sentry_value_t target)
-{
-	sentry_value_set_stacktrace(target, nullptr, 0);
 }
 
 TSharedPtr<ISentryId> FGenericPlatformSentrySubsystem::CaptureMessage(const FString& message, ESentryLevel level)

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -811,13 +811,18 @@ void FGenericPlatformSentrySubsystem::ClearAttachments()
 	attachments.Empty();
 }
 
+void FGenericPlatformSentrySubsystem::AttachStackTrace(sentry_value_t target)
+{
+	sentry_value_set_stacktrace(target, nullptr, 0);
+}
+
 TSharedPtr<ISentryId> FGenericPlatformSentrySubsystem::CaptureMessage(const FString& message, ESentryLevel level)
 {
 	sentry_value_t nativeEvent = sentry_value_new_message_event(FGenericPlatformSentryConverters::SentryLevelToNative(level), nullptr, TCHAR_TO_UTF8(*message));
 
 	if (isStackTraceEnabled)
 	{
-		sentry_value_set_stacktrace(nativeEvent, nullptr, 0);
+		AttachStackTrace(nativeEvent);
 	}
 
 	sentry_uuid_t id = sentry_capture_event(nativeEvent);
@@ -830,7 +835,7 @@ TSharedPtr<ISentryId> FGenericPlatformSentrySubsystem::CaptureMessageWithScope(c
 
 	if (isStackTraceEnabled)
 	{
-		sentry_value_set_stacktrace(nativeEvent, nullptr, 0);
+		AttachStackTrace(nativeEvent);
 	}
 
 	sentry_scope_t* scope = sentry_local_scope_new();
@@ -852,7 +857,7 @@ TSharedPtr<ISentryId> FGenericPlatformSentrySubsystem::CaptureEvent(TSharedPtr<I
 
 	if (isStackTraceEnabled)
 	{
-		sentry_value_set_stacktrace(nativeEvent, nullptr, 0);
+		AttachStackTrace(nativeEvent);
 	}
 
 	sentry_uuid_t id = sentry_capture_event(nativeEvent);
@@ -867,7 +872,7 @@ TSharedPtr<ISentryId> FGenericPlatformSentrySubsystem::CaptureEventWithScope(TSh
 
 	if (isStackTraceEnabled)
 	{
-		sentry_value_set_stacktrace(nativeEvent, nullptr, 0);
+		AttachStackTrace(nativeEvent);
 	}
 
 	sentry_scope_t* scope = sentry_local_scope_new();
@@ -890,7 +895,7 @@ TSharedPtr<ISentryId> FGenericPlatformSentrySubsystem::CaptureEnsure(const FStri
 	sentry_value_t nativeException = sentry_value_new_exception(TCHAR_TO_UTF8(*type), TCHAR_TO_UTF8(*message));
 	sentry_event_add_exception(exceptionEvent, nativeException);
 
-	sentry_value_set_stacktrace(exceptionEvent, nullptr, 0);
+	AttachStackTrace(exceptionEvent);
 
 	FString ScreenshotPath;
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -111,6 +111,11 @@ protected:
 	virtual sentry_value_t OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure);
 	virtual double OnTraceSampling(const sentry_transaction_context_t* transaction_ctx, sentry_value_t custom_sampling_ctx, const int* parent_sampled);
 
+	// Attaches a stack trace to the given event/exception/thread value. The default implementation lets
+	// sentry-native capture and symbolize the current stack. Platforms whose native SDK can't unwind or
+	// symbolize non-fatal events (e.g. PlayStation) can override this to supply an engine-captured stack.
+	virtual void AttachStackTrace(sentry_value_t target);
+
 	virtual bool IsScreenshotSupported() const;
 	virtual bool IsOutOfProcessScreenshotEnabled() const { return false; }
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -111,11 +111,6 @@ protected:
 	virtual sentry_value_t OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure);
 	virtual double OnTraceSampling(const sentry_transaction_context_t* transaction_ctx, sentry_value_t custom_sampling_ctx, const int* parent_sampled);
 
-	// Attaches a stack trace to the given event/exception/thread value. The default implementation lets
-	// sentry-native capture and symbolize the current stack. Platforms whose native SDK can't unwind or
-	// symbolize non-fatal events (e.g. PlayStation) can override this to supply an engine-captured stack.
-	virtual void AttachStackTrace(sentry_value_t target);
-
 	virtual bool IsScreenshotSupported() const;
 	virtual bool IsOutOfProcessScreenshotEnabled() const { return false; }
 
@@ -128,6 +123,8 @@ protected:
 
 	void SetEventCrashType(sentry_value_t event, ECrashContextType crashType);
 	void SetEventTag(sentry_value_t event, const char* key, const char* value);
+
+	virtual void AttachStackTrace(sentry_value_t target);
 
 	bool bUseNativeBackend;
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
@@ -191,8 +191,30 @@ sentry_value_t FGenericPlatformSentryConverters::CallstackToNative(const TArray<
 	sentry_value_t frames = sentry_value_new_list();
 	for (int i = 0; i < framesCount; ++i)
 	{
+		const FProgramCounterSymbolInfo& symbolInfo = callstack[framesCount - i - 1];
+
 		sentry_value_t frame = sentry_value_new_object();
-		sentry_value_set_by_key(frame, "instruction_addr", AddressToNative(callstack[framesCount - i - 1].ProgramCounter));
+		sentry_value_set_by_key(frame, "instruction_addr", AddressToNative(symbolInfo.ProgramCounter));
+
+		// Frames may be symbolized on-device (e.g. PlayStation in Development builds). When symbol data is
+		// available it's attached directly so the event is readable without server-side symbolication.
+		if (symbolInfo.FunctionName[0] != '\0')
+		{
+			sentry_value_set_by_key(frame, "function", sentry_value_new_string(symbolInfo.FunctionName));
+		}
+		if (symbolInfo.Filename[0] != '\0')
+		{
+			sentry_value_set_by_key(frame, "filename", sentry_value_new_string(symbolInfo.Filename));
+		}
+		if (symbolInfo.LineNumber > 0)
+		{
+			sentry_value_set_by_key(frame, "lineno", sentry_value_new_int32(symbolInfo.LineNumber));
+		}
+		if (symbolInfo.ModuleName[0] != '\0')
+		{
+			sentry_value_set_by_key(frame, "package", sentry_value_new_string(symbolInfo.ModuleName));
+		}
+
 		sentry_value_append(frames, frame);
 	}
 


### PR DESCRIPTION
This PR introduces a virtual `AttachStackTrace()` hook in the generic subsystem that all non-fatal capture paths (message, event, ensure) route through. The default implementation is unchanged - it lets `sentry-native` capture and symbolize the current stack - so behavior on existing platforms is identical.

Platform implementations whose native SDK can't unwind or symbolize non-fatal events can override this hook to supply an engine-captured stack instead. To support that, `CallstackToNative` now also emits on-device symbol data (function, filename, line, package) alongside the instruction address.

#skip-changelog