### PR TITLE
Fix flaky integration tests on macOS

### DIFF
--- a/.github/workflows/integration-test-macos.yml
+++ b/.github/workflows/integration-test-macos.yml
@@ -63,12 +63,22 @@ jobs:
           cmake -B build -S .
           Invoke-Pester Integration.Desktop.Tests.ps1 -CI
 
+      - name: Collect app logs and crash reports
+        if: ${{ always() && steps.run-integration-tests.outcome == 'failure' }}
+        run: |
+          DEST="$GITHUB_WORKSPACE/integration-test/output/diagnostics"
+          mkdir -p "$DEST/app-logs" "$DEST/crash-reports"
+          # Packaged Mac games log to ~/Library/Logs/<ProjectName> (FPaths::ProjectLogDir -> FMacPlatformProcess::UserLogsDir)
+          cp -R "$HOME/Library/Logs/SentryPlayground/." "$DEST/app-logs/" 2>/dev/null || echo "No app logs found"
+          # macOS records an .ips report for every process terminated by a signal, including the intentional test crashes.
+          # Collect reports for pwsh too: a launch that dies before execve is reported against the parent image, not the app.
+          find "$HOME/Library/Logs/DiagnosticReports" -maxdepth 1 -type f \( -name 'SentryPlayground*' -o -name 'pwsh*' \) -exec cp {} "$DEST/crash-reports/" \; 2>/dev/null || true
+          echo "Collected:"
+          find "$DEST" -type f -exec basename {} \;
+
       - name: Upload integration test output
         if: ${{ always() && steps.run-integration-tests.outcome == 'failure' }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: UE ${{ inputs.unreal-version }} integration test output (macOS, ${{ inputs.backend }})
-          path: |
-            integration-test/output/
-            sample-build/**/Saved/Logs/
-            ~/Library/Application Support/Epic/SentryPlayground/Saved/Logs/
+          path: integration-test/output/

--- a/.github/workflows/integration-test-macos.yml
+++ b/.github/workflows/integration-test-macos.yml
@@ -63,22 +63,12 @@ jobs:
           cmake -B build -S .
           Invoke-Pester Integration.Desktop.Tests.ps1 -CI
 
-      - name: Collect app logs and crash reports
-        if: ${{ always() && steps.run-integration-tests.outcome == 'failure' }}
-        run: |
-          DEST="$GITHUB_WORKSPACE/integration-test/output/diagnostics"
-          mkdir -p "$DEST/app-logs" "$DEST/crash-reports"
-          # Packaged Mac games log to ~/Library/Logs/<ProjectName> (FPaths::ProjectLogDir -> FMacPlatformProcess::UserLogsDir)
-          cp -R "$HOME/Library/Logs/SentryPlayground/." "$DEST/app-logs/" 2>/dev/null || echo "No app logs found"
-          # macOS records an .ips report for every process terminated by a signal, including the intentional test crashes.
-          # Collect reports for pwsh too: a launch that dies before execve is reported against the parent image, not the app.
-          find "$HOME/Library/Logs/DiagnosticReports" -maxdepth 1 -type f \( -name 'SentryPlayground*' -o -name 'pwsh*' \) -exec cp {} "$DEST/crash-reports/" \; 2>/dev/null || true
-          echo "Collected:"
-          find "$DEST" -type f -exec basename {} \;
-
       - name: Upload integration test output
         if: ${{ always() && steps.run-integration-tests.outcome == 'failure' }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
         with:
           name: UE ${{ inputs.unreal-version }} integration test output (macOS, ${{ inputs.backend }})
-          path: integration-test/output/
+          path: |
+            integration-test/output/
+            sample-build/**/Saved/Logs/
+            ~/Library/Application Support/Epic/SentryPlayground/Saved/Logs/

--- a/integration-test/Integration.Desktop.Tests.ps1
+++ b/integration-test/Integration.Desktop.Tests.ps1
@@ -132,6 +132,19 @@ BeforeAll {
         throw "Application not found at: $script:AppPath"
     }
 
+    # Command-line switches shared by every scenario
+    $script:BaseAppArgs = @(
+        '-nullrhi',     # Runs without graphics rendering (headless mode)
+        '-unattended',  # Disables user prompts and interactive dialogs
+        '-stdout',      # Ensures logs are written to stdout on Linux/Unix systems
+        '-nosplash',    # Prevents splash screen and dialogs
+        '-nosound'      # Prevents audio device init (hangs on audio-less CI runners)
+    )
+
+    if ($IsMacOS) {
+        $script:BaseAppArgs += '-llm'
+    }
+
     # Connect to Sentry API
     Write-Host "Connecting to Sentry API..." -ForegroundColor Yellow
     Connect-SentryApi -DSN $script:DSN -ApiToken $script:AuthToken
@@ -169,13 +182,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             Write-Host "Running $crashTypeName crash test..." -ForegroundColor Yellow
 
-            $appArgs = @(
-                '-nullrhi',     # Runs without graphics rendering (headless mode)
-                '-unattended',  # Disables user prompts and interactive dialogs
-                '-stdout',      # Ensures logs are written to stdout on Linux/Unix systems
-                '-nosplash',    # Prevents splash screen and dialogs
-                '-nosound'      # Prevents audio device init (hangs on audio-less CI runners)
-            )
+            $appArgs = @($script:BaseAppArgs)
 
             # Override default project settings
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"               # Prevents double initialization
@@ -295,13 +302,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             Write-Host "Running ensure capture test..." -ForegroundColor Yellow
 
-            $appArgs = @(
-                '-nullrhi',     # Runs without graphics rendering (headless mode)
-                '-unattended',  # Disables user prompts and interactive dialogs
-                '-stdout',      # Ensures logs are written to stdout on Linux/Unix systems
-                '-nosplash',    # Prevents splash screen and dialogs
-                '-nosound'      # Prevents audio device init (hangs on audio-less CI runners)
-            )
+            $appArgs = @($script:BaseAppArgs)
 
             # Override default project settings
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
@@ -402,13 +403,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             Write-Host "Running hang tracking test ($($_.Name))..." -ForegroundColor Yellow
 
-            $appArgs = @(
-                '-nullrhi',     # Runs without graphics rendering (headless mode)
-                '-unattended',  # Disables user prompts and interactive dialogs
-                '-stdout',      # Ensures logs are written to stdout on Linux/Unix systems
-                '-nosplash',    # Prevents splash screen and dialogs
-                '-nosound'      # Prevents audio device init (hangs on audio-less CI runners)
-            )
+            $appArgs = @($script:BaseAppArgs)
 
             # Override default project settings
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
@@ -509,13 +504,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             Write-Host "Running session replay crash test..." -ForegroundColor Yellow
 
-            $appArgs = @(
-                '-nullrhi',     # Runs without graphics rendering (headless mode)
-                '-unattended',  # Disables user prompts and interactive dialogs
-                '-stdout',      # Ensures logs are written to stdout on Linux/Unix systems
-                '-nosplash',    # Prevents splash screen and dialogs
-                '-nosound'      # Prevents audio device init (hangs on audio-less CI runners)
-            )
+            $appArgs = @($script:BaseAppArgs)
 
             # Override default project settings
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
@@ -531,7 +520,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
             # On macOS the cocoa backend builds and sends the replay envelope during the
             # relaunch, which requires AttachSessionReplay to remain enabled.
             if (-not $script:IsNativeBackend) {
-                $flushArgs = @('-init-only', '-nullrhi', '-unattended', '-stdout', '-nosplash')
+                $flushArgs = @('-init-only') + $script:BaseAppArgs
                 $flushArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
                 $flushArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:AttachSessionReplay=True"
                 Invoke-DeviceApp -ExecutablePath $script:AppPath -Arguments ($flushArgs -join ' ')
@@ -652,13 +641,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             Write-Host "Running message capture test..." -ForegroundColor Yellow
 
-            $appArgs = @(
-                '-nullrhi',     # Runs without graphics rendering (headless mode)
-                '-unattended',  # Disables user prompts and interactive dialogs
-                '-stdout',      # Ensures logs are written to stdout on Linux/Unix systems
-                '-nosplash',    # Prevents splash screen and dialogs
-                '-nosound'      # Prevents audio device init (hangs on audio-less CI runners)
-            )
+            $appArgs = @($script:BaseAppArgs)
 
             # Override default project settings to avoid double initialization
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
@@ -827,13 +810,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             Write-Host "Running feedback capture test..." -ForegroundColor Yellow
 
-            $appArgs = @(
-                '-nullrhi',     # Runs without graphics rendering (headless mode)
-                '-unattended',  # Disables user prompts and interactive dialogs
-                '-stdout',      # Ensures logs are written to stdout on Linux/Unix systems
-                '-nosplash',    # Prevents splash screen and dialogs
-                '-nosound'      # Prevents audio device init (hangs on audio-less CI runners)
-            )
+            $appArgs = @($script:BaseAppArgs)
 
             # Override default project settings to avoid double initialization
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
@@ -912,13 +889,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             Write-Host "Running structured logging test..." -ForegroundColor Yellow
 
-            $appArgs = @(
-                '-nullrhi',     # Runs without graphics rendering (headless mode)
-                '-unattended',  # Disables user prompts and interactive dialogs
-                '-stdout',      # Ensures logs are written to stdout on Linux/Unix systems
-                '-nosplash',    # Prevents splash screen and dialogs
-                '-nosound'      # Prevents audio device init (hangs on audio-less CI runners)
-            )
+            $appArgs = @($script:BaseAppArgs)
 
             # Override default project settings to avoid double initialization
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
@@ -1013,13 +984,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             Write-Host "Running metrics capture test..." -ForegroundColor Yellow
 
-            $appArgs = @(
-                '-nullrhi',     # Runs without graphics rendering (headless mode)
-                '-unattended',  # Disables user prompts and interactive dialogs
-                '-stdout',      # Ensures logs are written to stdout on Linux/Unix systems
-                '-nosplash',    # Prevents splash screen and dialogs
-                '-nosound'      # Prevents audio device init (hangs on audio-less CI runners)
-            )
+            $appArgs = @($script:BaseAppArgs)
 
             # Override default project settings
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"
@@ -1162,13 +1127,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             Write-Host "Running tracing capture test..." -ForegroundColor Yellow
 
-            $appArgs = @(
-                '-nullrhi',     # Runs without graphics rendering (headless mode)
-                '-unattended',  # Disables user prompts and interactive dialogs
-                '-stdout',      # Ensures logs are written to stdout on Linux/Unix systems
-                '-nosplash',    # Prevents splash screen and dialogs
-                '-nosound'      # Prevents audio device init (hangs on audio-less CI runners)
-            )
+            $appArgs = @($script:BaseAppArgs)
 
             # Override default project settings
             $appArgs += "-ini:Engine:[/Script/Sentry.SentrySettings]:Dsn=$script:DSN"


### PR DESCRIPTION
On macOS, integration test jobs failed roughly one run in three, always the same way: an app launch died with `exit 139 (SIGSEGV)` having written nothing to `stdout`, so whichever scenario owned that launch failed with a misleading error - `Expected 1 EVENT_CAPTURED line(s) but found 0` or `Cannot bind argument to parameter 'AppOutput' because it is null`. Which scenario got hit was pure chance and thus it looked like a different test failing every time.

Crash reports pulled off the runner show every one of them is the same engine crash with no Sentry frames anywhere:

```
FGenericPlatformMisc::RaiseException
UE::LLMPrivate::FLLMTracker::PopTag(ELLMTagSet)
FLLMScope::DestructInTheOpen()
FMallocBinned3::PushNewPoolToFront(...)
FMallocBinned3::Malloc(...)
operator new(unsigned long)
libc++.1.dylib   std::string::push_back
LaunchServices   ...
```

Unreal's Low Level Memory Tracker starts in a "not yet known" state and only learns whether it is wanted when the game thread reads the command line, early in `FEngineLoop::PreInitPreStartupScreen`. With no `-llm` it disables itself and frees its bookkeeping but on Apple platforms other threads are already running and allocating inside LLM scopes (above, macOS's `LaunchServices` on the main thread). That scope exits, pops its tag against freed state, LLM's internal check fires, and the process dies before it has logged a single line.

Epic's own [comment](https://github.com/EpicGames/UnrealEngine/blob/16d75d84714512edfb744e1fd0a59e9c74d57873/Engine/Source/Runtime/Core/Public/HAL/LowLevelMemTracker.h#L725-L732) in `LowLevelMemTracker.h` flags this hazard for platforms with `PLATFORM_HAS_MULTITHREADED_PREMAIN`, which is 1 on Apple and 0 on Windows/Linux - hence macOS only. It is a race in engine code, so `-llm` is a workaround for CI rather than a fix; the crash lives in the teardown path, and keeping LLM enabled means that path never runs.

### Key Changes

- **`Integration.Desktop.Tests.ps1`** - the five base switches were copy-pasted across 9 scenarios plus the replay flush launch; they are now one shared `$script:BaseAppArgs`, with `-llm` appended on macOS. Windows and Linux are unaffected and don't pay the tracker's overhead.

#skip-changelog