### PR TITLE
Skip transient overlay windows during session replay capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Fixes
 
 - Fix Android `minifyRelease` R8 build failure caused by missing `android.os.ProfilingManager`/`ProfilingResult` class references in the Java SDK ([#1505](https://github.com/getsentry/sentry-unreal/pull/1505))
-- Lock replay recording to a single window to prevent capturing unrelated frames ([#1512](https://github.com/getsentry/sentry-unreal/pull/1512))
+- Skip transient overlay windows during session replay capture ([#1512](https://github.com/getsentry/sentry-unreal/pull/1512))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Fix Android `minifyRelease` R8 build failure caused by missing `android.os.ProfilingManager`/`ProfilingResult` class references in the Java SDK ([#1505](https://github.com/getsentry/sentry-unreal/pull/1505))
+- Lock replay recording to a single window to prevent capturing unrelated frames ([#1512](https://github.com/getsentry/sentry-unreal/pull/1512))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -68,6 +68,11 @@ void FSentryBackBufferCapture::Stop()
 
 	// Ensure render thread is done with our textures before destruction
 	FlushRenderingCommands();
+
+	// Render thread is idle after the flush, so resetting the lock here is safe.
+	// A subsequent Start() will re-lock onto the first window it then sees.
+	LockedWindow = nullptr;
+
 	for (FTextureRHIRef& Slot : EncoderPool.Slots)
 	{
 		Slot.SafeRelease();
@@ -79,14 +84,33 @@ void FSentryBackBufferCapture::Stop()
 #if UE_VERSION_OLDER_THAN(5, 8, 0)
 void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, const FTextureRHIRef& BackBuffer)
 {
+	if (!AcceptWindow_RenderThread(SlateWindow))
+	{
+		return;
+	}
 	CaptureBackBuffer_RenderThread(BackBuffer);
 }
 #else
 void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, ISlateViewportProvider& ViewportProvider)
 {
+	if (!AcceptWindow_RenderThread(SlateWindow))
+	{
+		return;
+	}
 	CaptureBackBuffer_RenderThread(ViewportProvider.GetBackBufferResource());
 }
 #endif
+
+bool FSentryBackBufferCapture::AcceptWindow_RenderThread(const SWindow& SlateWindow)
+{
+	if (LockedWindow == nullptr)
+	{
+		LockedWindow = &SlateWindow;
+		UE_LOG(LogSentrySdk, Log, TEXT("Session replay: capture locked to the first presented window; other windows will be ignored."));
+	}
+
+	return LockedWindow == &SlateWindow;
+}
 
 void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIRef& BackBuffer)
 {

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -69,10 +69,6 @@ void FSentryBackBufferCapture::Stop()
 	// Ensure render thread is done with our textures before destruction
 	FlushRenderingCommands();
 
-	// Render thread is idle after the flush, so resetting the lock here is safe.
-	// A subsequent Start() will re-lock onto the first window it then sees.
-	LockedWindow = nullptr;
-
 	for (FTextureRHIRef& Slot : EncoderPool.Slots)
 	{
 		Slot.SafeRelease();
@@ -103,13 +99,11 @@ void FSentryBackBufferCapture::OnBackBufferReadyToPresent_RenderThread(SWindow& 
 
 bool FSentryBackBufferCapture::AcceptWindow_RenderThread(const SWindow& SlateWindow)
 {
-	if (LockedWindow == nullptr)
-	{
-		LockedWindow = &SlateWindow;
-		UE_LOG(LogSentrySdk, Log, TEXT("Session replay: capture locked to the first presented window; other windows will be ignored."));
-	}
-
-	return LockedWindow == &SlateWindow;
+	// Capture only real top-level windows. Transient overlays - tooltips, popup
+	// menus, notification toasts, cursor decorators - present through the same hook
+	// but aren't gameplay, and their differing size would otherwise be handed to the
+	// encoder. IsRegularWindow() excludes exactly that class.
+	return SlateWindow.IsRegularWindow();
 }
 
 void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIRef& BackBuffer)

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
@@ -73,9 +73,9 @@ private:
 	void OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, ISlateViewportProvider& ViewportProvider);
 #endif
 
-	// Returns true if this window is the one capture is locked to. The first
-	// window seen after Start() becomes the locked window; every other window
-	// (editor tooltips, notification toasts, secondary/PIE windows) is ignored.
+	// Returns true if SlateWindow is a real top-level window whose backbuffer should
+	// be captured. Transient overlays (tooltips, popup menus, notification toasts,
+	// cursor decorators) are rejected. Render thread only.
 	bool AcceptWindow_RenderThread(const SWindow& SlateWindow);
 
 	// Captures a single backbuffer frame and forwards it to the encoder (render thread)
@@ -106,10 +106,6 @@ private:
 	// Pool of textures that are submitted to the encoder. Ref-counted because
 	// the encoder thread holds these across frames
 	FCachedTexturePool EncoderPool;
-
-	// Identity of the window capture is locked to (raw pointer, compared only,
-	// never dereferenced). Null until the first frame is seen
-	const SWindow* LockedWindow = nullptr;
 
 	// Frame throttling
 	double NextCaptureTime = 0.0;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
@@ -73,6 +73,11 @@ private:
 	void OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, ISlateViewportProvider& ViewportProvider);
 #endif
 
+	// Returns true if this window is the one capture is locked to. The first
+	// window seen after Start() becomes the locked window; every other window
+	// (editor tooltips, notification toasts, secondary/PIE windows) is ignored.
+	bool AcceptWindow_RenderThread(const SWindow& SlateWindow);
+
 	// Captures a single backbuffer frame and forwards it to the encoder (render thread)
 	void CaptureBackBuffer_RenderThread(const FTextureRHIRef& BackBuffer);
 
@@ -101,6 +106,10 @@ private:
 	// Pool of textures that are submitted to the encoder. Ref-counted because
 	// the encoder thread holds these across frames
 	FCachedTexturePool EncoderPool;
+
+	// Identity of the window capture is locked to (raw pointer, compared only,
+	// never dereferenced). Null until the first frame is seen
+	const SWindow* LockedWindow = nullptr;
 
 	// Frame throttling
 	double NextCaptureTime = 0.0;


### PR DESCRIPTION
This PR narrows session replay capture to real top-level windows so transient Slate overlays are no longer recorded.

The backbuffer capture hook subscribes to `FSlateRenderer::OnBackBufferReadyToPresent` which fires once per presented Slate window. The `SWindow` argument was ignored so capture also grabbed short-lived overlay windows that present through the same hook, e.g. tooltips, popup menus / combo dropdowns, notification toasts and cursor decorators. These are unrelated to gameplay and render at their own (often tiny) sizes; forwarding such a frame hands the encoder a surface that doesn't match the recording, producing cropped/black/garbage frames.

The suggested fix is to filter the hook to regular top-level windows with `SWindow::IsRegularWindow()` so it rejects the overlay class while accepting normal application windows.

Note: In editor, this removes the overlay noise (the reported case), but does not disambiguate between multiple regular windows that can coexist (main editor window vs. an undocked asset editor). Reliably identifying which Editor window should be captured is deferred to a follow-up PR.