### PR TITLE
 Fix session replay GPU hang under load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixes
 
+- Fix session replay GPU hang under load ([#1517](https://github.com/getsentry/sentry-unreal/pull/1517))
 - Fix Android `minifyRelease` R8 build failure caused by missing `android.os.ProfilingManager`/`ProfilingResult` class references in the Java SDK ([#1505](https://github.com/getsentry/sentry-unreal/pull/1505))
 - Skip transient overlay windows during session replay capture ([#1512](https://github.com/getsentry/sentry-unreal/pull/1512))
 - Defer Session Replay capture on desktop until engine initialization is complete ([#1514](https://github.com/getsentry/sentry-unreal/pull/1514))

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -8,6 +8,7 @@
 #include "SentryVideoEncoder.h"
 #include "SentryVideoFrame.h"
 
+#include "DynamicRHI.h"
 #include "Framework/Application/SlateApplication.h"
 #include "GlobalShader.h"
 #include "HAL/PlatformTime.h"
@@ -254,6 +255,9 @@ void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIR
 	RHICmdList.Transition(FRHITransitionInfo(EncoderTex.GetReference(), ERHIAccess::Unknown, ERHIAccess::SRVGraphics));
 #endif
 
+	EncoderFrame->ReadyFence->Clear();
+	RHICmdList.WriteGPUFence(EncoderFrame->ReadyFence);
+
 	EncoderFrame->CaptureTimeSeconds = Now;
 
 	Encoder.SubmitFrame(EncoderFrame);
@@ -320,7 +324,12 @@ TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe> FSentryBackBufferCapture::Acq
 			Frame.Texture = FRHICommandListImmediate::Get().CreateTexture(Desc);
 		}
 
-		if (!Frame.Texture.IsValid())
+		if (!Frame.ReadyFence.IsValid())
+		{
+			Frame.ReadyFence = RHICreateGPUFence(TEXT("SentrySessionReplayFrameFence"));
+		}
+
+		if (!Frame.Texture.IsValid() || !Frame.ReadyFence.IsValid())
 		{
 			Frame.Release();
 			return nullptr;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -332,7 +332,7 @@ TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe> FSentryBackBufferCapture::Acq
 		if (!Frame.Texture.IsValid() || !Frame.ReadyFence.IsValid())
 		{
 			Frame.Release();
-			return nullptr;
+			continue;
 		}
 
 		return Slot;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.cpp
@@ -6,6 +6,7 @@
 
 #include "SentryDefines.h"
 #include "SentryVideoEncoder.h"
+#include "SentryVideoFrame.h"
 
 #include "Framework/Application/SlateApplication.h"
 #include "GlobalShader.h"
@@ -24,7 +25,7 @@
 FSentryBackBufferCapture::FSentryBackBufferCapture(FSentryVideoEncoder& InEncoder)
 	: Encoder(InEncoder)
 {
-	EncoderPool.Slots.SetNum(FSentryVideoEncoder::MaxQueueDepth);
+	EncoderPool.SetNum(FramePoolSize);
 	CapturePeriodSeconds = 1.0 / static_cast<double>(FMath::Max(1u, Encoder.GetFramerate()));
 }
 
@@ -69,10 +70,11 @@ void FSentryBackBufferCapture::Stop()
 	// Ensure render thread is done with our textures before destruction
 	FlushRenderingCommands();
 
-	for (FTextureRHIRef& Slot : EncoderPool.Slots)
+	for (TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& Slot : EncoderPool)
 	{
-		Slot.SafeRelease();
+		Slot.Reset();
 	}
+
 	Scratch.Texture.SafeRelease();
 	Converted.Texture.SafeRelease();
 }
@@ -159,9 +161,6 @@ void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIR
 	constexpr ERHIAccess PoolInitialState = ERHIAccess::SRVGraphics;
 #endif
 
-	FTextureRHIRef EncoderTex = AcquireTexturePoolSlot_RenderThread(EncoderPool, W, H, PF_B8G8R8A8,
-		PoolFlags, PoolInitialState, TEXT("SentrySessionReplayCapture"));
-
 	if (!ScratchTex.IsValid())
 	{
 		return;
@@ -174,8 +173,22 @@ void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIR
 	}
 #endif
 
+	// Acquire the encoder frame only after the scratch/converted textures are
+	// known good, so an early return above never strands a slot in flight. No free
+	// slot means the encoder is still consuming every frame in the pool and this
+	// capture will be dropped
+	TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe> EncoderFrame = AcquireFrame_RenderThread(W, H, PF_B8G8R8A8,
+		PoolFlags, PoolInitialState, TEXT("SentrySessionReplayCapture"));
+
+	if (!EncoderFrame.IsValid())
+	{
+		return;
+	}
+
+	FTextureRHIRef EncoderTex = EncoderFrame->Texture;
 	if (!EncoderTex.IsValid())
 	{
+		EncoderFrame->Release();
 		return;
 	}
 
@@ -241,7 +254,9 @@ void FSentryBackBufferCapture::CaptureBackBuffer_RenderThread(const FTextureRHIR
 	RHICmdList.Transition(FRHITransitionInfo(EncoderTex.GetReference(), ERHIAccess::Unknown, ERHIAccess::SRVGraphics));
 #endif
 
-	Encoder.SubmitFrame(EncoderTex, Now);
+	EncoderFrame->CaptureTimeSeconds = Now;
+
+	Encoder.SubmitFrame(EncoderFrame);
 }
 
 FTextureRHIRef FSentryBackBufferCapture::AcquireCachedTexture_RenderThread(FCachedTexture& Cache, uint32 Width, uint32 Height, EPixelFormat Format,
@@ -269,47 +284,52 @@ FTextureRHIRef FSentryBackBufferCapture::AcquireCachedTexture_RenderThread(FCach
 	return Cache.Texture;
 }
 
-FTextureRHIRef FSentryBackBufferCapture::AcquireTexturePoolSlot_RenderThread(FCachedTexturePool& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
+TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe> FSentryBackBufferCapture::AcquireFrame_RenderThread(uint32 Width, uint32 Height, EPixelFormat Format,
 	ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName)
 {
-	if (Width != Pool.Width || Height != Pool.Height || Format != Pool.Format || Flags != Pool.Flags)
+	for (TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& Slot : EncoderPool)
 	{
-		for (FTextureRHIRef& Slot : Pool.Slots)
+		if (!Slot.IsValid())
 		{
-			Slot.SafeRelease();
+			Slot = MakeShared<FSentryVideoFrame, ESPMode::ThreadSafe>();
 		}
-		Pool.Width = Width;
-		Pool.Height = Height;
-		Pool.Format = Format;
-		Pool.Flags = Flags;
-	}
 
-	FTextureRHIRef* FreeSlot = nullptr;
-	for (FTextureRHIRef& Slot : Pool.Slots)
-	{
-		if (Slot.GetRefCount() <= 1)
+		if (!Slot->TryAcquire())
 		{
-			FreeSlot = &Slot;
-			break;
+			continue;
 		}
+
+		FSentryVideoFrame& Frame = *Slot;
+
+		if (Frame.Width != Width || Frame.Height != Height || Frame.Format != Format || Frame.Flags != Flags)
+		{
+			Frame.Texture.SafeRelease();
+			Frame.Width = Width;
+			Frame.Height = Height;
+			Frame.Format = Format;
+			Frame.Flags = Flags;
+		}
+
+		if (!Frame.Texture.IsValid())
+		{
+			const FRHITextureCreateDesc Desc = FRHITextureCreateDesc::Create2D(DebugName)
+												   .SetExtent(static_cast<int32>(Width), static_cast<int32>(Height))
+												   .SetFormat(Format)
+												   .SetFlags(Flags)
+												   .SetInitialState(InitialState);
+			Frame.Texture = FRHICommandListImmediate::Get().CreateTexture(Desc);
+		}
+
+		if (!Frame.Texture.IsValid())
+		{
+			Frame.Release();
+			return nullptr;
+		}
+
+		return Slot;
 	}
 
-	if (!FreeSlot)
-	{
-		return nullptr;
-	}
-
-	if (!FreeSlot->IsValid())
-	{
-		const FRHITextureCreateDesc Desc = FRHITextureCreateDesc::Create2D(DebugName)
-											   .SetExtent(static_cast<int32>(Width), static_cast<int32>(Height))
-											   .SetFormat(Format)
-											   .SetFlags(Flags)
-											   .SetInitialState(InitialState);
-		*FreeSlot = FRHICommandListImmediate::Get().CreateTexture(Desc);
-	}
-
-	return *FreeSlot;
+	return nullptr;
 }
 
 #endif // USE_SENTRY_SESSION_REPLAY

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryBackBufferCapture.h
@@ -12,7 +12,9 @@
 #include "RHIAccess.h"
 #include "RHIDefinitions.h"
 #include "RHIFwd.h"
+#include "Templates/SharedPointer.h"
 
+struct FSentryVideoFrame;
 class FSentryVideoEncoder;
 class ISlateViewportProvider;
 class SWindow;
@@ -56,17 +58,6 @@ private:
 		ETextureCreateFlags Flags = ETextureCreateFlags::None;
 	};
 
-	// N-slot pool sharing one config across all slots. Slots are created lazily
-	// and recycled when their refcount drops back to 1 (no other holder)
-	struct FCachedTexturePool
-	{
-		TArray<FTextureRHIRef> Slots;
-		uint32 Width = 0;
-		uint32 Height = 0;
-		EPixelFormat Format = PF_Unknown;
-		ETextureCreateFlags Flags = ETextureCreateFlags::None;
-	};
-
 #if UE_VERSION_OLDER_THAN(5, 8, 0)
 	void OnBackBufferReadyToPresent_RenderThread(SWindow& SlateWindow, const FTextureRHIRef& BackBuffer);
 #else
@@ -86,9 +77,10 @@ private:
 	static FTextureRHIRef AcquireCachedTexture_RenderThread(FCachedTexture& Cache, uint32 Width, uint32 Height, EPixelFormat Format,
 		ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName);
 
-	// Returns a texture pool slot whose refcount is <= 1, recreating the entire pool when
-	// the config changes. Returns null when every slot is still in flight
-	static FTextureRHIRef AcquireTexturePoolSlot_RenderThread(FCachedTexturePool& Pool, uint32 Width, uint32 Height, EPixelFormat Format,
+	// Acquires a free pool frame and ensures its texture exists (recreated on config
+	// change). Marks the acquired frame in flight. Returns null when every slot is
+	// still owned by the encoder or on creation failure
+	TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe> AcquireFrame_RenderThread(uint32 Width, uint32 Height, EPixelFormat Format,
 		ETextureCreateFlags Flags, ERHIAccess InitialState, const TCHAR* DebugName);
 
 	FSentryVideoEncoder& Encoder;
@@ -103,9 +95,13 @@ private:
 	// before the final hardware copy into the CPUReadback EncoderPool slot
 	FCachedTexture Converted;
 
-	// Pool of textures that are submitted to the encoder. Ref-counted because
-	// the encoder thread holds these across frames
-	FCachedTexturePool EncoderPool;
+	// Number of encoder frames pooled
+	static constexpr int32 FramePoolSize = 5;
+
+	// Pool of frames submitted to the encoder. Each frame stays in flight from
+	// acquire until the encoder releases it, so the render thread never overwrites
+	// a slot the encoder still holds
+	TArray<TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>> EncoderPool;
 
 	// Frame throttling
 	double NextCaptureTime = 0.0;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -6,6 +6,7 @@
 
 #include "SentryDefines.h"
 #include "SentrySessionReplayRecorder.h"
+#include "SentryVideoFrame.h"
 
 #include "HAL/Event.h"
 #include "HAL/PlatformMisc.h"
@@ -85,20 +86,20 @@ void FSentryVideoEncoder::StopEncoder()
 	}
 }
 
-void FSentryVideoEncoder::SubmitFrame(const FTextureRHIRef& Texture, double CaptureTimeSeconds)
+void FSentryVideoEncoder::SubmitFrame(const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& Frame)
 {
-	if (!Texture.IsValid() || bStopRequested || bEncodingDisabled)
+	if (!Frame.IsValid() || !Frame->Texture.IsValid() || bStopRequested || bEncodingDisabled)
 	{
+		if (Frame.IsValid())
+		{
+			Frame->Release();
+		}
 		return;
 	}
 
 	{
 		FScopeLock Lock(&QueueLock);
-		if (PendingQueue.Num() >= MaxQueueDepth)
-		{
-			PendingQueue.RemoveAt(0, 1, EAllowShrinking::No);
-		}
-		PendingQueue.Add(FPendingFrame{ Texture, CaptureTimeSeconds });
+		PendingQueue.Add(Frame);
 	}
 	if (WakeEvent)
 	{
@@ -130,7 +131,7 @@ uint32 FSentryVideoEncoder::Run()
 {
 	while (!bStopRequested)
 	{
-		TArray<FPendingFrame> Frames;
+		TArray<TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>> Frames;
 		{
 			FScopeLock Lock(&QueueLock);
 			Swap(Frames, PendingQueue);
@@ -138,6 +139,13 @@ uint32 FSentryVideoEncoder::Run()
 
 		if (bEncodingDisabled)
 		{
+			for (const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& FramePtr : Frames)
+			{
+				if (FramePtr.IsValid())
+				{
+					FramePtr->Release();
+				}
+			}
 			if (WakeEvent)
 			{
 				WakeEvent->Wait(50);
@@ -145,8 +153,13 @@ uint32 FSentryVideoEncoder::Run()
 			continue;
 		}
 
-		for (const FPendingFrame& Frame : Frames)
+		for (const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& FramePtr : Frames)
 		{
+			if (!FramePtr.IsValid())
+			{
+				continue;
+			}
+			const FSentryVideoFrame& Frame = *FramePtr;
 			const FTextureRHIRef& FrameTexture = Frame.Texture;
 			if (!FrameTexture.IsValid())
 			{
@@ -229,6 +242,14 @@ uint32 FSentryVideoEncoder::Run()
 			}
 
 			DrainPackets();
+		}
+
+		for (const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& FramePtr : Frames)
+		{
+			if (FramePtr.IsValid())
+			{
+				FramePtr->Release();
+			}
 		}
 
 		Frames.Reset();
@@ -361,6 +382,13 @@ void FSentryVideoEncoder::Restart()
 
 	{
 		FScopeLock Lock(&QueueLock);
+		for (const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& FramePtr : PendingQueue)
+		{
+			if (FramePtr.IsValid())
+			{
+				FramePtr->Release();
+			}
+		}
 		PendingQueue.Reset();
 	}
 }

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -402,8 +402,6 @@ void FSentryVideoEncoder::Restart()
 	bInitSegmentPublished = false;
 	bFirstFrameValidated = false;
 	ConsecutiveSendFrameFailures = 0;
-
-	DrainAndReleaseQueue();
 }
 
 void FSentryVideoEncoder::FlushCurrentFragment()

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -131,135 +131,158 @@ uint32 FSentryVideoEncoder::Run()
 {
 	while (!bStopRequested)
 	{
-		TArray<TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>> Frames;
-		{
-			FScopeLock Lock(&QueueLock);
-			Swap(Frames, PendingQueue);
-		}
-
 		if (bEncodingDisabled)
 		{
-			for (const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& FramePtr : Frames)
-			{
-				if (FramePtr.IsValid())
-				{
-					FramePtr->Release();
-				}
-			}
+			DrainAndReleaseQueue();
 			if (WakeEvent)
 			{
-				WakeEvent->Wait(50);
+				WakeEvent->Wait(IdlePollIntervalMs);
 			}
 			continue;
 		}
 
-		for (const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& FramePtr : Frames)
+		TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe> Frame;
 		{
-			if (!FramePtr.IsValid())
+			FScopeLock Lock(&QueueLock);
+			if (PendingQueue.Num() > 0)
 			{
-				continue;
+				Frame = PendingQueue[0];
 			}
-			const FSentryVideoFrame& Frame = *FramePtr;
-			const FTextureRHIRef& FrameTexture = Frame.Texture;
-			if (!FrameTexture.IsValid())
-			{
-				continue;
-			}
-			const uint32 ResW = FrameTexture->GetSizeX();
-			const uint32 ResH = FrameTexture->GetSizeY();
-			if (!EnsureEncoderOpen(ResW, ResH))
-			{
-				if (bEncodingDisabled)
-				{
-					break;
-				}
-				continue;
-			}
+		}
 
-			TSharedRef<FVideoResourceRHI> Resource = MakeShared<FVideoResourceRHI>(Encoder->GetDevice().ToSharedRef(),
-				FVideoResourceRHI::FRawData{ FrameTexture, nullptr, 0 });
-
-			bool bForceKeyframe = false;
-			if (LastForcedKeyframeTime <= 0.0 || (Frame.CaptureTimeSeconds - LastForcedKeyframeTime) >= FragmentSeconds)
+		if (!Frame.IsValid())
+		{
+			if (WakeEvent)
 			{
-				bForceKeyframe = true;
-				LastForcedKeyframeTime = Frame.CaptureTimeSeconds;
+				WakeEvent->Wait(IdlePollIntervalMs);
 			}
+			continue;
+		}
 
-			if (CaptureTimeBaseSeconds < 0.0)
+		if (!Frame->IsGpuWriteComplete())
+		{
+			// The GPU hasn't finished writing this frame's texture yet and handing it to the
+			// encoder now is the race that can hang the device - instead, wait briefly and recheck.
+			// Polling must not be spun on to block (see FRHIGPUFence::Poll), so we yield between checks
+			if (WakeEvent)
 			{
-				CaptureTimeBaseSeconds = Frame.CaptureTimeSeconds;
+				WakeEvent->Wait(FencePollIntervalMs);
 			}
+			continue;
+		}
 
-			// VT interprets SendFrame's timestamp as microseconds (see Engine's VideoEncoderVT.hpp)
+		{
+			FScopeLock Lock(&QueueLock);
+			if (PendingQueue.Num() > 0)
+			{
+				PendingQueue.RemoveAt(0, 1, EAllowShrinking::No);
+			}
+		}
+
+		ProcessFrame(*Frame);
+
+		Frame->Release();
+	}
+
+	DrainAndReleaseQueue();
+
+	return 0;
+}
+
+void FSentryVideoEncoder::ProcessFrame(FSentryVideoFrame& Frame)
+{
+	const FTextureRHIRef& FrameTexture = Frame.Texture;
+	if (!FrameTexture.IsValid())
+	{
+		return;
+	}
+
+	const uint32 ResW = FrameTexture->GetSizeX();
+	const uint32 ResH = FrameTexture->GetSizeY();
+	if (!EnsureEncoderOpen(ResW, ResH))
+	{
+		return;
+	}
+
+	TSharedRef<FVideoResourceRHI> Resource = MakeShared<FVideoResourceRHI>(Encoder->GetDevice().ToSharedRef(),
+		FVideoResourceRHI::FRawData{ FrameTexture, nullptr, 0 });
+
+	bool bForceKeyframe = false;
+	if (LastForcedKeyframeTime <= 0.0 || (Frame.CaptureTimeSeconds - LastForcedKeyframeTime) >= FragmentSeconds)
+	{
+		bForceKeyframe = true;
+		LastForcedKeyframeTime = Frame.CaptureTimeSeconds;
+	}
+
+	if (CaptureTimeBaseSeconds < 0.0)
+	{
+		CaptureTimeBaseSeconds = Frame.CaptureTimeSeconds;
+	}
+
+	// VT interprets SendFrame's timestamp as microseconds (see Engine's VideoEncoderVT.hpp)
 #if PLATFORM_APPLE
-			static constexpr double SendTimestampScale = 1'000'000.0;
+	static constexpr double SendTimestampScale = 1'000'000.0;
 #else
-			static constexpr double SendTimestampScale = 1'000.0;
+	static constexpr double SendTimestampScale = 1'000.0;
 #endif
 
-			const double TimestampSeconds = FMath::Max(0.0, Frame.CaptureTimeSeconds - CaptureTimeBaseSeconds);
-			const double ScaledTimestamp = TimestampSeconds * SendTimestampScale;
+	const double TimestampSeconds = FMath::Max(0.0, Frame.CaptureTimeSeconds - CaptureTimeBaseSeconds);
+	const double ScaledTimestamp = TimestampSeconds * SendTimestampScale;
 
 #if PLATFORM_APPLE
-			// Restart the encoder every hour of recording. On Apple platforms this stays well clear of the
-			// uint32-microseconds wrap at ~71 min which would otherwise feed VT a backward PTS
-			// and corrupt all subsequent fragments. On Windows the natural wrap is at ~49 days
-			// so realistically periodic refresh of encoder state won't be needed there
-			constexpr double RestartThreshold = 3600.0 * SendTimestampScale;
-			if (ScaledTimestamp > RestartThreshold)
-			{
-				UE_LOG(LogSentrySdk, Log, TEXT("Session replay: encoder has been running for %.0f s; restarting to refresh state."), TimestampSeconds);
-				Restart();
-				continue;
-			}
+	// Restart the encoder every hour of recording. On Apple platforms this stays well clear of the
+	// uint32-microseconds wrap at ~71 min which would otherwise feed VT a backward PTS
+	// and corrupt all subsequent fragments. On Windows the natural wrap is at ~49 days
+	// so realistically periodic refresh of encoder state won't be needed there
+	constexpr double RestartThreshold = 3600.0 * SendTimestampScale;
+	if (ScaledTimestamp > RestartThreshold)
+	{
+		UE_LOG(LogSentrySdk, Log, TEXT("Session replay: encoder has been running for %.0f s; restarting to refresh state."), TimestampSeconds);
+		Restart();
+		return;
+	}
 #endif
 
-			const uint32 SendTimestamp = static_cast<uint32>(ScaledTimestamp);
+	const uint32 SendTimestamp = static_cast<uint32>(ScaledTimestamp);
 
-			const FAVResult Result = Encoder->SendFrame(Resource, SendTimestamp, bForceKeyframe);
-			if (Result.IsSuccess())
-			{
-				bFirstFrameValidated = true;
-				ConsecutiveSendFrameFailures = 0;
-			}
-			else if (!bFirstFrameValidated)
-			{
-				UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: encoder rejected the first frame. Recording disabled for this session."));
-				bEncodingDisabled.AtomicSet(true);
-				break;
-			}
-			else
-			{
-				if (++ConsecutiveSendFrameFailures >= MaxConsecutiveSendFrameFailures)
-				{
-					UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: encoder failed %d consecutive frames. Recording disabled for this session."), ConsecutiveSendFrameFailures);
-					bEncodingDisabled.AtomicSet(true);
-					break;
-				}
-
-				UE_LOG(LogSentrySdk, Verbose, TEXT("Session replay: SendFrame returned non-success (%d in a row)"), ConsecutiveSendFrameFailures);
-			}
-
-			DrainPackets();
+	const FAVResult Result = Encoder->SendFrame(Resource, SendTimestamp, bForceKeyframe);
+	if (Result.IsSuccess())
+	{
+		bFirstFrameValidated = true;
+		ConsecutiveSendFrameFailures = 0;
+	}
+	else if (!bFirstFrameValidated)
+	{
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: encoder rejected the first frame. Recording disabled for this session."));
+		bEncodingDisabled.AtomicSet(true);
+		return;
+	}
+	else
+	{
+		if (++ConsecutiveSendFrameFailures >= MaxConsecutiveSendFrameFailures)
+		{
+			UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: encoder failed %d consecutive frames. Recording disabled for this session."), ConsecutiveSendFrameFailures);
+			bEncodingDisabled.AtomicSet(true);
+			return;
 		}
 
-		for (const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& FramePtr : Frames)
-		{
-			if (FramePtr.IsValid())
-			{
-				FramePtr->Release();
-			}
-		}
+		UE_LOG(LogSentrySdk, Verbose, TEXT("Session replay: SendFrame returned non-success (%d in a row)"), ConsecutiveSendFrameFailures);
+	}
 
-		Frames.Reset();
+	DrainPackets();
+}
 
-		if (WakeEvent)
+void FSentryVideoEncoder::DrainAndReleaseQueue()
+{
+	FScopeLock Lock(&QueueLock);
+	for (const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& FramePtr : PendingQueue)
+	{
+		if (FramePtr.IsValid())
 		{
-			WakeEvent->Wait(50);
+			FramePtr->Release();
 		}
 	}
-	return 0;
+	PendingQueue.Reset();
 }
 
 bool FSentryVideoEncoder::ShouldSwapDimensions(uint32 ResourceWidth, uint32 ResourceHeight) const
@@ -380,17 +403,7 @@ void FSentryVideoEncoder::Restart()
 	bFirstFrameValidated = false;
 	ConsecutiveSendFrameFailures = 0;
 
-	{
-		FScopeLock Lock(&QueueLock);
-		for (const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& FramePtr : PendingQueue)
-		{
-			if (FramePtr.IsValid())
-			{
-				FramePtr->Release();
-			}
-		}
-		PendingQueue.Reset();
-	}
+	DrainAndReleaseQueue();
 }
 
 void FSentryVideoEncoder::FlushCurrentFragment()

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
@@ -20,6 +20,7 @@ class FRunnableThread;
 class FEvent;
 class FVideoResourceRHI;
 
+struct FSentryVideoFrame;
 class FSentrySessionReplayRecorder;
 
 /**
@@ -42,7 +43,7 @@ public:
 	void StopEncoder();
 
 	// Enqueues a texture for the encoder thread to process
-	void SubmitFrame(const FTextureRHIRef& Texture, double CaptureTimeSeconds);
+	void SubmitFrame(const TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>& Frame);
 
 	uint32 GetFramerate() const { return Framerate; }
 
@@ -56,9 +57,6 @@ public:
 	virtual void Stop() override;
 	virtual void Exit() override;
 	virtual uint32 Run() override;
-
-	// Frames buffered for the encoder thread
-	static constexpr int32 MaxQueueDepth = 5;
 
 private:
 	// Checks if frame dimensions match with the app's fixed screen orientation
@@ -109,14 +107,8 @@ private:
 	FThreadSafeBool bStopRequested;
 
 	// Encoder thread frame queue
-	struct FPendingFrame
-	{
-		FTextureRHIRef Texture;
-		double CaptureTimeSeconds = 0.0;
-	};
-
 	FCriticalSection QueueLock;
-	TArray<FPendingFrame> PendingQueue;
+	TArray<TSharedPtr<FSentryVideoFrame, ESPMode::ThreadSafe>> PendingQueue;
 
 	// Timing (encoder-thread-only)
 	double CaptureTimeBaseSeconds = -1.0;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
@@ -64,6 +64,12 @@ private:
 
 	bool EnsureEncoderOpen(uint32 ResourceWidth, uint32 ResourceHeight);
 
+	// Encodes one fence-ready frame and drains produced packets
+	void ProcessFrame(FSentryVideoFrame& Frame);
+
+	// Releases every queued frame back to its pool slot and empties the queue
+	void DrainAndReleaseQueue();
+
 	// Pulls available packets from the encoder, converts them to AVCC samples and emits a fragment at each keyframe boundary
 	void DrainPackets();
 
@@ -93,6 +99,11 @@ private:
 
 	int32 ConsecutiveSendFrameFailures = 0;
 	static constexpr int32 MaxConsecutiveSendFrameFailures = 30;
+
+	// Recheck cadence (ms) while waiting for a frame's GPU write fence to signal
+	static constexpr uint32 FencePollIntervalMs = 2;
+	// Idle wait (ms) when there is no work: encoding disabled or an empty queue
+	static constexpr uint32 IdlePollIntervalMs = 50;
 
 	// Capture config
 	uint32 Width = 0;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoFrame.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoFrame.cpp
@@ -1,0 +1,22 @@
+// Copyright (c) 2026 Sentry. All Rights Reserved.
+
+#include "SentryVideoFrame.h"
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+
+bool FSentryVideoFrame::TryAcquire()
+{
+	if (bInFlight)
+	{
+		return false;
+	}
+	bInFlight.AtomicSet(true);
+	return true;
+}
+
+void FSentryVideoFrame::Release()
+{
+	bInFlight.AtomicSet(false);
+}
+
+#endif // USE_SENTRY_SESSION_REPLAY

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoFrame.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoFrame.cpp
@@ -4,6 +4,8 @@
 
 #ifdef USE_SENTRY_SESSION_REPLAY
 
+#include "RHIResources.h"
+
 bool FSentryVideoFrame::TryAcquire()
 {
 	if (bInFlight)
@@ -17,6 +19,11 @@ bool FSentryVideoFrame::TryAcquire()
 void FSentryVideoFrame::Release()
 {
 	bInFlight.AtomicSet(false);
+}
+
+bool FSentryVideoFrame::IsGpuWriteComplete() const
+{
+	return !ReadyFence.IsValid() || (ReadyFence->NumPendingWriteCommands.GetValue() == 0 && ReadyFence->Poll());
 }
 
 #endif // USE_SENTRY_SESSION_REPLAY

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoFrame.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoFrame.h
@@ -19,6 +19,8 @@ struct FSentryVideoFrame
 {
 	FTextureRHIRef Texture;
 
+	FGPUFenceRHIRef ReadyFence;
+
 	double CaptureTimeSeconds = 0.0;
 
 	uint32 Width = 0;
@@ -34,6 +36,11 @@ struct FSentryVideoFrame
 	// Called by the encoder to mark this frame free again, once it has finished
 	// encoding it, so the capture path can reuse it
 	void Release();
+
+	// Checks if GPU has finished writing Texture (ReadyFence signalled), so the
+	// encoder may hand it to the hardware encoder. A frame with no fence counts as
+	// ready
+	bool IsGpuWriteComplete() const;
 
 private:
 	FThreadSafeBool bInFlight;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoFrame.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoFrame.h
@@ -1,0 +1,42 @@
+// Copyright (c) 2026 Sentry. All Rights Reserved.
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#ifdef USE_SENTRY_SESSION_REPLAY
+
+#include "HAL/ThreadSafeBool.h"
+#include "PixelFormat.h"
+#include "RHIDefinitions.h"
+#include "RHIFwd.h"
+
+/**
+ * A capture texture shared between the render-thread capture
+ * path that produces it and the encoder thread that consumes it.
+ */
+struct FSentryVideoFrame
+{
+	FTextureRHIRef Texture;
+
+	double CaptureTimeSeconds = 0.0;
+
+	uint32 Width = 0;
+	uint32 Height = 0;
+	EPixelFormat Format = PF_Unknown;
+	ETextureCreateFlags Flags = ETextureCreateFlags::None;
+
+	// Called by the capture path to claim this frame before writing to it. Marks
+	// the frame in use and returns true, or returns false if the encoder has not
+	// released it yet
+	bool TryAcquire();
+
+	// Called by the encoder to mark this frame free again, once it has finished
+	// encoding it, so the capture path can reuse it
+	void Release();
+
+private:
+	FThreadSafeBool bInFlight;
+};
+
+#endif // USE_SENTRY_SESSION_REPLAY

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -231,6 +231,8 @@ Source/Sentry/Private/SessionReplay/SentrySessionReplayRecorder.cpp
 Source/Sentry/Private/SessionReplay/SentrySessionReplayRecorder.h
 Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
 Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
+Source/Sentry/Private/SessionReplay/SentryVideoFrame.cpp
+Source/Sentry/Private/SessionReplay/SentryVideoFrame.h
 Source/Sentry/Private/Tests/SentryBreadcrumb.spec.cpp
 Source/Sentry/Private/Tests/SentryEvent.spec.cpp
 Source/Sentry/Private/Tests/SentryFeedback.spec.cpp


### PR DESCRIPTION
This PR fixes random GPU crashes that occur when session replay is enabled and the GPU is under load (e.g. during PSO compilation or DLSS). The crash surfaces as `LogD3D12RHI: Error: GPU crash detected: Device 0 Removed: DXGI_ERROR_DEVICE_HUNG`, alongside `NVENC: Failed to lock output bitstream` and a `SendFrame` failure on the same frame.

The root cause is a producer→consumer synchronization gap between the graphics queue and the hardware video encoder. The render thread records the capture draw into the encoder texture and hands it to the encoder thread, which passes it to NVENC. NVENC imports the texture through a shared/external handle and reads it on its own queue, outside the engine's RHI barrier tracking so nothing guaranteed the graphics-queue write had completed before NVENC read it. Under timing pressure this races and can hang the device.

The fix introduces an explicit GPU write fence per capture frame: the render thread signals it after the draw, and the encoder waits for it before reading, so the encoder never touches a texture the GPU is still writing. Slot reuse is also made explicit (in-flight ownership) so the render thread never overwrites a frame the encoder still holds.

## Key Changes

- New `FSentryVideoFrame` - a shared unit between the capture path (producer) and encoder thread (consumer), carrying the texture, a GPU `ReadyFence` and an `bInFlight` ownership flag. Replaces the previous refcount-based "is this slot free?" heuristic with an explicit `TryAcquire`/`Release` handshake.
- GPU write fence (the fix) - the capturer clears and writes a `FGPUFenceRHIRef` after the capture draw; the encoder gates on `IsGpuWriteComplete()` before `SendFrame`, so a texture is only encoded once the GPU has finished writing it. Applied on all platforms (also closes a latent GPU→CPU sync gap on the Apple readback path).
- Encoder loop restructured - Run now peeks the oldest queued frame, waits for its fence to signal, then pops and encodes it. Fences signal in submission order, so the head is always the first ready and no ready frame is starved behind a pending one.
- Fail-safe frame acquisition - a frame is dropped if either its texture or its fence can't be created, rather than silently submitting an unsynchronized (race-prone) frame.
- Pool bounds back-pressure - in-flight frames are capped by the pool size; when the encoder falls behind, captures are dropped instead of racing, and the queue-overflow eviction is removed.
- Cleanups - extracted `ProcessFrame`, shared `DrainAndReleaseQueue` for the disable/restart/shutdown paths, and named poll-interval constants (`FencePollIntervalMs`, `IdlePollIntervalMs`).

## Related items

- https://github.com/getsentry/sentry-unreal/pull/1509