### PR TITLE
Suppress missing `ProfilingManager`/`ProfilingResult` Android classes in R8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix Android `minifyRelease` R8 build failure caused by missing `android.os.ProfilingManager` class reference in the Java SDK ([#1505](https://github.com/getsentry/sentry-unreal/pull/1505))
+- Fix Android `minifyRelease` R8 build failure caused by missing `android.os.ProfilingManager`/`ProfilingResult` class references in the Java SDK ([#1505](https://github.com/getsentry/sentry-unreal/pull/1505))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fixes
 
-- Fix Android `minifyRelease` R8 build failure caused by missing `android.os.ProfilingManager` class reference in the Java SDK ([#PLACEHOLDER](https://github.com/getsentry/sentry-unreal/pull/PLACEHOLDER))
+- Fix Android `minifyRelease` R8 build failure caused by missing `android.os.ProfilingManager` class reference in the Java SDK ([#1505](https://github.com/getsentry/sentry-unreal/pull/1505))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Fix Android `minifyRelease` R8 build failure caused by missing `android.os.ProfilingManager` class reference in the Java SDK ([#PLACEHOLDER](https://github.com/getsentry/sentry-unreal/pull/PLACEHOLDER))
+
 ### Dependencies
 
 - Bump Java SDK from v8.51.0-1-g057ba3685 to v8.51.0 ([#1503](https://github.com/getsentry/sentry-unreal/pull/1503))

--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -64,6 +64,7 @@
         <insert>
             -dontwarn android.app.ApplicationStartInfo
             -dontwarn android.os.ProfilingManager
+            -dontwarn android.os.ProfilingResult
             -dontwarn io.sentry.unreal.**
             -keep class io.sentry.** { *; }
             -keep interface io.sentry.** { *; }

--- a/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
+++ b/plugin-dev/Source/Sentry/Sentry_Android_UPL.xml
@@ -63,6 +63,7 @@
     <proguardAdditions>
         <insert>
             -dontwarn android.app.ApplicationStartInfo
+            -dontwarn android.os.ProfilingManager
             -dontwarn io.sentry.unreal.**
             -keep class io.sentry.** { *; }
             -keep interface io.sentry.** { *; }


### PR DESCRIPTION
This PR fixes the Android R8 minification (`minifyRelease`) build failure introduced by the Java SDK 8.51.0 bump (#1503).

Java SDK 8.51.0 added `PerfettoProfiler`, which references `android.os.ProfilingManager` and `android.os.ProfilingResult` - API 35+ (Android 15) classes. When the build's `compileSdk` is below 35, R8 sees these as missing:

```
ERROR: R8: Missing class android.os.ProfilingManager (referenced from: io.sentry.android.core.PerfettoProfiler.profilingManager and 3 other contexts)
Missing class android.os.ProfilingResult (referenced from: io.sentry.android.core.PerfettoProfiler.profilingResult and 4 other contexts)
> Task :app:minifyReleaseWithR8 FAILED
```

Failing CI run: https://github.com/getsentry/sentry-unreal/actions/runs/30518575360/job/90815425367

### Why only UE 5.5 fails

Across the Android CI matrix, only **UE 5.5** fails; 5.4, 5.6, 5.7 and 5.8 pass. Two independent factors line up:

- **UE 5.6+** compiles against `compileSdk = 35`, so `ProfilingManager`/`ProfilingResult` exist on the classpath - nothing is missing.
- **UE 5.4** compiles against a lower `compileSdk` and hits the *same* missing classes, but its Android toolchain reports them as a **`WARNING:`** and the build succeeds.
- **UE 5.5** compiles against a lower `compileSdk` **and** its toolchain promotes the missing-class report to a hard **`ERROR:`**, failing the build.

So UE 5.5 is the unique combination of "`compileSdk` < 35" and "missing classes treated as a fatal R8 error".

## Suggested Fix

Add `-dontwarn` rules for both classes to the plugin's `proguardAdditions`. These APIs are only invoked on API 35+ devices, so suppressing the missing-class errors on a lower `compileSdk` is safe. This mirrors the existing `-dontwarn android.app.ApplicationStartInfo` rule added in #1222.
