### PR TITLE
Harden session replay GPU capture

### DIFF
--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -68,9 +68,9 @@ void FSentryBackBufferCapture::Stop()
 
 	// Ensure render thread is done with our textures before destruction
 	FlushRenderingCommands();
-	for (FTextureRHIRef& Slot : EncoderPool.Slots)
+	for (TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& Slot : EncoderPool.Slots)
 	{
-		Slot.SafeRelease();
+		Slot.Reset();
 	}
 	Scratch.Texture.SafeRelease();
 	Converted.Texture.SafeRelease();
@@ -141,9 +141,6 @@ void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIR
 	constexpr ERHIAccess PoolInitialState = ERHIAccess::SRVGraphics;
 #endif
 
-	FTextureRHIRef EncoderTex = AcquireTexturePoolSlot_RenderThread(EncoderPool, W, H, PF_B8G8R8A8,
-		PoolFlags, PoolInitialState, TEXT("SentrySessionReplayCapture"));
-
 	if (!ScratchTex.IsValid())
 	{
 		return;
@@ -156,10 +153,15 @@ void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIR
 	}
 #endif
 
-	if (!EncoderTex.IsValid())
+	FSentryVideoFramePtr EncoderFrame = AcquireTexturePoolSlot_RenderThread(EncoderPool, W, H, PF_B8G8R8A8,
+		PoolFlags, PoolInitialState, TEXT("SentrySessionReplayCapture"));
+
+	if (!EncoderFrame.IsValid())
 	{
 		return;
 	}
+
+	const FTextureRHIRef& EncoderTex = EncoderFrame->Texture;
 
 #if PLATFORM_APPLE
 	FTextureRHIRef DrawTarget = ConvertedTex;
@@ -188,7 +190,7 @@ void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIR
 
 	// Step 2: AddDrawTexturePass scratch -> DrawTarget (BGRA8). Same-format fast
 	// path is a hardware copy; format mismatch (HDR / 10-bit source) falls back
