### PR TITLE
Stop overwriting native-collected device context on consoles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Stop overwriting native-collected device context on consoles ([#1542](https://github.com/getsentry/sentry-unreal/pull/1542))
+
 ### Dependencies
 
 - Bump Android Gradle Plugin from v6.18.0 to v6.19.0 ([#1539](https://github.com/getsentry/sentry-unreal/pull/1539))

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -434,6 +434,12 @@ void FAndroidSentrySubsystem::SetContext(const FString& key, const TMap<FString,
 		*FSentryJavaObjectWrapper::GetJString(key), FAndroidSentryConverters::VariantMapToNative(values)->GetJObject());
 }
 
+void FAndroidSentrySubsystem::UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values)
+{
+	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, "updateContext", "(Ljava/lang/String;Ljava/util/HashMap;)V",
+		*FSentryJavaObjectWrapper::GetJString(key), FAndroidSentryConverters::VariantMapToNative(values)->GetJObject());
+}
+
 void FAndroidSentrySubsystem::SetTag(const FString& key, const FString& value)
 {
 	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, "setTag", "(Ljava/lang/String;Ljava/lang/String;)V",

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
@@ -38,6 +38,7 @@ public:
 	virtual void SetUser(TSharedPtr<ISentryUser> user) override;
 	virtual void RemoveUser() override;
 	virtual void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
+	virtual void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
 	virtual void SetTag(const FString& key, const FString& value) override;
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetAttribute(const FString& key, const FSentryVariant& value) override;

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -212,6 +212,26 @@ public class SentryBridgeJava {
 			}
 		});
 	}
+	public static void updateContext(final String key, final HashMap<String, Object> values) {
+		Sentry.configureScope(new ScopeCallback() {
+			@Override
+			public void run(@NonNull IScope scope) {
+				Object existing = scope.getContexts().get(key);
+				if (existing instanceof Map<?, ?>) {
+					Map<String, Object> merged = new HashMap<>();
+					for (Map.Entry<?, ?> entry : ((Map<?, ?>) existing).entrySet()) {
+						if (entry.getKey() instanceof String) {
+							merged.put((String) entry.getKey(), entry.getValue());
+						}
+					}
+					merged.putAll(values);
+					scope.setContexts(key, merged);
+				} else {
+					scope.setContexts(key, values);
+				}
+			}
+		});
+	}
 
 	public static void setTag(final String key, final String value) {
 		Sentry.configureScope(new ScopeCallback() {

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -592,6 +592,19 @@ void FAppleSentrySubsystem::SetContext(const FString& key, const TMap<FString, F
 	}];
 }
 
+void FAppleSentrySubsystem::UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values)
+{
+	[SENTRY_APPLE_CLASS(SentryObjCSDK) configureScope:^(SentryObjCScope* scope) {
+		NSDictionary* contexts = [scope serialize][@"context"];
+		NSDictionary* existing = [contexts objectForKey:key.GetNSString()];
+
+		NSMutableDictionary* merged = existing ? [existing mutableCopy] : [NSMutableDictionary dictionary];
+		[merged addEntriesFromDictionary:FAppleSentryConverters::VariantMapToNative(values)];
+
+		[scope setContextValue:merged forKey:key.GetNSString()];
+	}];
+}
+
 void FAppleSentrySubsystem::SetTag(const FString& key, const FString& value)
 {
 	[SENTRY_APPLE_CLASS(SentryObjCSDK) configureScope:^(SentryObjCScope* scope) {

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -40,6 +40,7 @@ public:
 	virtual void SetUser(TSharedPtr<ISentryUser> user) override;
 	virtual void RemoveUser() override;
 	virtual void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
+	virtual void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
 	virtual void SetTag(const FString& key, const FString& value) override;
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetAttribute(const FString& key, const FSentryVariant& value) override;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.cpp
@@ -99,6 +99,27 @@ void FGenericPlatformSentryCrashReporter::SetContext(const FString& key, const T
 	UpdateCrashReporterConfig();
 }
 
+void FGenericPlatformSentryCrashReporter::UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values)
+{
+	TSharedPtr<FJsonObject> contextConfig = crashReporterConfig->HasField(TEXT("contexts"))
+												? crashReporterConfig->GetObjectField(TEXT("contexts"))
+												: MakeShareable(new FJsonObject);
+
+	TSharedPtr<FJsonObject> valuesConfig = contextConfig->HasField(key)
+											   ? contextConfig->GetObjectField(key)
+											   : MakeShareable(new FJsonObject);
+
+	for (auto it = values.CreateConstIterator(); it; ++it)
+	{
+		valuesConfig->SetField(it.Key(), FGenericPlatformSentryConverters::VariantToJsonValue(it.Value()));
+	}
+
+	contextConfig->SetObjectField(key, valuesConfig);
+	crashReporterConfig->SetObjectField(TEXT("contexts"), contextConfig);
+
+	UpdateCrashReporterConfig();
+}
+
 void FGenericPlatformSentryCrashReporter::SetTag(const FString& key, const FString& value)
 {
 	TSharedPtr<FJsonObject> tagsConfig;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.h
@@ -21,6 +21,7 @@ public:
 	void SetUser(TSharedPtr<FGenericPlatformSentryUser> user);
 	void RemoveUser();
 	void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values);
+	void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values);
 	void SetTag(const FString& key, const FString& value);
 	void RemoveTag(const FString& key);
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -1088,6 +1088,16 @@ void FGenericPlatformSentrySubsystem::SetContext(const FString& key, const TMap<
 	}
 }
 
