### PR TITLE
Release discarded value in native before* callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Map `SENTRY_LEVEL_TRACE` in the native log-level converters so trace-level logs no longer emit a spurious "Unknown sentry level" warning ([#1534](https://github.com/getsentry/sentry-unreal/pull/1534))
+- Release discarded value in native before* callbacks ([#1536](https://github.com/getsentry/sentry-unreal/pull/1536))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -205,7 +205,13 @@ sentry_value_t FGenericPlatformSentrySubsystem::OnBeforeSend(sentry_value_t even
 
 	USentryEvent* ProcessedEvent = Handler->HandleBeforeSend(EventToProcess, nullptr);
 
-	return ProcessedEvent ? event : sentry_value_new_null();
+	if (!ProcessedEvent)
+	{
+		sentry_value_decref(event);
+		return sentry_value_new_null();
+	}
+
+	return event;
 }
 
 sentry_value_t FGenericPlatformSentrySubsystem::OnBeforeSendFeedback(sentry_value_t event, sentry_hint_t* hint, void* closure)
@@ -280,7 +286,13 @@ sentry_value_t FGenericPlatformSentrySubsystem::OnBeforeBreadcrumb(sentry_value_
 
 	USentryBreadcrumb* ProcessedBreadcrumb = Handler->HandleBeforeBreadcrumb(BreadcrumbToProcess, nullptr);
 
-	return ProcessedBreadcrumb ? breadcrumb : sentry_value_new_null();
+	if (!ProcessedBreadcrumb)
+	{
+		sentry_value_decref(breadcrumb);
+		return sentry_value_new_null();
+	}
+
+	return breadcrumb;
 }
 
 sentry_value_t FGenericPlatformSentrySubsystem::OnBeforeLog(sentry_value_t log, void* closure)
@@ -318,7 +330,13 @@ sentry_value_t FGenericPlatformSentrySubsystem::OnBeforeLog(sentry_value_t log, 
 
 	USentryLog* ProcessedLogData = Handler->HandleBeforeLog(LogData);
 
-	return ProcessedLogData ? log : sentry_value_new_null();
+	if (!ProcessedLogData)
+	{
+		sentry_value_decref(log);
+		return sentry_value_new_null();
+	}
+
+	return log;
 }
 
 sentry_value_t FGenericPlatformSentrySubsystem::OnBeforeMetric(sentry_value_t metric, void* closure)
@@ -356,7 +374,13 @@ sentry_value_t FGenericPlatformSentrySubsystem::OnBeforeMetric(sentry_value_t me
 
 	USentryMetric* ProcessedMetricData = Handler->HandleBeforeMetric(MetricData);
 
-	return ProcessedMetricData ? metric : sentry_value_new_null();
+	if (!ProcessedMetricData)
+	{
+		sentry_value_decref(metric);
+		return sentry_value_new_null();
+	}
+
+	return metric;
 }
 
 sentry_value_t FGenericPlatformSentrySubsystem::OnCrash(const sentry_ucontext_t* uctx, sentry_value_t event, void* closure)


### PR DESCRIPTION
This PR fixes a memory leak in the `sentry-native` `before*` callback handlers.

On `sentry-native` platforms, `before_send`, `before_breadcrumb`, `before_log`, and `before_metric` returned `sentry_value_new_null()` without releasing the incoming `sentry_value_t` when a handler drops an item. The SDK core transfers ownership to the callback and does not free the value on a null return, so each dropped item leaked one native value.

The fix is to decref before returning null in the four handlers, matching the already-correct `OnBeforeSendFeedback` (#1528). The wrappers never decref, so this is the only release on the drop path (no double-free).

Only affects `sentry-native` backends, only when a handler returns `null` to discard.

Closes #1529