-	// to the engine's built-in FDrawTexturePS pixel shader
+	// to the engine's built-in FDrawTexturePS pixel shader.
 	{
 		FRDGBuilder GraphBuilder(RHICmdList);
 
@@ -223,7 +225,12 @@ void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIR
 	RHICmdList.Transition(FRHITransitionInfo(EncoderTex.GetReference(), ERHIAccess::Unknown, ERHIAccess::SRVGraphics));
 #endif
 
-	Encoder.SubmitFrame(EncoderTex, Now);
+	// The encoder runs on a worker thread outside the render/RHI command
+	// streams. Do not expose this slot until all GPU writes above have passed.
+	EncoderFrame->ReadyFence->Clear();
+	RHICmdList.WriteGPUFence(EncoderFrame->ReadyFence);
+
+	Encoder.SubmitFrame(EncoderFrame, Now);
 }
 
 FTextureRHIRef FSentryBackBufferCapture::AcquireCachedTexture_RenderThread(FCachedTexture& Cache, uint32 Width, uint32 Height, EPixelFormat Format,
@@ -251,27 +258,31 @@ FTextureRHIRef FSentryBackBufferCapture::AcquireCachedTexture_RenderThread(FCach
 	return Cache.Texture;
 }
 
-FTextureRHIRef FSentryBackBufferCapture::AcquireTexturePoolSlot_RenderThread(FCachedTexturePool& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
+FSentryVideoFramePtr FSentryBackBufferCapture::AcquireTexturePoolSlot_RenderThread(
+	FCachedTexturePool& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
 	ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName)
 {
 	if (Width != Pool.Width || Height != Pool.Height || Format != Pool.Format || Flags != Pool.Flags)
 	{
-		for (FTextureRHIRef& Slot : Pool.Slots)
-		{
-			Slot.SafeRelease();
-		}
+		Pool.Slots.Reset();
+		Pool.Slots.SetNum(FSentryVideoEncoder::MaxQueueDepth);
 		Pool.Width = Width;
 		Pool.Height = Height;
 		Pool.Format = Format;
 		Pool.Flags = Flags;
 	}
 
-	FTextureRHIRef* FreeSlot = nullptr;
-	for (FTextureRHIRef& Slot : Pool.Slots)
+	FSentryVideoFramePtr FreeSlot;
+	for (FSentryVideoFramePtr& Slot : Pool.Slots)
 	{
-		if (Slot.GetRefCount() <= 1)
+		if (!Slot.IsValid())
 		{
-			FreeSlot = &Slot;
+			Slot = MakeShared<FSentryVideoFrame, ESPMode::ThreadSafe>();
+		}
+
+		if (Slot->TryAcquire())
+		{
+			FreeSlot = Slot;
 			break;
 		}
 	}
@@ -281,17 +292,28 @@ FTextureRHIRef FSentryBackBufferCapture::AcquireTexturePoolSlot_RenderThread(FCa
 		return nullptr;
 	}
 
-	if (!FreeSlot->IsValid())
+	if (!FreeSlot->Texture.IsValid())
 	{
 		const FRHITextureCreateDesc Desc = FRHITextureCreateDesc::Create2D(DebugName)
 											   .SetExtent(static_cast<int32>(Width), static_cast<int32>(Height))
 											   .SetFormat(Format)
 											   .SetFlags(Flags)
 											   .SetInitialState(InitialState);
-		*FreeSlot = FRHICommandListImmediate::Get().CreateTexture(Desc);
+		FreeSlot->Texture = FRHICommandListImmediate::Get().CreateTexture(Desc);
 	}
 
-	return *FreeSlot;
+	if (!FreeSlot->ReadyFence.IsValid())
+	{
+		FreeSlot->ReadyFence = RHICreateGPUFence(TEXT("SentrySessionReplayCaptureFence"));
+	}
+
+	if (!FreeSlot->Texture.IsValid() || !FreeSlot->ReadyFence.IsValid())
+	{
+		FreeSlot->Release();
+		return nullptr;
+	}
+
+	return FreeSlot;
 }
 
 #endif // USE_SENTRY_SESSION_REPLAY

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
@@ -14,22 +14,24 @@
 #include "RHIFwd.h"
 
 class FSentryVideoEncoder;
+struct FSentryVideoFrame;
 class ISlateViewportProvider;
 class SWindow;
 
 /**
  * Hooks FSlateRenderer::OnBackBufferReadyToPresent and forwards each rendered
- * frame of the primary game window to the encoder.
+ * rendered backbuffer to the encoder.
  *
  * Per frame on the render thread:
  *   1. Hardware-copy the backbuffer into a "scratch" texture that has the same
  *      format but also carries the ShaderResource flag (Slate backbuffers don't,
  *      which makes them unusable as an SRV directly).
- *   2. AddDrawTexturePass scratch -> a BGRA8 destination. When the scratch
- *      format is already BGRA8 this stays a hardware copy; otherwise the
- *      engine's built-in pixel-shader path converts HDR/10-bit to BGRA8.
- *      Destination is the encoder pool slot on Windows; on Apple platforms it's the
- *      "converted" texture because Metal forbids RenderTargetable | CPUReadback.
+ *   2. AddDrawTexturePass scratch -> a same-size BGRA8 destination. When the
+ *      scratch format is already BGRA8 this stays a hardware copy; otherwise
+ *      the engine's built-in pixel-shader path converts HDR/10-bit to BGRA8.
+ *      Destination is the encoder pool slot on Windows; on Apple platforms
+ *      it's the "converted" texture because Metal forbids RenderTargetable |
+ *      CPUReadback.
  *   3. Apple only: hardware-copy converted -> encoder pool slot (CPUReadback BGRA8).
  * The pool slot is then handed to the encoder.
  */
@@ -57,10 +59,10 @@ private:
 	};
 
 	// N-slot pool sharing one config across all slots. Slots are created lazily
-	// and recycled when their refcount drops back to 1 (no other holder)
+	// and explicitly released by the encoder thread after GPU/encoder completion
 	struct FCachedTexturePool
 	{
-		TArray<FTextureRHIRef> Slots;
+		TArray<TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>> Slots;
 		uint32 Width = 0;
 		uint32 Height = 0;
 		EPixelFormat Format = PF_Unknown;
@@ -81,9 +83,10 @@ private:
 	static FTextureRHIRef AcquireCachedTexture_RenderThread(FCachedTexture& Cache, uint32 Width, uint32 Height, EPixelFormat Format,
 		ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName);
 
-	// Returns a texture pool slot whose refcount is <= 1, recreating the entire pool when
+	// Returns an exclusively acquired texture pool slot, recreating the pool when
 	// the config changes. Returns null when every slot is still in flight
-	static FTextureRHIRef AcquireTexturePoolSlot_RenderThread(FCachedTexturePool& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
+	static TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe> AcquireTexturePoolSlot_RenderThread(
+		FCachedTexturePool& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
 		ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName);
 
 	FSentryVideoEncoder& Encoder;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentrySessionReplayRecorder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentrySessionReplayRecorder.cpp
@@ -43,7 +43,15 @@ bool FSentrySessionReplayRecorder::Initialize(const USentrySettings* Settings, c
 		return false;
 	}
 
-	WindowSeconds = Settings->SessionReplayDurationMs / 1000.0f;
+	constexpr uint32 MinReplayDurationMs = 1000;
+	constexpr uint32 MaxReplayDurationMs = 20000;
+	const uint32 ReplayDurationMs = FMath::Clamp(Settings->SessionReplayDurationMs, MinReplayDurationMs, MaxReplayDurationMs);
+	if (ReplayDurationMs != Settings->SessionReplayDurationMs)
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: requested duration %u ms is outside the supported range; using %u ms."),
+			Settings->SessionReplayDurationMs, ReplayDurationMs);
+	}
+	WindowSeconds = ReplayDurationMs / 1000.0f;
 	FragmentSeconds = Settings->SessionReplayOptions.FragmentSeconds;
 	RotationIntervalSeconds = Settings->SessionReplayOptions.RotationIntervalSeconds;
 
@@ -145,18 +153,20 @@ void FSentrySessionReplayRecorder::Shutdown()
 	{
 		FScopeLock Lock(&RingLock);
 		InitSegment.Empty();
+		InitSegmentWidth = 0;
+		InitSegmentHeight = 0;
 		FragmentRing.Reset();
 	}
 }
 
