### PR TITLE
ref(native): adapt to breaking API changes

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.cpp
@@ -5,12 +5,12 @@
 #if USE_SENTRY_NATIVE
 
 FGenericPlatformSentryAttachment::FGenericPlatformSentryAttachment(const TArray<uint8>& data, const FString& filename, const FString& contentType)
-	: Data(data), Filename(filename), ContentType(contentType), Attachment(nullptr)
+	: Data(data), Filename(filename), ContentType(contentType), Uuid(sentry_uuid_nil())
 {
 }
 
 FGenericPlatformSentryAttachment::FGenericPlatformSentryAttachment(const FString& path, const FString& filename, const FString& contentType)
-	: Path(path), Filename(filename), ContentType(contentType), Attachment(nullptr)
+	: Path(path), Filename(filename), ContentType(contentType), Uuid(sentry_uuid_nil())
 {
 }
 
@@ -19,14 +19,14 @@ FGenericPlatformSentryAttachment::~FGenericPlatformSentryAttachment()
 	// Put custom destructor logic here if needed
 }
 
-void FGenericPlatformSentryAttachment::SetNativeObject(sentry_attachment_t* attachment)
+void FGenericPlatformSentryAttachment::SetUuid(sentry_uuid_t uuid)
 {
-	Attachment = attachment;
+	Uuid = uuid;
 }
 
-sentry_attachment_t* FGenericPlatformSentryAttachment::GetNativeObject()
+sentry_uuid_t FGenericPlatformSentryAttachment::GetUuid()
 {
-	return Attachment;
+	return Uuid;
 }
 
 TArray<uint8> FGenericPlatformSentryAttachment::GetData() const

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryAttachment.h
@@ -15,8 +15,8 @@ public:
 	FGenericPlatformSentryAttachment(const FString& path, const FString& filename, const FString& contentType);
 	virtual ~FGenericPlatformSentryAttachment() override;
 
-	void SetNativeObject(sentry_attachment_t* attachment);
-	sentry_attachment_t* GetNativeObject();
+	void SetUuid(sentry_uuid_t uuid);
+	sentry_uuid_t GetUuid();
 
 	virtual TArray<uint8> GetData() const override;
 	virtual FString GetPath() const override;
@@ -31,7 +31,7 @@ private:
 	FString Filename;
 	FString ContentType;
 
-	sentry_attachment_t* Attachment;
+	sentry_uuid_t Uuid;
 };
 
 typedef FGenericPlatformSentryAttachment FPlatformSentryAttachment;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryFeedback.cpp
@@ -107,8 +107,8 @@ sentry_hint_t* FGenericPlatformSentryFeedback::GetHintNativeObject()
 
 void FGenericPlatformSentryFeedback::AddFileAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment)
 {
-	sentry_attachment_t* nativeAttachment =
-		sentry_hint_attach_file(Hint, TCHAR_TO_UTF8(*attachment->GetPath()));
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_file(TCHAR_TO_UTF8(*attachment->GetPath()));
 
 	if (!attachment->GetFilename().IsEmpty())
 		sentry_attachment_set_filename(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetFilename()));
