### PR TITLE
Defer session replay capture on macOS/iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Fix Android `minifyRelease` R8 build failure caused by missing `android.os.ProfilingManager`/`ProfilingResult` class references in the Java SDK ([#1505](https://github.com/getsentry/sentry-unreal/pull/1505))
 - Skip transient overlay windows during session replay capture ([#1512](https://github.com/getsentry/sentry-unreal/pull/1512))
+- Defer Session Replay capture on desktop until engine initialization is complete ([#1514](https://github.com/getsentry/sentry-unreal/pull/1514))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -39,6 +39,7 @@
 #include "Utils/SentryCallbackUtils.h"
 #include "Utils/SentryFileUtils.h"
 
+#include "CoreGlobals.h"
 #include "GenericPlatform/GenericPlatformOutputDevices.h"
 #include "HAL/FileManager.h"
 #include "Misc/CoreDelegates.h"
@@ -280,19 +281,27 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 #ifdef USE_SENTRY_SESSION_REPLAY
 		if (settings->AttachSessionReplay)
 		{
-			SessionReplayId = FGuid::NewGuid().ToString(EGuidFormats::Digits).ToLower();
-
-			SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
-			if (SessionReplay->Initialize(settings, SessionReplayId, GetReplayPath()))
+			// The recorder hooks the Slate backbuffer, which isn't available yet if Sentry is initialized
+			// before the engine loop finishes. Defer the start until engine init completes in that case.
+			if (GIsRunning)
 			{
-				SetContext(TEXT("replay"), { { TEXT("replay_id"), FSentryVariant(SessionReplayId) } });
-				SetAttribute(TEXT("sentry.replay_id"), FSentryVariant(SessionReplayId));
-				SetAttribute(TEXT("sentry._internal.replay_is_buffering"), FSentryVariant(true));
+				StartSessionReplay(settings);
 			}
 			else
 			{
-				SessionReplay.Reset();
-				SessionReplayId.Reset();
+				if (!EngineLoopInitCompleteHandle.IsValid())
+				{
+					EngineLoopInitCompleteHandle = FCoreDelegates::OnFEngineLoopInitComplete.AddLambda([this, settings]
+					{
+						if (EngineLoopInitCompleteHandle.IsValid())
+						{
+							FCoreDelegates::OnFEngineLoopInitComplete.Remove(EngineLoopInitCompleteHandle);
+							EngineLoopInitCompleteHandle.Reset();
+						}
+
+						StartSessionReplay(settings);
+					});
+				}
 			}
 		}
 #endif
@@ -302,6 +311,12 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 void FAppleSentrySubsystem::Close()
 {
 #ifdef USE_SENTRY_SESSION_REPLAY
+	if (EngineLoopInitCompleteHandle.IsValid())
+	{
+		FCoreDelegates::OnFEngineLoopInitComplete.Remove(EngineLoopInitCompleteHandle);
+		EngineLoopInitCompleteHandle.Reset();
+	}
+
 	if (SessionReplay)
 	{
 		SessionReplay->Shutdown();
@@ -853,6 +868,29 @@ bool FAppleSentrySubsystem::GetLatestSessionReplay(FString& OutReplayPath, FStri
 }
 
 #ifdef USE_SENTRY_SESSION_REPLAY
+void FAppleSentrySubsystem::StartSessionReplay(const USentrySettings* settings)
+{
+	if (SessionReplay)
+	{
+		return;
+	}
+
+	SessionReplayId = FGuid::NewGuid().ToString(EGuidFormats::Digits).ToLower();
+
+	SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
+	if (SessionReplay->Initialize(settings, SessionReplayId, GetReplayPath()))
+	{
+		SetContext(TEXT("replay"), { { TEXT("replay_id"), FSentryVariant(SessionReplayId) } });
+		SetAttribute(TEXT("sentry.replay_id"), FSentryVariant(SessionReplayId));
+		SetAttribute(TEXT("sentry._internal.replay_is_buffering"), FSentryVariant(true));
+	}
+	else
+	{
+		SessionReplay.Reset();
+		SessionReplayId.Reset();
+	}
+}
+
 FString FAppleSentrySubsystem::GetReplayPath() const
 {
 	const FString ReplayPath = FPaths::Combine(FPaths::ProjectSavedDir(), TEXT("SentryReplays"), FString::Printf(TEXT("replay-%s.mp4"), *SessionReplayId));

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -287,21 +287,16 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 			{
 				StartSessionReplay(settings);
 			}
-			else
+			else if (!EngineLoopInitCompleteHandle.IsValid())
 			{
-				if (!EngineLoopInitCompleteHandle.IsValid())
+				// OnFEngineLoopInitComplete broadcasts exactly once. Don't Remove() this binding from inside
+				// the callback: RemoveDelegateInstance calls Unbind() synchronously, freeing this lambda's own
+				// storage (captured `this`/`settings`), so any subsequent access is a use-after-free. The
+				// binding is torn down later in Close() instead.
+				EngineLoopInitCompleteHandle = FCoreDelegates::OnFEngineLoopInitComplete.AddLambda([this, settings]
 				{
-					EngineLoopInitCompleteHandle = FCoreDelegates::OnFEngineLoopInitComplete.AddLambda([this, settings]
-					{
-						if (EngineLoopInitCompleteHandle.IsValid())
-						{
-							FCoreDelegates::OnFEngineLoopInitComplete.Remove(EngineLoopInitCompleteHandle);
-							EngineLoopInitCompleteHandle.Reset();
-						}
-
-						StartSessionReplay(settings);
-					});
-				}
+					StartSessionReplay(settings);
+				});
 			}
 		}
 #endif

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -84,11 +84,15 @@ protected:
 
 private:
 #ifdef USE_SENTRY_SESSION_REPLAY
+	void StartSessionReplay(const USentrySettings* settings);
+
 	FString GetReplayPath() const;
 
 	FString SessionReplayId;
 
 	TUniquePtr<FSentrySessionReplayRecorder> SessionReplay;
+
+	FDelegateHandle EngineLoopInitCompleteHandle;
 #endif
 };
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -663,52 +663,25 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 		{
 			StartSessionReplay(settings);
 		}
-		else if (!EngineLoopInitCompleteHandle.IsValid())
+		else
 		{
-			EngineLoopInitCompleteHandle = FCoreDelegates::OnFEngineLoopInitComplete.AddRaw(this, &FGenericPlatformSentrySubsystem::StartSessionReplayAfterEngineInit);
+			if (!EngineLoopInitCompleteHandle.IsValid())
+			{
+				EngineLoopInitCompleteHandle = FCoreDelegates::OnFEngineLoopInitComplete.AddLambda([this, settings]
+				{
+					if (EngineLoopInitCompleteHandle.IsValid())
+					{
+						FCoreDelegates::OnFEngineLoopInitComplete.Remove(EngineLoopInitCompleteHandle);
+						EngineLoopInitCompleteHandle.Reset();
+					}
+
+					StartSessionReplay(settings);
+				});
+			}
 		}
 	}
 #endif
 }
-
-#ifdef USE_SENTRY_SESSION_REPLAY
-void FGenericPlatformSentrySubsystem::StartSessionReplay(const USentrySettings* settings)
-{
-	if (!isEnabled || !settings || !settings->AttachSessionReplay || SessionReplay)
-	{
-		return;
-	}
-
-	// Clear replay videos captured during previous session if any
-	IFileManager::Get().DeleteDirectory(*FPaths::Combine(GetDatabasePath(), TEXT("replays")), false, true);
-
-	SessionReplayId = FGuid::NewGuid().ToString(EGuidFormats::Digits).ToLower();
-
-	SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
-	if (SessionReplay->Initialize(settings, SessionReplayId, GetReplayPath()))
-	{
-		SetContext(TEXT("replay"), { { TEXT("replay_id"), FSentryVariant(SessionReplayId) } });
-		SetAttribute(TEXT("sentry.replay_id"), FSentryVariant(SessionReplayId));
-		SetAttribute(TEXT("sentry._internal.replay_is_buffering"), FSentryVariant(true));
-	}
-	else
-	{
-		SessionReplay.Reset();
-		SessionReplayId.Reset();
-	}
-}
-
-void FGenericPlatformSentrySubsystem::StartSessionReplayAfterEngineInit()
-{
-	if (EngineLoopInitCompleteHandle.IsValid())
-	{
-		FCoreDelegates::OnFEngineLoopInitComplete.Remove(EngineLoopInitCompleteHandle);
-		EngineLoopInitCompleteHandle.Reset();
-	}
-
-	StartSessionReplay(FSentryModule::Get().GetSettings());
-}
-#endif
 
 void FGenericPlatformSentrySubsystem::Close()
 {
@@ -1399,6 +1372,32 @@ FString FGenericPlatformSentrySubsystem::GetScreenshotPath() const
 }
 
 #ifdef USE_SENTRY_SESSION_REPLAY
+void FGenericPlatformSentrySubsystem::StartSessionReplay(const USentrySettings* settings)
+{
+	if (SessionReplay)
+	{
+		return;
+	}
+
+	// Clear replay videos captured during previous session if any
+	IFileManager::Get().DeleteDirectory(*FPaths::Combine(GetDatabasePath(), TEXT("replays")), false, true);
+
+	SessionReplayId = FGuid::NewGuid().ToString(EGuidFormats::Digits).ToLower();
+
+	SessionReplay = MakeUnique<FSentrySessionReplayRecorder>();
+	if (SessionReplay->Initialize(settings, SessionReplayId, GetReplayPath()))
+	{
+		SetContext(TEXT("replay"), { { TEXT("replay_id"), FSentryVariant(SessionReplayId) } });
+		SetAttribute(TEXT("sentry.replay_id"), FSentryVariant(SessionReplayId));
+		SetAttribute(TEXT("sentry._internal.replay_is_buffering"), FSentryVariant(true));
+	}
+	else
+	{
+		SessionReplay.Reset();
+		SessionReplayId.Reset();
+	}
+}
+
 FString FGenericPlatformSentrySubsystem::GetReplayPath() const
 {
 	const FString ReplayPath = FPaths::Combine(GetDatabasePath(), TEXT("replays"), FString::Printf(TEXT("replay-%s.mp4"), *SessionReplayId));

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -671,12 +671,6 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 			{
 				EngineLoopInitCompleteHandle = FCoreDelegates::OnFEngineLoopInitComplete.AddLambda([this, settings]
 				{
-					if (EngineLoopInitCompleteHandle.IsValid())
-					{
-						FCoreDelegates::OnFEngineLoopInitComplete.Remove(EngineLoopInitCompleteHandle);
-						EngineLoopInitCompleteHandle.Reset();
-					}
-
 					StartSessionReplay(settings);
 				});
 			}

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -659,6 +659,8 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 #ifdef USE_SENTRY_SESSION_REPLAY
 	if (isEnabled && settings->AttachSessionReplay)
 	{
+		// The recorder hooks the Slate backbuffer, which isn't available yet if Sentry is initialized
+		// before the engine loop finishes. Defer the start until engine init completes in that case.
 		if (GIsRunning)
 		{
 			StartSessionReplay(settings);

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -177,6 +177,7 @@ private:
 	FString SessionReplayId;
 
 	TUniquePtr<FSentrySessionReplayRecorder> SessionReplay;
+
 	FDelegateHandle EngineLoopInitCompleteHandle;
 #endif
 };

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -170,9 +170,9 @@ private:
 	FThreadSafeBool bIsCrashing;
 
 #ifdef USE_SENTRY_SESSION_REPLAY
-	FString GetReplayPath() const;
 	void StartSessionReplay(const USentrySettings* settings);
-	void StartSessionReplayAfterEngineInit();
+
+	FString GetReplayPath() const;
 
 	FString SessionReplayId;
 


### PR DESCRIPTION
This PR fixes session replay being silently dropped on macOS/iOS when the SDK is initialized before the engine loop finishes.

Follow up for #1510 which deferred session replay start until engine initialization on `sentry-native` platforms.

The Apple (cocoa) backend still started the recorder inline during `InitWithSettings` so it carried the same exposure: the shared `FSentrySessionReplayRecorder` hooks the Slate backbuffer (`FSentryBackBufferCapture::Start()` requires `FSlateApplication::IsInitialized()` and a valid renderer) which isn't available yet if Sentry is initialized before
`OnFEngineLoopInitComplete`. When that happens `Start()` returns `false` and replay is silently disabled.

### Key Changes

**Apple (`AppleSentrySubsystem`)**
- Start the recorder immediately when `GIsRunning`, otherwise defer to `FCoreDelegates::OnFEngineLoopInitComplete`.
- Factor the recorder setup into `StartSessionReplay()` with an `if (SessionReplay) return;` double-start guard.
- Remove/reset the delegate handle in `Close()` so a pending deferred start can't fire on a destroyed instance.
- Previous-run replay cleanup remains in the `before_send` path (unchanged).

**Generic platform (`GenericPlatformSentrySubsystem`)**
- Simplify the deferral introduced in #1510 to an inline `AddLambda`, dropping the separate `StartSessionReplayAfterEngineInit` method.