-FSentryReplayInfo FSentrySessionReplayRecorder::BuildReplayInfo() const
+FSentryReplayInfo FSentrySessionReplayRecorder::BuildReplayInfo(int32 Width, int32 Height) const
 {
 	const FDateTime NowUtc = FDateTime::UtcNow();
 
 	FSentryReplayInfo Info;
 	Info.ReplayId = ReplayId;
-	Info.Width = Encoder ? static_cast<int32>(Encoder->GetWidth()) : 0;
-	Info.Height = Encoder ? static_cast<int32>(Encoder->GetHeight()) : 0;
+	Info.Width = Width;
+	Info.Height = Height;
 	Info.FrameRate = Encoder ? static_cast<int32>(Encoder->GetFramerate()) : 0;
 	Info.DurationMs = LatestDurationMs;
 	Info.FrameCount = LatestFrameCount;
@@ -167,10 +177,12 @@ FSentryReplayInfo FSentrySessionReplayRecorder::BuildReplayInfo() const
 	return Info;
 }
 
-void FSentrySessionReplayRecorder::OnInitSegmentReady(TArray<uint8>&& NewInitSegment)
+void FSentrySessionReplayRecorder::OnInitSegmentReady(TArray<uint8>&& NewInitSegment, uint32 Width, uint32 Height)
 {
 	FScopeLock Lock(&RingLock);
 	InitSegment = MoveTemp(NewInitSegment);
+	InitSegmentWidth = static_cast<int32>(Width);
+	InitSegmentHeight = static_cast<int32>(Height);
 
 	if (!FragmentRing.IsEmpty())
 	{
@@ -241,12 +253,17 @@ void FSentrySessionReplayRecorder::DoRotation()
 	TArray<uint8> Snapshot;
 	int64 TotalFrames = 0;
 	uint64 TotalTicks = 0;
+	int32 SnapshotWidth = 0;
+	int32 SnapshotHeight = 0;
 	{
 		FScopeLock Lock(&RingLock);
-		if (InitSegment.Num() == 0 || FragmentRing.Num() == 0)
+		if (InitSegment.Num() == 0 || InitSegmentWidth <= 0 || InitSegmentHeight <= 0 || FragmentRing.Num() == 0)
 		{
 			return;
 		}
+
+		SnapshotWidth = InitSegmentWidth;
+		SnapshotHeight = InitSegmentHeight;
 
 		int64 Reserve = InitSegment.Num();
 		for (int32 i = 0; i < FragmentRing.Num(); ++i)
@@ -283,7 +300,7 @@ void FSentrySessionReplayRecorder::DoRotation()
 	{
 		bSnapshotOnDisk.AtomicSet(true);
 
-		WriteReplayMetadata();
+		WriteReplayMetadata(SnapshotWidth, SnapshotHeight);
 	}
 }
 
@@ -316,10 +333,10 @@ bool FSentrySessionReplayRecorder::WriteSnapshot(const TArray<uint8>& Bytes)
 	return true;
 }
 
-void FSentrySessionReplayRecorder::WriteReplayMetadata()
+void FSentrySessionReplayRecorder::WriteReplayMetadata(int32 Width, int32 Height)
 {
 	FString Json;
-	if (!FJsonObjectConverter::UStructToJsonObjectString(BuildReplayInfo(), Json, 0, 0, 0, nullptr, false))
+	if (!FJsonObjectConverter::UStructToJsonObjectString(BuildReplayInfo(Width, Height), Json, 0, 0, 0, nullptr, false))
 	{
 		return;
 	}

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentrySessionReplayRecorder.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentrySessionReplayRecorder.h
@@ -46,7 +46,7 @@ public:
 	const FString& GetAttachmentPath() const { return AttachmentPath; }
 
 	// Called by the encoder thread when the init segment (ftyp+moov) is ready
-	void OnInitSegmentReady(TArray<uint8>&& InitSegment);
+	void OnInitSegmentReady(TArray<uint8>&& InitSegment, uint32 Width, uint32 Height);
 	// Called by the encoder thread when a fragment (moof+mdat) is complete
 	void OnFragmentReady(TArray<uint8>&& Fragment, uint32 FrameCount, uint64 DurationTicks);
 
@@ -61,11 +61,11 @@ private:
 	bool WriteSnapshot(const TArray<uint8>& Bytes);
 
 	// Assembles the platform-agnostic replay model from the most recent on-disk snapshot
-	FSentryReplayInfo BuildReplayInfo() const;
+	FSentryReplayInfo BuildReplayInfo(int32 Width, int32 Height) const;
 
 	// Writes the JSON metadata sidecar next to the mp4 (temp + atomic rename) so the
 	// SDK can build and send the replay envelope outside the crash handler
-	void WriteReplayMetadata();
+	void WriteReplayMetadata(int32 Width, int32 Height);
 
 	bool bEnabled = false;
 	FThreadSafeBool bSnapshotOnDisk;
@@ -96,6 +96,8 @@ private:
 	// Fragment ring + init segment, protected by RingLock
 	FCriticalSection RingLock;
 	TArray<uint8> InitSegment;
+	int32 InitSegmentWidth = 0;
+	int32 InitSegmentHeight = 0;
 	TRingBuffer<FFragment> FragmentRing;
 
 	int32 LatestFrameCount = 0;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -11,6 +11,7 @@
 #include "HAL/PlatformMisc.h"
 #include "HAL/RunnableThread.h"
 #include "Misc/ScopeLock.h"
+#include "Misc/ScopeExit.h"
 #include "RHI.h"
 
 #include "AVConfig.h"
@@ -83,22 +84,42 @@ void FSentryVideoEncoder::StopEncoder()
 		FPlatformProcess::ReturnSynchEventToPool(WakeEvent);
 		WakeEvent = nullptr;
 	}
+
+	RetirePendingFrames();
+	PollRetiredFrames();
+	ResourceCache.Reset();
 }
 
