### PR TITLE
Deprecate `EnableStructuredLogging` and `EnableMetrics` settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 ## Unreleased
 
+> [!IMPORTANT]
+> Structured logging and metrics are now always enabled, having been on by default since `1.11.0`. The corresponding `EnableStructuredLogging` and `EnableMetrics` settings are deprecated and no longer have any effect.
+>
+> We recognize that this change may inconvenience applications that relied on the opt-out. Use a `BeforeLogHandler` or `BeforeMetricHandler` to filter logs or metrics before they are sent. We made this tradeoff deliberately because consistent behavior across SDK integrations will help most users successfully adopt these features.
+
+### Behavioral Changes
+
+- Structured logging and metrics are now always enabled
+
 ### Features
 
 - Add `beforeSendFeedback` callback for user feedback filtering ([#1528](https://github.com/getsentry/sentry-unreal/pull/1528))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 
 ### Behavioral Changes
 
-- Structured logging and metrics are now always enabled
+- Structured logging and metrics are now always enabled ([#1538](https://github.com/getsentry/sentry-unreal/pull/1538))
 
 ### Features
 

--- a/integration-test/Integration.Android.Tests.ps1
+++ b/integration-test/Integration.Android.Tests.ps1
@@ -184,7 +184,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
         # ==========================================
 
         Write-Host "Running log-capture test on $Platform..." -ForegroundColor Yellow
-        $logIntentArgs = "-e cmdline -log-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableStructuredLogging=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeLogHandler=/Script/SentryPlayground.CppBeforeLogHandler"
+        $logIntentArgs = "-e cmdline -log-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeLogHandler=/Script/SentryPlayground.CppBeforeLogHandler"
         $global:AndroidLogResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $logIntentArgs
 
         Write-Host "Log test exit code: $($global:AndroidLogResult.ExitCode)" -ForegroundColor Cyan
@@ -194,7 +194,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
         # ==========================================
 
         Write-Host "Running metric-capture test on $Platform..." -ForegroundColor Yellow
-        $metricIntentArgs = "-e cmdline -metric-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableMetrics=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeMetricHandler=/Script/SentryPlayground.CppBeforeMetricHandler"
+        $metricIntentArgs = "-e cmdline -metric-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeMetricHandler=/Script/SentryPlayground.CppBeforeMetricHandler"
         $global:AndroidMetricResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $metricIntentArgs
 
         Write-Host "Metric test exit code: $($global:AndroidMetricResult.ExitCode)" -ForegroundColor Cyan

--- a/integration-test/Integration.Desktop.Tests.ps1
+++ b/integration-test/Integration.Desktop.Tests.ps1
@@ -922,7 +922,6 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             # Override default project settings to avoid double initialization
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
-            $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:EnableStructuredLogging=True"
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:BeforeLogHandler=/Script/SentryPlayground.CppBeforeLogHandler"
 
             # -log-capture triggers integration test log scenario in the sample app
@@ -1024,7 +1023,6 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             # Override default project settings
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
-            $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:EnableMetrics=True"
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:BeforeMetricHandler=/Script/SentryPlayground.CppBeforeMetricHandler"
 
             # -metric-capture triggers integration test metric scenario in the sample app

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -84,8 +84,8 @@ void FAndroidSentrySubsystem::InitWithSettings(const USentrySettings* settings, 
 	SettingsJson->SetBoolField(TEXT("enableTombstone"),
 		settings->AndroidCrashBackend == ESentryAndroidCrashBackend::TombstoneOnly || settings->AndroidCrashBackend == ESentryAndroidCrashBackend::TombstoneMergedWithNdk);
 	SettingsJson->SetBoolField(TEXT("enableAutoLogAttachment"), settings->EnableAutoLogAttachment);
-	SettingsJson->SetBoolField(TEXT("enableStructuredLogging"), settings->EnableStructuredLogging);
-	SettingsJson->SetBoolField(TEXT("enableMetrics"), settings->EnableMetrics);
+	SettingsJson->SetBoolField(TEXT("enableStructuredLogging"), true);
+	SettingsJson->SetBoolField(TEXT("enableMetrics"), true);
 	SettingsJson->SetStringField(TEXT("deviceType"), GetDeviceType());
 	if (settings->EnableOfflineCaching)
 	{

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -97,8 +97,8 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 			options.maxBreadcrumbs = settings->MaxBreadcrumbs;
 			options.sendDefaultPii = settings->SendDefaultPii;
 			options.maxAttachmentSize = settings->MaxAttachmentSize;
-			options.enableLogs = settings->EnableStructuredLogging;
-			options.enableMetrics = settings->EnableMetrics;
+			options.enableLogs = YES;
+			options.enableMetrics = YES;
 #if SENTRY_OBJC_UIKIT_AVAILABLE
 			options.attachScreenshot = settings->AttachScreenshot;
 #endif

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -664,8 +664,8 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 	sentry_options_set_shutdown_timeout(options, settings->ShutdownTimeout);
 	sentry_options_set_crashpad_wait_for_upload(options, settings->CrashpadWaitForUpload);
 	sentry_options_set_logger_enabled_when_crashed(options, settings->EnableOnCrashLogging);
-	sentry_options_set_enable_logs(options, settings->EnableStructuredLogging);
-	sentry_options_set_enable_metrics(options, settings->EnableMetrics);
+	sentry_options_set_enable_logs(options, true);
+	sentry_options_set_enable_metrics(options, true);
 	sentry_options_set_before_send_metric(options, HandleBeforeMetric, this);
 	sentry_options_set_http_retry(options, 1);
 	sentry_options_set_enable_large_attachments(options, settings->EnableLargeAttachments);

--- a/plugin-dev/Source/Sentry/Private/SentryOutputDevice.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentryOutputDevice.cpp
@@ -28,7 +28,6 @@ FSentryOutputDevice::FSentryOutputDevice()
 	StructuredLoggingFlags.Add(ESentryLevel::Info, Settings->StructuredLoggingLevels.bOnInfoLog);
 	StructuredLoggingFlags.Add(ESentryLevel::Debug, Settings->StructuredLoggingLevels.bOnDebugLog);
 
-	bIsStructuredLoggingEnabled = Settings->EnableStructuredLogging;
 	StructuredLoggingCategories = Settings->StructuredLoggingCategories;
 	bSendBreadcrumbsWithStructuredLogging = Settings->bSendBreadcrumbsWithStructuredLogging;
 }
@@ -63,7 +62,7 @@ void FSentryOutputDevice::Serialize(const TCHAR* V, ELogVerbosity::Type Verbosit
 	ESentryLevel Level = SentryLogUtils::ConvertLogVerbosityToSentryLevel(Verbosity);
 	const FString CategoryString = Category.ToString();
 
-	if (bIsStructuredLoggingEnabled && ShouldForwardToStructuredLogging(CategoryString, Level))
+	if (ShouldForwardToStructuredLogging(CategoryString, Level))
 	{
 		// Use level-specific logging methods
 		switch (Level)

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -179,10 +179,7 @@ void USentrySubsystem::Initialize()
 		ConfigureHangTracking();
 	}
 
-	if (Settings->EnableMetrics)
-	{
-		ConfigurePerformanceMetrics();
-	}
+	ConfigurePerformanceMetrics();
 }
 
 void USentrySubsystem::InitializeWithSettings(const FConfigureSettingsDelegate& OnConfigureSettings)

--- a/plugin-dev/Source/Sentry/Public/SentryOutputDevice.h
+++ b/plugin-dev/Source/Sentry/Public/SentryOutputDevice.h
@@ -27,7 +27,6 @@ private:
 	TMap<ESentryLevel, bool> BreadcrumbFlags;
 	TMap<ESentryLevel, bool> StructuredLoggingFlags;
 
-	bool bIsStructuredLoggingEnabled;
 	TArray<FString> StructuredLoggingCategories;
 	bool bSendBreadcrumbsWithStructuredLogging;
 

--- a/plugin-dev/Source/Sentry/Public/SentrySettings.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySettings.h
@@ -393,59 +393,53 @@ class SENTRY_API USentrySettings : public UObject
 		Meta = (DisplayName = "Enable large attachments (for desktop and consoles only)", ToolTip = "When enabled, attachments above an internal size threshold are uploaded out-of-band via a separate request. When disabled, oversized attachments are rejected by Sentry. Currently supported on Windows, Linux, Mac (with native backend) and consoles."))
 	bool EnableLargeAttachments;
 
-	UPROPERTY(Config, EditAnywhere, Category = "General|Structured Logging",
-		Meta = (DisplayName = "Enable structured logging", ToolTip = "Flag indicating whether to enable structured logging that forwards UE_LOG calls to Sentry logger."))
+	UPROPERTY(Config, Meta = (DeprecatedProperty, DeprecationMessage = "Structured logging is now always enabled. This setting no longer has any effect and will be removed in the future."))
 	bool EnableStructuredLogging;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "General|Structured Logging",
-		Meta = (DisplayName = "Structured logging categories", ToolTip = "List of UE_LOG categories to forward to Sentry structured logging. Leave empty to forward all.", EditCondition = "EnableStructuredLogging"))
+		Meta = (DisplayName = "Structured logging categories", ToolTip = "List of UE_LOG categories to forward to Sentry structured logging. Leave empty to forward all."))
 	TArray<FString> StructuredLoggingCategories;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "General|Structured Logging",
-		Meta = (DisplayName = "Forward log messages with verbosity level", EditCondition = "EnableStructuredLogging"))
+		Meta = (DisplayName = "Forward log messages with verbosity level"))
 	FStructuredLoggingLevels StructuredLoggingLevels;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Structured Logging",
