### PR TITLE
Resolve iOS sandbox path before uploading session replay envelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix Android `minifyRelease` R8 build failure caused by missing `android.os.ProfilingManager`/`ProfilingResult` class references in the Java SDK ([#1505](https://github.com/getsentry/sentry-unreal/pull/1505))
 - Skip transient overlay windows during session replay capture ([#1512](https://github.com/getsentry/sentry-unreal/pull/1512))
 - Defer Session Replay capture on desktop until engine initialization is complete ([#1514](https://github.com/getsentry/sentry-unreal/pull/1514))
+- Fix iOS session replay upload after a crash by resolving the sandbox video path ([#1518](https://github.com/getsentry/sentry-unreal/pull/1518))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
@@ -253,12 +253,12 @@ bool FAppleSentryReplayEnvelope::CaptureForCrashEvent(SentryObjCEvent* event, co
 		return false;
 	}
 
-	const FString NativeVideoPath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*videoPath);
+	const FString platformVideoPath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*videoPath);
 
-	NSData* video = [NSData dataWithContentsOfFile:NativeVideoPath.GetNSString()];
+	NSData* video = [NSData dataWithContentsOfFile:platformVideoPath.GetNSString()];
 	if (video == nil || video.length == 0)
 	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to read video file at %s"), *NativeVideoPath);
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to read video file at %s"), *platformVideoPath);
 		return false;
 	}
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
@@ -14,6 +14,7 @@
 #include "Infrastructure/AppleSentryConverters.h"
 
 #include "JsonObjectConverter.h"
+#include "HAL/FileManager.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
 
@@ -252,10 +253,12 @@ bool FAppleSentryReplayEnvelope::CaptureForCrashEvent(SentryObjCEvent* event, co
 		return false;
 	}
 
-	NSData* video = [NSData dataWithContentsOfFile:videoPath.GetNSString()];
+	const FString NativeVideoPath = IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead(*videoPath);
+
+	NSData* video = [NSData dataWithContentsOfFile:NativeVideoPath.GetNSString()];
 	if (video == nil || video.length == 0)
 	{
-		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to read video file at %s"), *videoPath);
+		UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: failed to read video file at %s"), *NativeVideoPath);
 		return false;
 	}
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryReplayEnvelope.cpp
@@ -13,8 +13,8 @@
 
 #include "Infrastructure/AppleSentryConverters.h"
 
-#include "JsonObjectConverter.h"
 #include "HAL/FileManager.h"
+#include "JsonObjectConverter.h"
 #include "Misc/FileHelper.h"
 #include "Misc/Paths.h"
 


### PR DESCRIPTION
On iOS, session replay video captured for a previous run's crash wasn't uploaded to Sentry due to its invalid sandbox path (likely a regression from https://github.com/getsentry/sentry-unreal/pull/1468). On the launch following a crash the SDK logged:

```
LogSentrySdk: Warning: Session replay: failed to read video file at ../../../<Project>/Saved/SentryReplays/replay-<id>.mp4
```

The recorder writes the replay `.mp4` through `IFileManager` (`CreateFileWriter` → `Move`). On iOS, `IFileManager` transparently remaps the UE virtual `Saved/` path into the app sandbox (Documents/Caches), so the file physically lands there.

When building the crash envelope, `FAppleSentryReplayEnvelope::CaptureForCrashEvent` reads the video with `[NSData dataWithContentsOfFile:]` which is a native API that does **not** apply that sandbox remapping. It received the unmapped UE path, so the read failed and the replay was dropped. The metadata sidecar read succeeded because it goes through `FFileHelper`/`IFileManager`, which does the remapping.

### Suggested Fix

Resolve the real on-disk path with `IFileManager::Get().ConvertToAbsolutePathForExternalAppForRead()` before handing it to `NSData`. On iOS this runs the same sandbox mapping the writer used (and falls back to the write-mapped location), and on other Apple platforms it's a no-op.

### Testing

Verified on device (iPhone, iOS): reproduced the crash → relaunch cycle. Before the change the video read failed with the warning above; after the change the replay video is read and uploaded.

[Example replay](https://sentry-sdks.sentry.io/explore/replays/e1dee25ec941b8557b89b9b229f8a5b7/?groupId=7532510000&referrer=%2Fissues%2F%3AgroupId%2F&t=0&t_main=errors) captured on iOS.