### PR TITLE
Handle `SENTRY_LEVEL_TRACE` in native log level converters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add `beforeSendFeedback` callback for user feedback filtering ([#1528](https://github.com/getsentry/sentry-unreal/pull/1528))
 
+### Fixes
+
+- Map `SENTRY_LEVEL_TRACE` in the native log-level converters so trace-level logs no longer emit a spurious "Unknown sentry level" warning ([#1534](https://github.com/getsentry/sentry-unreal/pull/1534))
+
 ### Dependencies
 
 - Bump Cocoa SDK from v9.25.0 to v9.26.0 ([#1532](https://github.com/getsentry/sentry-unreal/pull/1532))

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
@@ -275,6 +275,7 @@ ESentryLevel FGenericPlatformSentryConverters::SentryLevelToUnreal(sentry_level_
 
 	switch (level)
 	{
+	case SENTRY_LEVEL_TRACE:
 	case SENTRY_LEVEL_DEBUG:
 		Level = ESentryLevel::Debug;
 		break;
@@ -441,6 +442,9 @@ ELogVerbosity::Type FGenericPlatformSentryConverters::SentryLevelToLogVerbosity(
 
 	switch (level)
 	{
+	case SENTRY_LEVEL_TRACE:
+		LogVerbosity = ELogVerbosity::VeryVerbose;
+		break;
 	case SENTRY_LEVEL_DEBUG:
 		LogVerbosity = ELogVerbosity::Verbose;
 		break;


### PR DESCRIPTION
The native log-level converters (`GenericPlatformSentryConverters`) didn't handle `SENTRY_LEVEL_TRACE`, so a trace-level sentry-native log fell through to the `default` branch and emitted a spurious `"Unknown sentry level value used"` warning:

- `SentryLevelToLogVerbosity` warned and returned `Error`
- `SentryLevelToUnreal(sentry_level_t)` warned and returned `Debug`

This maps the level correctly instead:

- `SentryLevelToLogVerbosity`: `SENTRY_LEVEL_TRACE` → `ELogVerbosity::VeryVerbose`
- `SentryLevelToUnreal`: `SENTRY_LEVEL_TRACE` folds into `Debug` (`ESentryLevel` has no `Trace` value)