@@ -116,20 +116,20 @@ void FGenericPlatformSentryFeedback::AddFileAttachment(TSharedPtr<FGenericPlatfo
 	if (!attachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
 
-	attachment->SetNativeObject(nativeAttachment);
+	attachment->SetUuid(sentry_hint_add_attachment(Hint, nativeAttachment));
 }
 
 void FGenericPlatformSentryFeedback::AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment)
 {
 	const TArray<uint8>& byteBuf = attachment->GetDataByRef();
 
-	sentry_attachment_t* nativeAttachment =
-		sentry_hint_attach_bytes(Hint, reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*attachment->GetFilename()));
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_bytes(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*attachment->GetFilename()));
 
 	if (!attachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
 
-	attachment->SetNativeObject(nativeAttachment);
+	attachment->SetUuid(sentry_hint_add_attachment(Hint, nativeAttachment));
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
@@ -233,8 +233,8 @@ void FGenericPlatformSentryScope::Apply(sentry_scope_t* scope)
 
 void FGenericPlatformSentryScope::AddFileAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
 {
-	sentry_attachment_t* nativeAttachment =
-		sentry_scope_attach_file(scope, TCHAR_TO_UTF8(*attachment->GetPath()));
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_file(TCHAR_TO_UTF8(*attachment->GetPath()));
 
 	if (!attachment->GetFilename().IsEmpty())
 		sentry_attachment_set_filename(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetFilename()));
@@ -242,20 +242,20 @@ void FGenericPlatformSentryScope::AddFileAttachment(TSharedPtr<FGenericPlatformS
 	if (!attachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
 
-	attachment->SetNativeObject(nativeAttachment);
+	attachment->SetUuid(sentry_scope_add_attachment(scope, nativeAttachment));
 }
 
 void FGenericPlatformSentryScope::AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
 {
 	const TArray<uint8>& byteBuf = attachment->GetDataByRef();
 
-	sentry_attachment_t* nativeAttachment =
-		sentry_scope_attach_bytes(scope, reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*attachment->GetFilename()));
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_bytes(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*attachment->GetFilename()));
 
 	if (!attachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
 
-	attachment->SetNativeObject(nativeAttachment);
+	attachment->SetUuid(sentry_scope_add_attachment(scope, nativeAttachment));
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -488,8 +488,8 @@ void FGenericPlatformSentrySubsystem::AddFileAttachment(TSharedPtr<ISentryAttach
 {
 	TSharedPtr<FGenericPlatformSentryAttachment> platformAttachment = StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment);
 
-	sentry_attachment_t* nativeAttachment =
-		sentry_attach_file(TCHAR_TO_UTF8(*platformAttachment->GetPath()));
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_file(TCHAR_TO_UTF8(*platformAttachment->GetPath()));
 
 	if (!platformAttachment->GetFilename().IsEmpty())
 		sentry_attachment_set_filename(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetFilename()));
@@ -497,7 +497,7 @@ void FGenericPlatformSentrySubsystem::AddFileAttachment(TSharedPtr<ISentryAttach
 	if (!platformAttachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetContentType()));
 
-	platformAttachment->SetNativeObject(nativeAttachment);
+	platformAttachment->SetUuid(sentry_add_attachment(nativeAttachment));
 
 	attachments.Add(platformAttachment);
 }
@@ -508,13 +508,13 @@ void FGenericPlatformSentrySubsystem::AddByteAttachment(TSharedPtr<ISentryAttach
 
 	const TArray<uint8>& byteBuf = platformAttachment->GetDataByRef();
 
-	sentry_attachment_t* nativeAttachment =
-		sentry_attach_bytes(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*platformAttachment->GetFilename()));
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_bytes(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), TCHAR_TO_UTF8(*platformAttachment->GetFilename()));
 
 	if (!platformAttachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetContentType()));
 
-	platformAttachment->SetNativeObject(nativeAttachment);
+	platformAttachment->SetUuid(sentry_add_attachment(nativeAttachment));
 
 	attachments.Add(platformAttachment);
 }
@@ -871,14 +871,14 @@ void FGenericPlatformSentrySubsystem::RemoveAttachment(TSharedPtr<ISentryAttachm
 {
 	TSharedPtr<FGenericPlatformSentryAttachment> platformAttachment = StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment);
 
-	sentry_attachment_t* nativeAttachment = platformAttachment->GetNativeObject();
+	sentry_uuid_t uuid = platformAttachment->GetUuid();
 
-	if (!nativeAttachment)
+	if (sentry_uuid_is_nil(&uuid))
 		return;
 
-	sentry_remove_attachment(nativeAttachment);
+	sentry_remove_attachment(uuid);
 
-	platformAttachment->SetNativeObject(nullptr);
+	platformAttachment->SetUuid(sentry_uuid_nil());
 }
 
 void FGenericPlatformSentrySubsystem::ClearAttachments()