-		Meta = (DisplayName = "Also send breadcrumbs", ToolTip = "Whether to also send breadcrumbs when structured logging is enabled.", EditCondition = "EnableStructuredLogging"))
+		Meta = (DisplayName = "Also send breadcrumbs", ToolTip = "Whether to also send breadcrumbs when structured logging is enabled."))
 	bool bSendBreadcrumbsWithStructuredLogging;
 
-	UPROPERTY(Config, EditAnywhere, Category = "General|Metrics",
-		Meta = (DisplayName = "Enable metrics", ToolTip = "Flag indicating whether to enable the Sentry metrics API for tracking counters, distributions, and gauges."))
+	UPROPERTY(Config, Meta = (DeprecatedProperty, DeprecationMessage = "The Sentry metrics API is now always enabled. This setting no longer has any effect and will be removed in the future."))
 	bool EnableMetrics;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Metrics|Performance",
-		Meta = (DisplayName = "Collect frame time metrics", ToolTip = "Automatically collect frame time and per-thread performance metrics (frame duration, game thread, render thread, GPU, FPS). Requires metrics to be enabled.",
-			EditCondition = "EnableMetrics"))
+		Meta = (DisplayName = "Collect frame time metrics", ToolTip = "Automatically collect frame time and per-thread performance metrics (frame duration, game thread, render thread, GPU, FPS)."))
 	bool EnableAutoFrameTimeMetrics;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Metrics|Performance",
 		Meta = (DisplayName = "Frame time sample interval (seconds)", ToolTip = "How often to sample frame time metrics (frame time, thread times, GPU time, FPS). Default: 1 second.",
-			EditCondition = "EnableAutoFrameTimeMetrics && EnableMetrics", ClampMin = 0.05))
+			EditCondition = "EnableAutoFrameTimeMetrics", ClampMin = 0.05))
 	float FrameTimeSampleInterval;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Metrics|Performance",
