### PR TITLE
Fix Android structured log level conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Map `SENTRY_LEVEL_TRACE` in the native log-level converters so trace-level logs no longer emit a spurious "Unknown sentry level" warning ([#1534](https://github.com/getsentry/sentry-unreal/pull/1534))
+- Fix Android structured log levels being mapped to the wrong severity ([#1537](https://github.com/getsentry/sentry-unreal/pull/1537))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/Infrastructure/AndroidSentryConverters.cpp
@@ -193,7 +193,7 @@ TSharedPtr<FSentryJavaObjectWrapper> FAndroidSentryConverters::SentryLogLevelToN
 
 	jfieldID debugEnumFieldField = Env->GetStaticFieldID(levelEnumClass, "DEBUG", "Lio/sentry/SentryLogLevel;");
 	jfieldID infoEnumFieldField = Env->GetStaticFieldID(levelEnumClass, "INFO", "Lio/sentry/SentryLogLevel;");
-	jfieldID warningEnumFieldField = Env->GetStaticFieldID(levelEnumClass, "WARNING", "Lio/sentry/SentryLogLevel;");
+	jfieldID warningEnumFieldField = Env->GetStaticFieldID(levelEnumClass, "WARN", "Lio/sentry/SentryLogLevel;");
 	jfieldID errorEnumFieldField = Env->GetStaticFieldID(levelEnumClass, "ERROR", "Lio/sentry/SentryLogLevel;");
 	jfieldID fatalEnumFieldField = Env->GetStaticFieldID(levelEnumClass, "FATAL", "Lio/sentry/SentryLogLevel;");
 
@@ -231,21 +231,23 @@ ESentryLevel FAndroidSentryConverters::SentryLogLevelToUnreal(jobject level)
 
 	int levelValue = NativeLevel.CallMethod<int>(OrdinalMethod);
 
+	// See SentryLogLevel.java for the ordinal mapping
 	switch (levelValue)
 	{
 	case 0:
+	case 1:
 		unrealLevel = ESentryLevel::Debug;
 		break;
-	case 1:
+	case 2:
 		unrealLevel = ESentryLevel::Info;
 		break;
-	case 2:
+	case 3:
 		unrealLevel = ESentryLevel::Warning;
 		break;
-	case 3:
+	case 4:
 		unrealLevel = ESentryLevel::Error;
 		break;
-	case 4:
+	case 5:
 		unrealLevel = ESentryLevel::Fatal;
 		break;
 	default:


### PR DESCRIPTION
The Android structured-log level converters were written against the *event* `SentryLevel` enum shape (`DEBUG, INFO, WARNING, ERROR, FATAL`), but the structured-log enum [`SentryLogLevel`](https://github.com/getsentry/sentry-java/blob/8.52.0/sentry/src/main/java/io/sentry/SentryLogLevel.java#L9-L14) is different: `TRACE, DEBUG, INFO, WARN, ERROR, FATAL`. This broke both conversion directions.

**Read - `SentryLogLevelToUnreal`** reads `ordinal()` and mapped `0→Debug, 1→Info, 2→Warning, 3→Error, 4→Fatal`. Because `TRACE` occupies ordinal 0, `DEBUG`, `INFO`, `WARN` and `ERROR` each mapped one level too severe, and `FATAL` (ordinal 5) fell through to the `default` and was reported as `Debug`. (`TRACE`→`Debug` happened to be correct as that's the intended fold.)

| `SentryLogLevel` | ordinal | before | after |
|---|---|---|---|
| TRACE | 0 | Debug | Debug |
| DEBUG | 1 | Info | Debug |
| INFO | 2 | Warning | Info |
| WARN | 3 | Error | Warning |
| ERROR | 4 | Fatal | Error |
| FATAL | 5 | Debug (default) | Fatal |

**Write - `SentryLogLevelToNative`** looked up the static field `"WARNING"`, but `SentryLogLevel` defines `WARN`. `GetStaticFieldID` returned null for `ESentryLevel::Warning`, so warning-level structured logs were written with a null level object.

Fixes both directions; `TRACE` folds into `Debug` since `ESentryLevel` has no `Trace` (matching the native and Apple converters). Introducing `ESentryLevel::Trace` is intentionally left for a separate PR.