@@ -991,10 +991,11 @@ TSharedPtr<ISentryId> FGenericPlatformSentrySubsystem::CaptureEnsure(const FStri
 
 	sentry_scope_t* scope = sentry_local_scope_new();
 
-	sentry_attachment_t* screenshotAttachment =
-		sentry_scope_attach_file(scope, TCHAR_TO_UTF8(*ScreenshotPath));
+	sentry_value_t screenshotAttachment =
+		sentry_attachment_from_file(TCHAR_TO_UTF8(*ScreenshotPath));
 	sentry_attachment_set_filename(screenshotAttachment, "screenshot.png");
 	sentry_attachment_set_content_type(screenshotAttachment, "image/png");
+	sentry_scope_add_attachment(scope, screenshotAttachment);
 
 	sentry_uuid_t id = sentry_scope_capture_event(scope, exceptionEvent);
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -699,9 +699,6 @@ void FGenericPlatformSentrySubsystem::InitWithSettings(const USentrySettings* se
 	UE_LOG(LogSentrySdk, Log, TEXT("Sentry initialization completed with result %d (0 on success)."), initResult);
 
 	isEnabled = initResult == 0 ? true : false;
-
-	sentry_clear_crashed_last_run();
-
 	isStackTraceEnabled = settings->AttachStacktrace;
 	isPiiAttachmentEnabled = settings->SendDefaultPii;
 

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryFeedback.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryFeedback.cpp
@@ -18,8 +18,8 @@ FMicrosoftSentryFeedback::FMicrosoftSentryFeedback(const FString& message)
 
 void FMicrosoftSentryFeedback::AddFileAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment)
 {
-	sentry_attachment_t* nativeAttachment =
-		sentry_hint_attach_filew(Hint, *attachment->GetPath());
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_filew(*attachment->GetPath());
 
 	if (!attachment->GetFilename().IsEmpty())
 		sentry_attachment_set_filenamew(nativeAttachment, *attachment->GetFilename());
@@ -27,20 +27,20 @@ void FMicrosoftSentryFeedback::AddFileAttachment(TSharedPtr<FGenericPlatformSent
 	if (!attachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
 
-	attachment->SetNativeObject(nativeAttachment);
+	attachment->SetUuid(sentry_hint_add_attachment(Hint, nativeAttachment));
 }
 
 void FMicrosoftSentryFeedback::AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment)
 {
 	const TArray<uint8>& byteBuf = attachment->GetDataByRef();
 
-	sentry_attachment_t* nativeAttachment =
-		sentry_hint_attach_bytesw(Hint, reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *attachment->GetFilename());
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_bytesw(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *attachment->GetFilename());
 
 	if (!attachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
 
-	attachment->SetNativeObject(nativeAttachment);
+	attachment->SetUuid(sentry_hint_add_attachment(Hint, nativeAttachment));
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentryScope.cpp
@@ -8,8 +8,8 @@
 
 void FMicrosoftSentryScope::AddFileAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
 {
-	sentry_attachment_t* nativeAttachment =
-		sentry_scope_attach_filew(scope, *attachment->GetPath());
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_filew(*attachment->GetPath());
 
 	if (!attachment->GetFilename().IsEmpty())
 		sentry_attachment_set_filenamew(nativeAttachment, *attachment->GetFilename());
@@ -17,20 +17,20 @@ void FMicrosoftSentryScope::AddFileAttachment(TSharedPtr<FGenericPlatformSentryA
 	if (!attachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
 
-	attachment->SetNativeObject(nativeAttachment);
+	attachment->SetUuid(sentry_scope_add_attachment(scope, nativeAttachment));
 }
 
 void FMicrosoftSentryScope::AddByteAttachment(TSharedPtr<FGenericPlatformSentryAttachment> attachment, sentry_scope_t* scope)
 {
 	const TArray<uint8>& byteBuf = attachment->GetDataByRef();
 
-	sentry_attachment_t* nativeAttachment =
-		sentry_scope_attach_bytesw(scope, reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *attachment->GetFilename());
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_bytesw(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *attachment->GetFilename());
 
 	if (!attachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*attachment->GetContentType()));
 
-	attachment->SetNativeObject(nativeAttachment);
+	attachment->SetUuid(sentry_scope_add_attachment(scope, nativeAttachment));
 }
 
 #endif

--- a/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Microsoft/MicrosoftSentrySubsystem.cpp
@@ -75,8 +75,8 @@ void FMicrosoftSentrySubsystem::AddFileAttachment(TSharedPtr<ISentryAttachment> 
 {
 	TSharedPtr<FGenericPlatformSentryAttachment> platformAttachment = StaticCastSharedPtr<FGenericPlatformSentryAttachment>(attachment);
 
-	sentry_attachment_t* nativeAttachment =
-		sentry_attach_filew(*platformAttachment->GetPath());
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_filew(*platformAttachment->GetPath());
 
 	if (!platformAttachment->GetFilename().IsEmpty())
 		sentry_attachment_set_filenamew(nativeAttachment, *platformAttachment->GetFilename());
@@ -84,7 +84,7 @@ void FMicrosoftSentrySubsystem::AddFileAttachment(TSharedPtr<ISentryAttachment> 
 	if (!platformAttachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetContentType()));
 
-	platformAttachment->SetNativeObject(nativeAttachment);
+	platformAttachment->SetUuid(sentry_add_attachment(nativeAttachment));
 
 	attachments.Add(platformAttachment);
 }
@@ -95,13 +95,13 @@ void FMicrosoftSentrySubsystem::AddByteAttachment(TSharedPtr<ISentryAttachment> 
 
 	const TArray<uint8>& byteBuf = platformAttachment->GetDataByRef();
 
-	sentry_attachment_t* nativeAttachment =
-		sentry_attach_bytesw(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *platformAttachment->GetFilename());
+	sentry_value_t nativeAttachment =
+		sentry_attachment_from_bytesw(reinterpret_cast<const char*>(byteBuf.GetData()), byteBuf.Num(), *platformAttachment->GetFilename());
 
 	if (!platformAttachment->GetContentType().IsEmpty())
 		sentry_attachment_set_content_type(nativeAttachment, TCHAR_TO_UTF8(*platformAttachment->GetContentType()));
 
-	platformAttachment->SetNativeObject(nativeAttachment);
+	platformAttachment->SetUuid(sentry_add_attachment(nativeAttachment));
 
 	attachments.Add(platformAttachment);
 }


### PR DESCRIPTION
Adapt to breaking changes in sentry-native master (upcoming 0.17):
- https://github.com/getsentry/sentry-native/pull/1974
- https://github.com/getsentry/sentry-native/pull/2023
- ~~https://github.com/getsentry/sentry-native/pull/1980~~ (calls already removed)

#skip-changelog (internal)