-void FSentryVideoEncoder::SubmitFrame(const FTextureRHIRef& Texture, double CaptureTimeSeconds)
+void FSentryVideoEncoder::SubmitFrame(const FSentryVideoFramePtr& Frame, double CaptureTimeSeconds)
 {
-	if (!Texture.IsValid() || bStopRequested || bEncodingDisabled)
+	if (!Frame.IsValid())
 	{
+		return;
+	}
+
+	if (!Frame->Texture.IsValid() || !Frame->ReadyFence.IsValid())
+	{
+		Frame->Release();
 		return;
 	}
 
 	{
 		FScopeLock Lock(&QueueLock);
+		if (bStopRequested || bEncodingDisabled)
+		{
+			RetiredFrames.Add(Frame);
+			return;
+		}
+
 		if (PendingQueue.Num() >= MaxQueueDepth)
 		{
+			if (PendingQueue[0].Frame.IsValid())
+			{
+				RetiredFrames.Add(MoveTemp(PendingQueue[0].Frame));
+			}
 			PendingQueue.RemoveAt(0, 1, EAllowShrinking::No);
 		}
-		PendingQueue.Add(FPendingFrame{ Texture, CaptureTimeSeconds });
+		PendingQueue.Add(FPendingFrame{ Frame, CaptureTimeSeconds });
 	}
 	if (WakeEvent)
 	{
@@ -122,6 +143,7 @@ void FSentryVideoEncoder::Stop()
 
 void FSentryVideoEncoder::Exit()
 {
+	ResourceCache.Reset();
 	Encoder.Reset();
 	bEncoderOpen = false;
 }
@@ -130,14 +152,11 @@ uint32 FSentryVideoEncoder::Run()
 {
 	while (!bStopRequested)
 	{
-		TArray<FPendingFrame> Frames;
-		{
-			FScopeLock Lock(&QueueLock);
-			Swap(Frames, PendingQueue);
-		}
+		PollRetiredFrames();
 
 		if (bEncodingDisabled)
 		{
+			RetirePendingFrames();
 			if (WakeEvent)
 			{
 				WakeEvent->Wait(50);
@@ -145,99 +164,125 @@ uint32 FSentryVideoEncoder::Run()
 			continue;
 		}
 
-		for (const FPendingFrame& Frame : Frames)
+		FPendingFrame PendingFrame;
+		bool bQueueNotEmpty = false;
 		{
-			const FTextureRHIRef& FrameTexture = Frame.Texture;
-			if (!FrameTexture.IsValid())
+			FScopeLock Lock(&QueueLock);
+			bQueueNotEmpty = !PendingQueue.IsEmpty();
+			if (bQueueNotEmpty)
 			{
-				continue;
-			}
-			const uint32 ResW = FrameTexture->GetSizeX();
-			const uint32 ResH = FrameTexture->GetSizeY();
-			if (!EnsureEncoderOpen(ResW, ResH))
-			{
-				if (bEncodingDisabled)
+				const FSentryVideoFramePtr& FirstFrame = PendingQueue[0].Frame;
+				if (!FirstFrame.IsValid() || !FirstFrame->ReadyFence.IsValid() || FirstFrame->ReadyFence->Poll())
 				{
-					break;
+					PendingFrame = MoveTemp(PendingQueue[0]);
+					PendingQueue.RemoveAt(0, 1, EAllowShrinking::No);
 				}
-				continue;
 			}
+		}
 
-			TSharedRef<FVideoResourceRHI> Resource = MakeShared<FVideoResourceRHI>(Encoder->GetDevice().ToSharedRef(),
-				FVideoResourceRHI::FRawData{ FrameTexture, nullptr, 0 });
-
-			bool bForceKeyframe = false;
-			if (LastForcedKeyframeTime <= 0.0 || (Frame.CaptureTimeSeconds - LastForcedKeyframeTime) >= FragmentSeconds)
+		if (!PendingFrame.Frame.IsValid())
+		{
+			if (WakeEvent)
 			{
-				bForceKeyframe = true;
-				LastForcedKeyframeTime = Frame.CaptureTimeSeconds;
+				// A queued frame whose fence has not passed is checked again
+				// shortly. Polling from this worker never blocks the RHI thread.
+				WakeEvent->Wait(bQueueNotEmpty ? 1 : 50);
 			}
+			continue;
+		}
 
-			if (CaptureTimeBaseSeconds < 0.0)
-			{
-				CaptureTimeBaseSeconds = Frame.CaptureTimeSeconds;
-			}
+		ON_SCOPE_EXIT
+		{
+			PendingFrame.Frame->Release();
+		};
 
-			// VT interprets SendFrame's timestamp as microseconds (see Engine's VideoEncoderVT.hpp)
+		const FTextureRHIRef& FrameTexture = PendingFrame.Frame->Texture;
+		if (!FrameTexture.IsValid())
+		{
+			continue;
+		}
+
+		const uint32 ResW = FrameTexture->GetSizeX();
+		const uint32 ResH = FrameTexture->GetSizeY();
+		if (!EnsureEncoderOpen(ResW, ResH))
+		{
+			continue;
+		}
+
+		TSharedPtr<FVideoResourceRHI> Resource = GetOrCreateResource(FrameTexture);
+		if (!Resource.IsValid())
+		{
+			UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to wrap capture texture for the video encoder"));
+			continue;
+		}
+
+		bool bForceKeyframe = false;
+		if (LastForcedKeyframeTime <= 0.0 || (PendingFrame.CaptureTimeSeconds - LastForcedKeyframeTime) >= FragmentSeconds)
+		{
+			bForceKeyframe = true;
+			LastForcedKeyframeTime = PendingFrame.CaptureTimeSeconds;
+		}
+
+		if (CaptureTimeBaseSeconds < 0.0)
+		{
+			CaptureTimeBaseSeconds = PendingFrame.CaptureTimeSeconds;
+		}
+
+		// VT interprets SendFrame's timestamp as microseconds (see Engine's VideoEncoderVT.hpp)
 #if PLATFORM_APPLE
-			static constexpr double SendTimestampScale = 1'000'000.0;
+		static constexpr double SendTimestampScale = 1'000'000.0;
 #else
-			static constexpr double SendTimestampScale = 1'000.0;
+		static constexpr double SendTimestampScale = 1'000.0;
 #endif
 
-			const double TimestampSeconds = FMath::Max(0.0, Frame.CaptureTimeSeconds - CaptureTimeBaseSeconds);
-			const double ScaledTimestamp = TimestampSeconds * SendTimestampScale;
+		const double TimestampSeconds = FMath::Max(0.0, PendingFrame.CaptureTimeSeconds - CaptureTimeBaseSeconds);
+		const double ScaledTimestamp = TimestampSeconds * SendTimestampScale;
 
 #if PLATFORM_APPLE
-			// Restart the encoder every hour of recording. On Apple platforms this stays well clear of the
-			// uint32-microseconds wrap at ~71 min which would otherwise feed VT a backward PTS
-			// and corrupt all subsequent fragments. On Windows the natural wrap is at ~49 days
-			// so realistically periodic refresh of encoder state won't be needed there
-			constexpr double RestartThreshold = 3600.0 * SendTimestampScale;
-			if (ScaledTimestamp > RestartThreshold)
-			{
-				UE_LOG(LogSentrySdk, Log, TEXT("Session replay: encoder has been running for %.0f s; restarting to refresh state."), TimestampSeconds);
-				Restart();
-				continue;
-			}
+		// Restart the encoder every hour of recording. On Apple platforms this stays well clear of the
+		// uint32-microseconds wrap at ~71 min which would otherwise feed VT a backward PTS
+		// and corrupt all subsequent fragments. On Windows the natural wrap is at ~49 days
+		// so realistically periodic refresh of encoder state won't be needed there
+		constexpr double RestartThreshold = 3600.0 * SendTimestampScale;
+		if (ScaledTimestamp > RestartThreshold)
+		{
+			UE_LOG(LogSentrySdk, Log, TEXT("Session replay: encoder has been running for %.0f s; restarting to refresh state."), TimestampSeconds);
+			Restart();
+			continue;
+		}
 #endif
 
-			const uint32 SendTimestamp = static_cast<uint32>(ScaledTimestamp);
+		const uint32 SendTimestamp = static_cast<uint32>(ScaledTimestamp);
 
-			const FAVResult Result = Encoder->SendFrame(Resource, SendTimestamp, bForceKeyframe);
-			if (Result.IsSuccess())
-			{
-				bFirstFrameValidated = true;
-				ConsecutiveSendFrameFailures = 0;
-			}
-			else if (!bFirstFrameValidated)
-			{
-				UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: encoder rejected the first frame. Recording disabled for this session."));
-				bEncodingDisabled.AtomicSet(true);
-				break;
-			}
-			else
-			{
-				if (++ConsecutiveSendFrameFailures >= MaxConsecutiveSendFrameFailures)
-				{
-					UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: encoder failed %d consecutive frames. Recording disabled for this session."), ConsecutiveSendFrameFailures);
-					bEncodingDisabled.AtomicSet(true);
-					break;
-				}
-
-				UE_LOG(LogSentrySdk, Verbose, TEXT("Session replay: SendFrame returned non-success (%d in a row)"), ConsecutiveSendFrameFailures);
-			}
-
-			DrainPackets();
-		}
-
-		Frames.Reset();
-
-		if (WakeEvent)
+		const FAVResult Result = Encoder->SendFrame(Resource, SendTimestamp, bForceKeyframe);
+		if (Result.IsSuccess())
 		{
-			WakeEvent->Wait(50);
+			bFirstFrameValidated = true;
+			ConsecutiveSendFrameFailures = 0;
 		}
+		else if (!bFirstFrameValidated)
+		{
+			UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: encoder rejected the first frame. Recording disabled for this session."));
+			bEncodingDisabled.AtomicSet(true);
+			continue;
+		}
+		else
+		{
+			if (++ConsecutiveSendFrameFailures >= MaxConsecutiveSendFrameFailures)
+			{
+				UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: encoder failed %d consecutive frames. Recording disabled for this session."), ConsecutiveSendFrameFailures);
+				bEncodingDisabled.AtomicSet(true);
+				continue;
+			}
+
+			UE_LOG(LogSentrySdk, Verbose, TEXT("Session replay: SendFrame returned non-success (%d in a row)"), ConsecutiveSendFrameFailures);
+		}
+
+		DrainPackets();
 	}
+
+	RetirePendingFrames();
+	WaitForRetiredFrames();
 	return 0;
 }
 
@@ -267,11 +312,14 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 		const bool bSameTransposedSize = ExpectedOrientation != EDeviceScreenOrientation::Unknown &&
 										 ResourceWidth == Height && ResourceHeight == Width;
 
-		if (!bSameSize && !bSameTransposedSize && !bResolutionChanged)
+		if (!bSameSize && !bSameTransposedSize)
 		{
-			UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: capture resolution changed from %ux%u to %ux%u; recording stays locked to the original size and may be cropped or black."),
-				Width, Height, ResourceWidth, ResourceHeight);
-			bResolutionChanged = true;
+			if (!bResolutionChanged)
+			{
+				UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: capture resolution changed from %ux%u to %ux%u; recording stays locked to the original size and may be cropped or black."),
+					Width, Height, ResourceWidth, ResourceHeight);
+				bResolutionChanged = true;
+			}
 		}
 		return true;
 	}
