### PR TITLE
ci: Replace secrets: inherit with explicit secret maps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,7 +252,10 @@ jobs:
   test-linux:
     needs: [package-preparation, generate-test-matrix]
     name: Linux UE ${{ matrix.unreal }}
-    secrets: inherit
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     strategy:
       fail-fast: false
       matrix:
@@ -264,7 +267,10 @@ jobs:
   test-windows:
     needs: [package-preparation, generate-test-matrix]
     name: Windows UE ${{ matrix.unreal }}
-    secrets: inherit
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     strategy:
       fail-fast: false
       matrix:
@@ -276,7 +282,10 @@ jobs:
   test-macos:
     needs: [package-preparation]
     name: macOS UE ${{ matrix.unreal }}
-    secrets: inherit
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     strategy:
       fail-fast: false
       matrix:
@@ -290,7 +299,10 @@ jobs:
   test-android:
     needs: [package-preparation, generate-test-matrix]
     name: Android UE ${{ matrix.unreal }}
-    secrets: inherit
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     strategy:
       fail-fast: false
       matrix:
@@ -302,7 +314,9 @@ jobs:
   integration-test-linux:
     needs: [test-linux, generate-test-matrix]
     name: Linux UE ${{ matrix.unreal }} (${{ matrix.backend }})
-    secrets: inherit
+    secrets:
+      SENTRY_UNREAL_TEST_DSN: ${{ secrets.SENTRY_UNREAL_TEST_DSN }}
+      SENTRY_API_TOKEN: ${{ secrets.SENTRY_API_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -316,7 +330,9 @@ jobs:
   integration-test-windows:
     needs: [test-windows, generate-test-matrix]
     name: Windows UE ${{ matrix.unreal }} (${{ matrix.backend }})
-    secrets: inherit
+    secrets:
+      SENTRY_UNREAL_TEST_DSN: ${{ secrets.SENTRY_UNREAL_TEST_DSN }}
+      SENTRY_API_TOKEN: ${{ secrets.SENTRY_API_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -333,7 +349,9 @@ jobs:
   integration-test-macos:
     needs: [test-macos]
     name: macOS UE ${{ matrix.unreal }} (${{ matrix.backend }})
-    secrets: inherit
+    secrets:
+      SENTRY_UNREAL_TEST_DSN: ${{ secrets.SENTRY_UNREAL_TEST_DSN }}
+      SENTRY_API_TOKEN: ${{ secrets.SENTRY_API_TOKEN }}
     strategy:
       fail-fast: false
       matrix:
@@ -347,7 +365,11 @@ jobs:
   integration-test-android:
     needs: [test-android, generate-test-matrix]
     name: Android UE ${{ matrix.unreal }}
-    secrets: inherit
+    secrets:
+      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+      SENTRY_UNREAL_TEST_DSN: ${{ secrets.SENTRY_UNREAL_TEST_DSN }}
+      SENTRY_API_TOKEN: ${{ secrets.SENTRY_API_TOKEN }}
     strategy:
       fail-fast: false
       max-parallel: 1

--- a/.github/workflows/integration-test-android.yml
+++ b/.github/workflows/integration-test-android.yml
@@ -4,6 +4,15 @@ on:
       unreal-version:
         required: true
         type: string
+    secrets:
+      SAUCE_USERNAME:
+        required: true
+      SAUCE_ACCESS_KEY:
+        required: true
+      SENTRY_UNREAL_TEST_DSN:
+        required: true
+      SENTRY_API_TOKEN:
+        required: true
 
 jobs:
   integration-test:

--- a/.github/workflows/integration-test-linux.yml
+++ b/.github/workflows/integration-test-linux.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: "crashpad"
+    secrets:
+      SENTRY_UNREAL_TEST_DSN:
+        required: true
+      SENTRY_API_TOKEN:
+        required: true
 
 jobs:
   integration-test:

--- a/.github/workflows/integration-test-macos.yml
+++ b/.github/workflows/integration-test-macos.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: "cocoa"
+    secrets:
+      SENTRY_UNREAL_TEST_DSN:
+        required: true
+      SENTRY_API_TOKEN:
+        required: true
 
 jobs:
   integration-test:

--- a/.github/workflows/integration-test-windows.yml
+++ b/.github/workflows/integration-test-windows.yml
@@ -8,6 +8,11 @@ on:
         required: false
         type: string
         default: "crashpad"
+    secrets:
+      SENTRY_UNREAL_TEST_DSN:
+        required: true
+      SENTRY_API_TOKEN:
+        required: true
 
 jobs:
   integration-test:

--- a/.github/workflows/test-android.yml
+++ b/.github/workflows/test-android.yml
@@ -4,6 +4,13 @@ on:
       unreal-version:
         required: true
         type: string
+    secrets:
+      SENTRY_AUTH_TOKEN:
+        required: true
+      SENTRY_ORG:
+        required: true
+      SENTRY_PROJECT:
+        required: true
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/test-linux.yml
+++ b/.github/workflows/test-linux.yml
@@ -4,6 +4,13 @@ on:
       unreal-version:
         required: true
         type: string
+    secrets:
+      SENTRY_AUTH_TOKEN:
+        required: true
+      SENTRY_ORG:
+        required: true
+      SENTRY_PROJECT:
+        required: true
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/test-macos.yml
+++ b/.github/workflows/test-macos.yml
@@ -4,6 +4,13 @@ on:
       unreal-version:
         required: true
         type: string
+    secrets:
+      SENTRY_AUTH_TOKEN:
+        required: true
+      SENTRY_ORG:
+        required: true
+      SENTRY_PROJECT:
+        required: true
 
 jobs:
   test:

--- a/.github/workflows/test-windows.yml
+++ b/.github/workflows/test-windows.yml
@@ -4,6 +4,13 @@ on:
       unreal-version:
         required: true
         type: string
+    secrets:
+      SENTRY_AUTH_TOKEN:
+        required: true
+      SENTRY_ORG:
+        required: true
+      SENTRY_PROJECT:
+        required: true
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
## Summary
- 8 jobs in `ci.yml` (`test-linux`, `test-windows`, `test-macos`, `test-android`, `integration-test-linux`, `integration-test-windows`, `integration-test-macos`, `integration-test-android`) used `secrets: inherit`, exposing every repository secret to the called reusable workflows.
- None of the called workflows declared a `workflow_call.secrets` schema despite reading `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `SENTRY_UNREAL_TEST_DSN`, `SENTRY_API_TOKEN`, and/or `SAUCE_USERNAME`/`SAUCE_ACCESS_KEY`.
- Added explicit secret schemas to each called workflow and updated `ci.yml` to pass only the secrets each workflow actually needs, by name.

This completes the fix for VULN-2362 — the `changelog-preview.yml` location of this ticket (the 7th of 7) was already handled in #1516.

## Test plan
- [x] Validated all touched workflow YAML parses correctly
- [x] Cross-referenced every `secrets.*` reference in each called workflow against the new explicit `secrets:` maps in `ci.yml`
- [ ] Confirm CI runs (test-linux/windows/macos/android, integration-test-linux/windows/macos/android) still succeed with the explicit secret passing

Fixes VULN-2362

🤖 Generated with [Claude Code](https://claude.com/claude-code)