-		Meta = (DisplayName = "Collect game stats metrics", ToolTip = "Periodically collect game stats (e.g., process memory usage, active UObject count). Requires metrics to be enabled.",
-			EditCondition = "EnableMetrics"))
+		Meta = (DisplayName = "Collect game stats metrics", ToolTip = "Periodically collect game stats (e.g., process memory usage, active UObject count)."))
 	bool EnableAutoGameStatsMetrics;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Metrics|Performance",
 		Meta = (DisplayName = "Game stats sample interval (seconds)", ToolTip = "How often to sample game stats metrics (memory, UObject count). Default: 60 seconds.",
-			EditCondition = "EnableAutoGameStatsMetrics && EnableMetrics", ClampMin = 1))
+			EditCondition = "EnableAutoGameStatsMetrics", ClampMin = 1))
 	int32 GameStatsSampleInterval;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Metrics|Performance",
-		Meta = (DisplayName = "Collect GC pause metrics (UE 5.5+)", ToolTip = "Emit a metric for each garbage collection pause duration. GC pauses are a common source of hitches in Unreal Engine games. Requires Unreal Engine 5.5 or later.",
-			EditCondition = "EnableMetrics"))
+		Meta = (DisplayName = "Collect GC pause metrics (UE 5.5+)", ToolTip = "Emit a metric for each garbage collection pause duration. GC pauses are a common source of hitches in Unreal Engine games. Requires Unreal Engine 5.5 or later."))
 	bool EnableAutoGCMetrics;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Metrics|Performance",