@@ -332,15 +380,88 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 	return true;
 }
 
+TSharedPtr<FVideoResourceRHI> FSentryVideoEncoder::GetOrCreateResource(const FTextureRHIRef& Texture)
+{
+	const uint32 TextureWidth = Texture->GetSizeX();
+	const uint32 TextureHeight = Texture->GetSizeY();
+	if (TextureWidth != ResourceCacheWidth || TextureHeight != ResourceCacheHeight)
+	{
+		ResourceCache.Reset();
+		ResourceCacheWidth = TextureWidth;
+		ResourceCacheHeight = TextureHeight;
+	}
+
+	TSharedPtr<FVideoResourceRHI>& Resource = ResourceCache.FindOrAdd(Texture.GetReference());
+	if (!Resource.IsValid())
+	{
+		Resource = MakeShared<FVideoResourceRHI>(Encoder->GetDevice().ToSharedRef(),
+			FVideoResourceRHI::FRawData{ Texture, nullptr, 0 });
+	}
+	return Resource;
+}
+
+void FSentryVideoEncoder::RetirePendingFrames()
+{
+	FScopeLock Lock(&QueueLock);
+	for (FPendingFrame& PendingFrame : PendingQueue)
+	{
+		if (PendingFrame.Frame.IsValid())
+		{
+			RetiredFrames.Add(MoveTemp(PendingFrame.Frame));
+		}
+	}
+	PendingQueue.Reset();
+}
+
+int32 FSentryVideoEncoder::PollRetiredFrames()
+{
+	FScopeLock Lock(&QueueLock);
+	for (int32 Index = RetiredFrames.Num() - 1; Index >= 0; --Index)
+	{
+		const FSentryVideoFramePtr& Frame = RetiredFrames[Index];
+		if (!Frame.IsValid() || !Frame->ReadyFence.IsValid() || Frame->ReadyFence->Poll())
+		{
+			if (Frame.IsValid())
+			{
+				Frame->Release();
+			}
+			RetiredFrames.RemoveAtSwap(Index, 1, EAllowShrinking::No);
+		}
+	}
+	return RetiredFrames.Num();
+}
+
+void FSentryVideoEncoder::WaitForRetiredFrames()
+{
+	// Capture is stopped and its render commands are flushed before the encoder
+	// is joined. Give the RHI thread time to finish any discarded frame writes
+	// without ever exposing those slots for reuse while their fences are pending.
+	const double Deadline = FPlatformTime::Seconds() + 5.0;
+	while (PollRetiredFrames() > 0 && FPlatformTime::Seconds() < Deadline)
+	{
+		FPlatformProcess::SleepNoStats(0.001f);
+	}
+
+	const int32 Remaining = PollRetiredFrames();
+	if (Remaining > 0)
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: %d retired capture frame(s) still have pending GPU fences during shutdown."), Remaining);
+	}
+}
+
 void FSentryVideoEncoder::Restart()
 {
 	DrainPackets();
 
 	FlushCurrentFragment();
 
+	ResourceCache.Reset();
+	ResourceCacheWidth = 0;
+	ResourceCacheHeight = 0;
 	Encoder.Reset();
 
 	bEncoderOpen = false;
+	bResolutionChanged = false;
 
 	CaptureTimeBaseSeconds = -1.0;
 	LastPacketTimestampMs = 0;
@@ -355,10 +476,7 @@ void FSentryVideoEncoder::Restart()
 	bFirstFrameValidated = false;
 	ConsecutiveSendFrameFailures = 0;
 
-	{
-		FScopeLock Lock(&QueueLock);
-		PendingQueue.Reset();
-	}
+	RetirePendingFrames();
 }
 
 void FSentryVideoEncoder::FlushCurrentFragment()
