### PR TITLE
Defer session replay until engine initialization

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -39,6 +39,7 @@
 #include "GenericPlatform/CrashReporter/GenericPlatformSentryCrashContext.h"
 #include "GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.h"
 
+#include "CoreGlobals.h"
 #include "Dom/JsonObject.h"
 #include "Serialization/JsonSerializer.h"
 
@@ -658,26 +659,56 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 #ifdef USE_SENTRY_SESSION_REPLAY
 	if (isEnabled && settings->AttachSessionReplay)
 	{
-		// Clear replay videos captured during previous session if any
-		IFileManager::Get().DeleteDirectory(*FPaths::Combine(GetDatabasePath(), TEXT("replays")), false, true);
-
-		SessionReplayId = FGuid::NewGuid().ToString(EGuidFormats::Digits).ToLower();
-
-		SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
-		if (SessionReplay->Initialize(settings, SessionReplayId, GetReplayPath()))
+		if (GIsRunning)
 		{
-			SetContext(TEXT("replay"), { { TEXT("replay_id"), FSentryVariant(SessionReplayId) } });
-			SetAttribute(TEXT("sentry.replay_id"), FSentryVariant(SessionReplayId));
-			SetAttribute(TEXT("sentry._internal.replay_is_buffering"), FSentryVariant(true));
+			StartSessionReplay(settings);
 		}
-		else
+		else if (!EngineLoopInitCompleteHandle.IsValid())
 		{
-			SessionReplay.Reset();
-			SessionReplayId.Reset();
+			EngineLoopInitCompleteHandle = FCoreDelegates::OnFEngineLoopInitComplete.AddRaw(this, &FGenericPlatformSentrySubsystem::StartSessionReplayAfterEngineInit);
 		}
 	}
 #endif
 }
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+void FGenericPlatformSentrySubsystem::StartSessionReplay(const USentrySettings* settings)
+{
+	if (!isEnabled || !settings || !settings->AttachSessionReplay || SessionReplay)
+	{
+		return;
+	}
+
+	// Clear replay videos captured during previous session if any
+	IFileManager::Get().DeleteDirectory(*FPaths::Combine(GetDatabasePath(), TEXT("replays")), false, true);
+
+	SessionReplayId = FGuid::NewGuid().ToString(EGuidFormats::Digits).ToLower();
+
+	SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
+	if (SessionReplay->Initialize(settings, SessionReplayId, GetReplayPath()))
+	{
+		SetContext(TEXT("replay"), { { TEXT("replay_id"), FSentryVariant(SessionReplayId) } });
+		SetAttribute(TEXT("sentry.replay_id"), FSentryVariant(SessionReplayId));
+		SetAttribute(TEXT("sentry._internal.replay_is_buffering"), FSentryVariant(true));
+	}
+	else
+	{
+		SessionReplay.Reset();
+		SessionReplayId.Reset();
+	}
+}
+
+void FGenericPlatformSentrySubsystem::StartSessionReplayAfterEngineInit()
+{
+	if (EngineLoopInitCompleteHandle.IsValid())
+	{
+		FCoreDelegates::OnFEngineLoopInitComplete.Remove(EngineLoopInitCompleteHandle);
+		EngineLoopInitCompleteHandle.Reset();
+	}
+
+	StartSessionReplay(FSentryModule::Get().GetSettings());
+}
+#endif
 
 void FGenericPlatformSentrySubsystem::Close()
 {
@@ -690,6 +721,12 @@ void FGenericPlatformSentrySubsystem::Close()
 	isEnabled = false;
 
 #ifdef USE_SENTRY_SESSION_REPLAY
+	if (EngineLoopInitCompleteHandle.IsValid())
+	{
+		FCoreDelegates::OnFEngineLoopInitComplete.Remove(EngineLoopInitCompleteHandle);
+		EngineLoopInitCompleteHandle.Reset();
+	}
+
 	if (SessionReplay)
 	{
 		SessionReplay->Shutdown();

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -171,10 +171,13 @@ private:
 
 #ifdef USE_SENTRY_SESSION_REPLAY
 	FString GetReplayPath() const;
+	void StartSessionReplay(const USentrySettings* settings);
+	void StartSessionReplayAfterEngineInit();
 
 	FString SessionReplayId;
 
 	TUniquePtr<FSentrySessionReplayRecorder> SessionReplay;
+	FDelegateHandle EngineLoopInitCompleteHandle;
 #endif
 };
 

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -312,6 +312,10 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 #endif
 
 	TSharedRef<FAVDevice>& Device = FAVDevice::GetHardwareDevice();
+	if (!Device->HasContext<FVideoContextRHI>())
+	{
+		return false;
+	}
 
 	Encoder = FVideoEncoder::Create<FVideoResourceRHI>(Device, Config);
 	if (!Encoder.IsValid())


### PR DESCRIPTION
## Summary

- Defer session replay startup until the engine loop has completed initialization.
- Remove the deferred startup delegate after it fires and during subsystem shutdown.
- Verify that the hardware device has an RHI video context before creating the encoder.

## Testing

- Built SentryPlaygroundEditor with session replay enabled using Unreal Engine 5.7.4.
- Passed all 66 Sentry automation tests.
- Completed a D3D12 and NVENC replay run and verified the encoder opened after engine initialization.
- Verified valid fragmented MP4 output and a clean shutdown.