### PR TITLE
Resolve writable Sentry database path

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -1348,7 +1348,7 @@ FString FGenericPlatformSentrySubsystem::GetCrashReporterLogoPath() const
 FString FGenericPlatformSentrySubsystem::GetDatabasePath() const
 {
 	const FString DatabasePath = FPaths::Combine(databaseParentPath, TEXT(".sentry-native"));
-	const FString DatabaseFullPath = FPaths::ConvertRelativePathToFull(DatabasePath);
+	const FString DatabaseFullPath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForWrite(*DatabasePath);
 
 	return DatabaseFullPath;
 }


### PR DESCRIPTION
## Summary

- Resolve the Sentry database directory with ConvertToAbsolutePathForExternalAppForWrite.
- Keep replay output in the same writable location used by the native SDK attachment path.

## Testing

- Built SentryPlaygroundEditor with session replay enabled using Unreal Engine 5.7.4.
- Passed all 66 Sentry automation tests.
- Completed a D3D12 and NVENC replay run using the resolved absolute path.
- Verified a valid 150-frame fragmented MP4 was written successfully.