@@ -407,7 +525,7 @@ void FSentryVideoEncoder::DrainPackets()
 		if (!bInitSegmentPublished && CachedSps.Num() > 0 && CachedPps.Num() > 0)
 		{
 			TArray<uint8> Init = FSentryFMP4Writer::BuildInitSegment(Width, Height, CachedSps, CachedPps);
-			Recorder.OnInitSegmentReady(MoveTemp(Init));
+			Recorder.OnInitSegmentReady(MoveTemp(Init), Width, Height);
 			bInitSegmentPublished = true;
 		}
 

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
@@ -16,11 +16,41 @@
 
 #include "Video/VideoEncoder.h"
 
+#include <atomic>
+
 class FRunnableThread;
 class FEvent;
 class FVideoResourceRHI;
 
 class FSentrySessionReplayRecorder;
+
+/**
+ * One reusable capture-pool slot shared by the render and encoder threads.
+ *
+ * The render thread marks a slot in flight before writing it. The encoder
+ * thread releases it only after the GPU write fence has passed and SendFrame
+ * has finished consuming the texture.
+ */
+struct FSentryVideoFrame
+{
+	bool TryAcquire()
+	{
+		return !bInFlight.exchange(true, std::memory_order_acq_rel);
+	}
+
+	void Release()
+	{
+		bInFlight.store(false, std::memory_order_release);
+	}
+
+	FTextureRHIRef Texture;
+	FGPUFenceRHIRef ReadyFence;
+
+private:
+	std::atomic<bool> bInFlight{ false };
+};
+
+using FSentryVideoFramePtr = TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>;
 
 /**
  * Wraps the AVCodecs H.264 encoder and runs on a dedicated thread.
@@ -41,13 +71,10 @@ public:
 	bool StartEncoder();
 	void StopEncoder();
 
-	// Enqueues a texture for the encoder thread to process
-	void SubmitFrame(const FTextureRHIRef& Texture, double CaptureTimeSeconds);
+	// Enqueues a capture-pool slot for the encoder thread to process
+	void SubmitFrame(const FSentryVideoFramePtr& Frame, double CaptureTimeSeconds);
 
 	uint32 GetFramerate() const { return Framerate; }
-
-	uint32 GetWidth() const { return Width; }
-	uint32 GetHeight() const { return Height; }
 
 	bool IsEncodingDisabled() const { return bEncodingDisabled; }
 
@@ -65,6 +92,15 @@ private:
 	bool ShouldSwapDimensions(uint32 ResourceWidth, uint32 ResourceHeight) const;
 
 	bool EnsureEncoderOpen(uint32 ResourceWidth, uint32 ResourceHeight);
+
+	// Reuses the AVCodecs wrapper and its native resource mapping for each pool texture
+	TSharedPtr<FVideoResourceRHI> GetOrCreateResource(const FTextureRHIRef& Texture);
+
+	// Moves queued slots to the retired list without making them reusable.
+	// A retired slot is released only after its GPU write fence passes.
+	void RetirePendingFrames();
+	int32 PollRetiredFrames();
+	void WaitForRetiredFrames();
 
 	// Pulls available packets from the encoder, converts them to AVCC samples and emits a fragment at each keyframe boundary
 	void DrainPackets();
@@ -111,12 +147,20 @@ private:
 	// Encoder thread frame queue
 	struct FPendingFrame
 	{
-		FTextureRHIRef Texture;
+		FSentryVideoFramePtr Frame;
 		double CaptureTimeSeconds = 0.0;
 	};
 
 	FCriticalSection QueueLock;
 	TArray<FPendingFrame> PendingQueue;
+	TArray<FSentryVideoFramePtr> RetiredFrames;
+
+	// Encoder-thread-only cache. Keeping the wrapper alive also keeps AVCodecs'
+	// native D3D/Vulkan/Metal mapping alive instead of rebuilding it every frame.
+	// The cache is reset whenever the native input dimensions change.
+	TMap<FRHITexture*, TSharedPtr<FVideoResourceRHI>> ResourceCache;
+	uint32 ResourceCacheWidth = 0;
+	uint32 ResourceCacheHeight = 0;
 
 	// Timing (encoder-thread-only)
 	double CaptureTimeBaseSeconds = -1.0;


### PR DESCRIPTION
## Summary

- Add GPU fences before handing captured textures to the encoder thread.
- Bound queued and retired frame resources to avoid unsafe reuse and excess VRAM growth.
- Preserve a single MP4 stream when the viewport resolution changes.
- Harden encoder and recorder shutdown ordering.

## Testing

- Built SentryPlaygroundEditor with session replay enabled using Unreal Engine 5.7.4.
- Passed all 66 Sentry automation tests.
- Completed D3D12 and NVENC replay runs at 1280x720 and with a live resize from 2560x1440.
- Verified valid fragmented MP4 output and no GPU, device removal, encoder, or fence errors.