### PR TITLE
Reduce per-frame allocations in the session replay encoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Defer Session Replay capture on desktop until engine initialization is complete ([#1514](https://github.com/getsentry/sentry-unreal/pull/1514))
 - Fix iOS session replay upload after a crash by resolving the sandbox video path ([#1518](https://github.com/getsentry/sentry-unreal/pull/1518))
 - Sample frame time metrics on a wall-clock interval instead of every Nth frame ([#1522](https://github.com/getsentry/sentry-unreal/pull/1522))
+- Reduce per-frame allocations in the session replay encoder ([#1527](https://github.com/getsentry/sentry-unreal/pull/1527))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -336,8 +336,6 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 				Width, Height, ResourceWidth, ResourceHeight);
 			bResolutionChanged = true;
 
-			// The capture pool textures were recreated at the new size, so wrappers
-			// cached for the old ones are stale and will never be reused - drop them.
 			ResourceCache.Empty();
 		}
 		return true;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -330,11 +330,14 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 		const bool bSameTransposedSize = ExpectedOrientation != EDeviceScreenOrientation::Unknown &&
 										 ResourceWidth == Height && ResourceHeight == Width;
 
-		if (!bSameSize && !bSameTransposedSize && !bResolutionChanged)
+		if (!bSameSize && !bSameTransposedSize)
 		{
-			UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: capture resolution changed from %ux%u to %ux%u; recording stays locked to the original size and may be cropped or black."),
-				Width, Height, ResourceWidth, ResourceHeight);
-			bResolutionChanged = true;
+			if (!bResolutionChanged)
+			{
+				UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: capture resolution changed from %ux%u to %ux%u; recording stays locked to the original size and may be cropped or black."),
+					Width, Height, ResourceWidth, ResourceHeight);
+				bResolutionChanged = true;
+			}
 
 			ResourceCache.Empty();
 		}

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -124,6 +124,7 @@ void FSentryVideoEncoder::Stop()
 void FSentryVideoEncoder::Exit()
 {
 	Encoder.Reset();
+	ResourceCache.Empty();
 	bEncoderOpen = false;
 }
 
@@ -204,9 +205,6 @@ void FSentryVideoEncoder::ProcessFrame(FSentryVideoFrame& Frame)
 		return;
 	}
 
-	TSharedRef<FVideoResourceRHI> Resource = MakeShared<FVideoResourceRHI>(Encoder->GetDevice().ToSharedRef(),
-		FVideoResourceRHI::FRawData{ FrameTexture, nullptr, 0 });
-
 	bool bForceKeyframe = false;
 	if (LastForcedKeyframeTime <= 0.0 || (Frame.CaptureTimeSeconds - LastForcedKeyframeTime) >= FragmentSeconds)
 	{
@@ -245,6 +243,12 @@ void FSentryVideoEncoder::ProcessFrame(FSentryVideoFrame& Frame)
 
 	const uint32 SendTimestamp = static_cast<uint32>(ScaledTimestamp);
 
+	const TSharedPtr<FVideoResourceRHI> Resource = AcquireVideoResource(FrameTexture);
+	if (!Resource.IsValid())
+	{
+		return;
+	}
+
 	const FAVResult Result = Encoder->SendFrame(Resource, SendTimestamp, bForceKeyframe);
 	if (Result.IsSuccess())
 	{
@@ -270,6 +274,21 @@ void FSentryVideoEncoder::ProcessFrame(FSentryVideoFrame& Frame)
 	}
 
 	DrainPackets();
+}
+
+TSharedPtr<FVideoResourceRHI> FSentryVideoEncoder::AcquireVideoResource(const FTextureRHIRef& Texture)
+{
+	if (const FCachedVideoResource* Cached = ResourceCache.Find(Texture.GetReference()))
+	{
+		return Cached->Resource;
+	}
+
+	TSharedPtr<FVideoResourceRHI> Resource = MakeShared<FVideoResourceRHI>(Encoder->GetDevice().ToSharedRef(),
+		FVideoResourceRHI::FRawData{ Texture, nullptr, 0 });
+
+	ResourceCache.Add(Texture.GetReference(), FCachedVideoResource{ Texture, Resource });
+
+	return Resource;
 }
 
 void FSentryVideoEncoder::DrainAndReleaseQueue()
@@ -316,6 +335,10 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 			UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: capture resolution changed from %ux%u to %ux%u; recording stays locked to the original size and may be cropped or black."),
 				Width, Height, ResourceWidth, ResourceHeight);
 			bResolutionChanged = true;
+
+			// The capture pool textures were recreated at the new size, so wrappers
+			// cached for the old ones are stale and will never be reused - drop them.
+			ResourceCache.Empty();
 		}
 		return true;
 	}
@@ -387,6 +410,7 @@ void FSentryVideoEncoder::Restart()
 	FlushCurrentFragment();
 
 	Encoder.Reset();
+	ResourceCache.Empty();
 
 	bEncoderOpen = false;
 

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.cpp
@@ -278,6 +278,15 @@ void FSentryVideoEncoder::ProcessFrame(FSentryVideoFrame& Frame)
 
 TSharedPtr<FVideoResourceRHI> FSentryVideoEncoder::AcquireVideoResource(const FTextureRHIRef& Texture)
 {
+	if (ResourceCache.Num() > 0)
+	{
+		const FTextureRHIRef& CachedTexture = ResourceCache.CreateConstIterator().Value().Texture;
+		if (CachedTexture->GetSizeX() != Texture->GetSizeX() || CachedTexture->GetSizeY() != Texture->GetSizeY())
+		{
+			ResourceCache.Empty();
+		}
+	}
+
 	if (const FCachedVideoResource* Cached = ResourceCache.Find(Texture.GetReference()))
 	{
 		return Cached->Resource;
@@ -330,16 +339,11 @@ bool FSentryVideoEncoder::EnsureEncoderOpen(uint32 ResourceWidth, uint32 Resourc
 		const bool bSameTransposedSize = ExpectedOrientation != EDeviceScreenOrientation::Unknown &&
 										 ResourceWidth == Height && ResourceHeight == Width;
 
-		if (!bSameSize && !bSameTransposedSize)
+		if (!bSameSize && !bSameTransposedSize && !bResolutionChanged)
 		{
-			if (!bResolutionChanged)
-			{
-				UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: capture resolution changed from %ux%u to %ux%u; recording stays locked to the original size and may be cropped or black."),
-					Width, Height, ResourceWidth, ResourceHeight);
-				bResolutionChanged = true;
-			}
-
-			ResourceCache.Empty();
+			UE_LOG(LogSentrySdk, Warning, TEXT("Session replay: capture resolution changed from %ux%u to %ux%u; recording stays locked to the original size and may be cropped or black."),
+				Width, Height, ResourceWidth, ResourceHeight);
+			bResolutionChanged = true;
 		}
 		return true;
 	}

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
@@ -67,6 +67,10 @@ private:
 	// Encodes one fence-ready frame and drains produced packets
 	void ProcessFrame(FSentryVideoFrame& Frame);
 
+	// Returns a cached FVideoResourceRHI wrapping Texture, creating one on first use.
+	// Encoder must be open. Encoder-thread only.
+	TSharedPtr<FVideoResourceRHI> AcquireVideoResource(const FTextureRHIRef& Texture);
+
 	// Releases every queued frame back to its pool slot and empties the queue
 	void DrainAndReleaseQueue();
 
@@ -93,6 +97,21 @@ private:
 	EDeviceScreenOrientation ExpectedOrientation = EDeviceScreenOrientation::Unknown;
 
 	TSharedPtr<TVideoEncoder<FVideoResourceRHI>> Encoder;
+
+	// Reuses one FVideoResourceRHI wrapper per input texture so the AVCodecs
+	// resource mapping/registration runs once per texture instead of on every
+	// SendFrame. The capture side recycles a small fixed texture pool, so this map
+	// stays small. Keyed by the raw texture pointer; the FTextureRHIRef held in the
+	// value pins that texture alive, so its address can't be recycled by a different
+	// texture while cached (no ABA). Encoder-thread only, and bound to the current
+	// encoder's device - emptied on encoder teardown (Restart/Exit) and on a capture
+	// resolution change.
+	struct FCachedVideoResource
+	{
+		FTextureRHIRef Texture;
+		TSharedPtr<FVideoResourceRHI> Resource;
+	};
+	TMap<FRHITexture*, FCachedVideoResource> ResourceCache;
 
 	bool bFirstFrameValidated = false;
 	FThreadSafeBool bEncodingDisabled;

--- a/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
+++ b/plugin-dev/Source/Sentry/Private/SessionReplay/SentryVideoEncoder.h
@@ -67,8 +67,7 @@ private:
 	// Encodes one fence-ready frame and drains produced packets
 	void ProcessFrame(FSentryVideoFrame& Frame);
 
-	// Returns a cached FVideoResourceRHI wrapping Texture, creating one on first use.
-	// Encoder must be open. Encoder-thread only.
+	// Returns a cached FVideoResourceRHI wrapping Texture, creating one on first use
 	TSharedPtr<FVideoResourceRHI> AcquireVideoResource(const FTextureRHIRef& Texture);
 
 	// Releases every queued frame back to its pool slot and empties the queue
@@ -98,14 +97,6 @@ private:
 
 	TSharedPtr<TVideoEncoder<FVideoResourceRHI>> Encoder;
 
-	// Reuses one FVideoResourceRHI wrapper per input texture so the AVCodecs
-	// resource mapping/registration runs once per texture instead of on every
-	// SendFrame. The capture side recycles a small fixed texture pool, so this map
-	// stays small. Keyed by the raw texture pointer; the FTextureRHIRef held in the
-	// value pins that texture alive, so its address can't be recycled by a different
-	// texture while cached (no ABA). Encoder-thread only, and bound to the current
-	// encoder's device - emptied on encoder teardown (Restart/Exit) and on a capture
-	// resolution change.
 	struct FCachedVideoResource
 	{
 		FTextureRHIRef Texture;


### PR DESCRIPTION
This PR reduces per-frame work in the session replay encoder by caching the resource wrapper used to submit each captured texture to the hardware encoder.

The capture pipeline recycles a small fixed pool of GPU textures and hands them to the encoder thread each frame. To submit a texture it must be wrapped in an `FVideoResourceRHI`, which registers the texture with the AVCodecs device. The encoder built a brand-new wrapper on every `SendFrame`, re-running that registration each frame even though only the same handful of pooled textures cycle through.

### Key changes

- Cache one `FVideoResourceRHI` per input texture (`AcquireVideoResource`) and reuse it, so the AVCodecs mapping/registration is done once per texture instead of once per frame. Encoded output is unchanged.
- The cache is keyed by the texture pointer, with the value holding an `FTextureRHIRef` that pins the texture alive so its address cannot be recycled by a different texture while cached.
- Access is confined to the encoder thread (`AcquireVideoResource`, `Restart`, `Exit`), so no locking is required.
- The cache is emptied whenever its wrappers could go stale: on encoder teardown (`Restart` / `Exit`), and on a capture size change - detected in `AcquireVideoResource` when a cached entry's size no longer matches the incoming frame (the pool recreates its textures at the new size). Clearing happens once per transition, so a stable size stays fully cached.

### Related Items

- #1509
- #1517