+void FGenericPlatformSentrySubsystem::UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values)
+{
+	sentry_update_context(TCHAR_TO_UTF8(*key), FGenericPlatformSentryConverters::VariantMapToNative(values));
+
+	if (crashReporter)
+	{
+		crashReporter->SetContext(key, values);
+	}
+}
+
 void FGenericPlatformSentrySubsystem::SetTag(const FString& key, const FString& value)
 {
 	sentry_set_tag(TCHAR_TO_UTF8(*key), TCHAR_TO_UTF8(*value));

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -1094,7 +1094,7 @@ void FGenericPlatformSentrySubsystem::UpdateContext(const FString& key, const TM
 
 	if (crashReporter)
 	{
-		crashReporter->SetContext(key, values);
+		crashReporter->UpdateContext(key, values);
 	}
 }
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -51,6 +51,7 @@ public:
 	virtual void SetUser(TSharedPtr<ISentryUser> user) override;
 	virtual void RemoveUser() override;
 	virtual void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
+	virtual void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
 	virtual void SetTag(const FString& key, const FString& value) override;
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetAttribute(const FString& key, const FSentryVariant& value) override;

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
@@ -55,6 +55,7 @@ public:
 	virtual void SetUser(TSharedPtr<ISentryUser> user) = 0;
 	virtual void RemoveUser() = 0;
 	virtual void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values) = 0;
+	virtual void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values) = 0;
 	virtual void SetTag(const FString& key, const FString& value) = 0;
 	virtual void RemoveTag(const FString& key) = 0;
 	virtual void SetAttribute(const FString& key, const FSentryVariant& value) = 0;

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentrySubsystem.h
@@ -34,6 +34,7 @@ public:
 	virtual void SetUser(TSharedPtr<ISentryUser> user) override {}
 	virtual void RemoveUser() override {}
 	virtual void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values) override {}
+	virtual void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values) override {}
 	virtual void SetTag(const FString& key, const FString& value) override {}
 	virtual void RemoveTag(const FString& key) override {}
 	virtual void SetAttribute(const FString& key, const FSentryVariant& value) override {}

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -994,7 +994,7 @@ void USentrySubsystem::AddDeviceContext()
 	DeviceContext.Add(TEXT("number_of_cores_including_hyperthreads"), FString::FromInt(FPlatformMisc::NumberOfCoresIncludingHyperthreads()));
 	DeviceContext.Add(TEXT("physical_memory_size_gb"), FString::FromInt(MemoryConstants.TotalPhysicalGB));
 
-	SubsystemNativeImpl->SetContext(TEXT("device"), DeviceContext);
+	SubsystemNativeImpl->UpdateContext(TEXT("device"), DeviceContext);
 }
 
 void USentrySubsystem::PromoteTags()


### PR DESCRIPTION
This PR fixes device context data loss on platforms where the native SDK (or its console extensions) pre-populates the `device` context on the scope at init.

`AddDeviceContext` previously used `SetContext`, which fully replaces the context object under a key. On the game consoles (PS5, Xbox, Switch), whose extension layers seed `device` with `model`/`family`/`manufacturer`/`arch` during init, this overwrote the SDK-collected fields with the plugin's generic subset, losing the console device identity.

A new internal `UpdateContext` API merges the provided values into the existing context (new values take precedence) instead of replacing it, so both the SDK-collected fields and the Unreal-specific ones survive.

## Key Changes

- Add `UpdateContext` to the subsystem interface with per-platform implementations:
  - **Native / consoles**: `sentry_update_context` (the sentry-native merge primitive).
  - **Cocoa**: emulated read-merge-write on the scope (sentry-cocoa has no merge primitive).
  - **Android**: scope-level read-merge-write via a new `SentryBridgeJava.updateContext` (benefits custom user contexts).
  - **Null**: no-op stub.
- Route `AddDeviceContext` through `UpdateContext` so console/desktop device identity is preserved alongside the Unreal-specific fields.

Note: Setting the `device` context is effectively a no-op on Android: sentry-java rebuilds the `device` context per event with richer device info (manufacturer, model, family, arch, chipset, processor count, memory, screen, …) and overwrites the scope value at capture time, while the Unreal-specific `device_type` is merged back in via `beforeSend`. The new `UpdateContext` still applies for custom user contexts on Android.

## Related Items

- getsentry/sentry-native#1835