### PR TITLE
Set scope tags in a single call on native platforms

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryScope.cpp
@@ -213,9 +213,9 @@ void FGenericPlatformSentryScope::Apply(sentry_scope_t* scope)
 		sentry_scope_set_fingerprints(scope, FGenericPlatformSentryConverters::StringArrayToNative(Fingerprint));
 	}
 
-	for (const auto& TagItem : Tags)
+	if (Tags.Num() > 0)
 	{
-		sentry_scope_set_tag(scope, TCHAR_TO_UTF8(*TagItem.Key), TCHAR_TO_UTF8(*TagItem.Value));
+		sentry_scope_set_tags(scope, FGenericPlatformSentryConverters::StringMapToNative(Tags));
 	}
 
 	for (const auto& ExtraItem : Extra)


### PR DESCRIPTION
When an event is captured with a scope, the plugin copies that scope's tags over to the native SDK. This PR makes it do so in a single `sentry_scope_set_tags` call instead of one `sentry_scope_set_tag` per entry.

## Related items

- https://github.com/getsentry/sentry-native/pull/1993

#skip-changelog
