### PR TITLE
Fix crashes going unreported after first-time DSN setup until editor restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - Stop overwriting native-collected device context on consoles ([#1542](https://github.com/getsentry/sentry-unreal/pull/1542))
+- Fix crashes going unreported after first-time DSN setup until editor restart ([#1545](https://github.com/getsentry/sentry-unreal/pull/1545))
 
 ### Dependencies
 

--- a/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
+++ b/plugin-dev/Source/SentryEditor/Private/SentrySettingsCustomization.cpp
@@ -658,8 +658,6 @@ FString FSentrySettingsCustomization::GetLinuxBinariesDirPath() const
 
 int32 FSentrySettingsCustomization::GetGeneralSettingsStatusAsInt() const
 {
-	USentrySubsystem* SentrySubsystem = GEngine->GetEngineSubsystem<USentrySubsystem>();
-
 	USentrySettings* Settings = FSentryModule::Get().GetSettings();
 
 	if (Settings->Dsn.IsEmpty())
@@ -667,7 +665,7 @@ int32 FSentrySettingsCustomization::GetGeneralSettingsStatusAsInt() const
 		return static_cast<int32>(ESentrySettingsStatus::DsnMissing);
 	}
 
-	if (Settings->IsDirty() && SentrySubsystem->IsEnabled())
+	if (Settings->IsDirty())
 	{
 		return static_cast<int32>(ESentrySettingsStatus::Modified);
 	}


### PR DESCRIPTION
This PR fixes crashes not being reported after setting the DSN for the first time in plugin settings menu until the editor is relaunched and the misleading UX that hid the problem.

`USentrySubsystem` auto-initializes once at editor startup. On a fresh project the DSN is empty so init bails and the crash handler is never installed. Pasting the DSN afterward only marks settings dirty (nothing re-inits) so the settings panel's status check fell through to a green "Configured" because its "Modified" branch required `IsEnabled()`, which was still false. This is the core UX trap: the panel told the user everything was set up while the SDK wasn't running and it hid the `Apply` button that re-inits the SDK live.

Removing the `&& SentrySubsystem->IsEnabled()` operand fixes it - pasting the DSN already sets the dirty flag, so the "settings modified" banner + "Apply" button now appear on first setup. Clicking "Apply" initializes the SDK in-session and the panel no longer reports "Configured" while the crash handler is inactive.