-		Meta = (DisplayName = "Collect network metrics (UE 5.7+)", ToolTip = "Emit network performance metrics (ping, bandwidth, packet loss, jitter) during active multiplayer sessions. Only active when a network driver is present. Requires Unreal Engine 5.7 or later.",
-			EditCondition = "EnableMetrics"))
+		Meta = (DisplayName = "Collect network metrics (UE 5.7+)", ToolTip = "Emit network performance metrics (ping, bandwidth, packet loss, jitter) during active multiplayer sessions. Only active when a network driver is present. Requires Unreal Engine 5.7 or later."))
 	bool EnableAutoNetworkMetrics;
 
 	UPROPERTY(Config, EditAnywhere, Category = "General|Metrics|Performance",
 		Meta = (DisplayName = "Network metrics sample interval (seconds)", ToolTip = "How often to sample network metrics. Default: 10 seconds.",
-			EditCondition = "EnableAutoNetworkMetrics && EnableMetrics", ClampMin = 1))
+			EditCondition = "EnableAutoNetworkMetrics", ClampMin = 1))
 	int32 NetworkMetricsSampleInterval;
 
 	UPROPERTY(Config, EditAnywhere, BlueprintReadWrite, Category = "General|Breadcrumbs",


### PR DESCRIPTION
This PR deprecates the `EnableStructuredLogging` and `EnableMetrics` plugin settings and makes both features enabled unconditionally.

Structured logging and metrics have been on by default since `1.11.0`. This removes the opt-out so behavior is consistent across all platforms and SDK integrations. Applications that want to filter logs or metrics can still do so via `BeforeLogHandler` / `BeforeMetricHandler`.

### Changes

- Force structured logging and metrics on at every platform init site (`GenericPlatform`, `Apple`, `Android`, `SentrySubsystem`, `SentryOutputDevice`)
- Mark `EnableStructuredLogging` / `EnableMetrics` deprecated: hidden from the settings UI (`DeprecatedProperty` meta), still parsed from existing `.ini` files, values ignored
- Drop the now-meaningless `EnableStructuredLogging` / `EnableMetrics` `EditCondition`s from the dependent structured-logging and metrics sub-settings
- Remove the dead `bIsStructuredLoggingEnabled` flag from `FSentryOutputDevice`
- Remove the redundant `EnableStructuredLogging=True` / `EnableMetrics=True` `-ini` overrides from the desktop and Android integration tests

### Documentation

- https://github.com/getsentry/sentry-docs/pull/19044

### Related items

- https://github.com/getsentry/sentry-native/pull/1980