### PR TITLE
Add `SetTags` to Sentry subsystem for updating multiple tags in one go

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add crash upload mode setting for the native backend ([#1547](https://github.com/getsentry/sentry-unreal/pull/1547))
+- Add `SetTags` to Sentry subsystem for updating multiple tags in one go ([#1550](https://github.com/getsentry/sentry-unreal/pull/1550))
 
 ### Fixes
 

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.cpp
@@ -446,6 +446,12 @@ void FAndroidSentrySubsystem::SetTag(const FString& key, const FString& value)
 		*FSentryJavaObjectWrapper::GetJString(key), *FSentryJavaObjectWrapper::GetJString(value));
 }
 
+void FAndroidSentrySubsystem::SetTags(const TMap<FString, FString>& tags)
+{
+	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, "setTags", "(Ljava/util/HashMap;)V",
+		FAndroidSentryConverters::StringMapToNative(tags)->GetJObject());
+}
+
 void FAndroidSentrySubsystem::RemoveTag(const FString& key)
 {
 	FSentryJavaObjectWrapper::CallStaticMethod<void>(SentryJavaClasses::SentryBridgeJava, "removeTag", "(Ljava/lang/String;)V",

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentrySubsystem.h
@@ -40,6 +40,7 @@ public:
 	virtual void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
 	virtual void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
 	virtual void SetTag(const FString& key, const FString& value) override;
+	virtual void SetTags(const TMap<FString, FString>& tags) override;
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetAttribute(const FString& key, const FSentryVariant& value) override;
 	virtual void RemoveAttribute(const FString& key) override;

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -242,6 +242,17 @@ public class SentryBridgeJava {
 		});
 	}
 
+	public static void setTags(final HashMap<String, String> tags) {
+		Sentry.configureScope(new ScopeCallback() {
+			@Override
+			public void run(@NonNull IScope scope) {
+				for (Map.Entry<String, String> tag : tags.entrySet()) {
+					scope.setTag(tag.getKey(), tag.getValue());
+				}
+			}
+		});
+	}
+
 	public static void removeTag(final String key) {
 		Sentry.configureScope(new ScopeCallback() {
 			@Override

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -612,6 +612,16 @@ void FAppleSentrySubsystem::SetTag(const FString& key, const FString& value)
 	}];
 }
 
+void FAppleSentrySubsystem::SetTags(const TMap<FString, FString>& tags)
+{
+	[SENTRY_APPLE_CLASS(SentryObjCSDK) configureScope:^(SentryObjCScope* scope) {
+		for (const auto& tag : tags)
+		{
+			[scope setTagValue:tag.Value.GetNSString() forKey:tag.Key.GetNSString()];
+		}
+	}];
+}
+
 void FAppleSentrySubsystem::RemoveTag(const FString& key)
 {
 	[SENTRY_APPLE_CLASS(SentryObjCSDK) configureScope:^(SentryObjCScope* scope) {

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -42,6 +42,7 @@ public:
 	virtual void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
 	virtual void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
 	virtual void SetTag(const FString& key, const FString& value) override;
+	virtual void SetTags(const TMap<FString, FString>& tags) override;
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetAttribute(const FString& key, const FSentryVariant& value) override;
 	virtual void RemoveAttribute(const FString& key) override;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.cpp
@@ -139,6 +139,22 @@ void FGenericPlatformSentryCrashReporter::SetTag(const FString& key, const FStri
 	UpdateCrashReporterConfig();
 }
 
+void FGenericPlatformSentryCrashReporter::SetTags(const TMap<FString, FString>& tags)
+{
+	TSharedPtr<FJsonObject> tagsConfig = crashReporterConfig->HasField(TEXT("tags"))
+											 ? crashReporterConfig->GetObjectField(TEXT("tags"))
+											 : MakeShareable(new FJsonObject);
+
+	for (auto it = tags.CreateConstIterator(); it; ++it)
+	{
+		tagsConfig->SetStringField(it.Key(), it.Value());
+	}
+
+	crashReporterConfig->SetObjectField(TEXT("tags"), tagsConfig);
+
+	UpdateCrashReporterConfig();
+}
+
 void FGenericPlatformSentryCrashReporter::RemoveTag(const FString& key)
 {
 	TSharedPtr<FJsonObject> tagsConfig;

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/CrashReporter/GenericPlatformSentryCrashReporter.h
@@ -23,6 +23,7 @@ public:
 	void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values);
 	void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values);
 	void SetTag(const FString& key, const FString& value);
+	void SetTags(const TMap<FString, FString>& tags);
 	void RemoveTag(const FString& key);
 
 protected:

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.cpp
@@ -1107,6 +1107,16 @@ void FGenericPlatformSentrySubsystem::SetTag(const FString& key, const FString& 
 	}
 }
 
+void FGenericPlatformSentrySubsystem::SetTags(const TMap<FString, FString>& tags)
+{
+	sentry_set_tags(FGenericPlatformSentryConverters::StringMapToNative(tags));
+
+	if (crashReporter)
+	{
+		crashReporter->SetTags(tags);
+	}
+}
+
 void FGenericPlatformSentrySubsystem::RemoveTag(const FString& key)
 {
 	sentry_remove_tag(TCHAR_TO_UTF8(*key));

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentrySubsystem.h
@@ -53,6 +53,7 @@ public:
 	virtual void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
 	virtual void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values) override;
 	virtual void SetTag(const FString& key, const FString& value) override;
+	virtual void SetTags(const TMap<FString, FString>& tags) override;
 	virtual void RemoveTag(const FString& key) override;
 	virtual void SetAttribute(const FString& key, const FSentryVariant& value) override;
 	virtual void RemoveAttribute(const FString& key) override;

--- a/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentrySubsystemInterface.h
@@ -57,6 +57,7 @@ public:
 	virtual void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values) = 0;
 	virtual void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values) = 0;
 	virtual void SetTag(const FString& key, const FString& value) = 0;
+	virtual void SetTags(const TMap<FString, FString>& tags) = 0;
 	virtual void RemoveTag(const FString& key) = 0;
 	virtual void SetAttribute(const FString& key, const FSentryVariant& value) = 0;
 	virtual void RemoveAttribute(const FString& key) = 0;

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentrySubsystem.h
@@ -36,6 +36,7 @@ public:
 	virtual void SetContext(const FString& key, const TMap<FString, FSentryVariant>& values) override {}
 	virtual void UpdateContext(const FString& key, const TMap<FString, FSentryVariant>& values) override {}
 	virtual void SetTag(const FString& key, const FString& value) override {}
+	virtual void SetTags(const TMap<FString, FString>& tags) override {}
 	virtual void RemoveTag(const FString& key) override {}
 	virtual void SetAttribute(const FString& key, const FSentryVariant& value) override {}
 	virtual void RemoveAttribute(const FString& key) override {}

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -1016,34 +1016,41 @@ void USentrySubsystem::PromoteTags()
 	const USentrySettings* Settings = FSentryModule::Get().GetSettings();
 	check(Settings);
 
+	TMap<FString, FString> PromotedTags;
+
 	if (Settings->TagsPromotion.bPromoteBuildConfiguration)
 	{
-		SubsystemNativeImpl->SetTag(TEXT("Configuration"), LexToString(FApp::GetBuildConfiguration()));
+		PromotedTags.Add(TEXT("Configuration"), LexToString(FApp::GetBuildConfiguration()));
 	}
 
 	if (Settings->TagsPromotion.bPromoteTargetType)
 	{
-		SubsystemNativeImpl->SetTag(TEXT("Target Type"), LexToString(FApp::GetBuildTargetType()));
+		PromotedTags.Add(TEXT("Target Type"), LexToString(FApp::GetBuildTargetType()));
 	}
 
 	if (Settings->TagsPromotion.bPromoteEngineMode)
 	{
-		SubsystemNativeImpl->SetTag(TEXT("Engine Mode"), FGenericPlatformMisc::GetEngineMode());
+		PromotedTags.Add(TEXT("Engine Mode"), FGenericPlatformMisc::GetEngineMode());
 	}
 
 	if (Settings->TagsPromotion.bPromoteIsGame)
 	{
-		SubsystemNativeImpl->SetTag(TEXT("Is game"), LexToString(FApp::IsGame()));
+		PromotedTags.Add(TEXT("Is game"), LexToString(FApp::IsGame()));
 	}
 
 	if (Settings->TagsPromotion.bPromoteIsStandalone)
 	{
-		SubsystemNativeImpl->SetTag(TEXT("Is standalone"), LexToString(FApp::IsStandalone()));
+		PromotedTags.Add(TEXT("Is standalone"), LexToString(FApp::IsStandalone()));
 	}
 
 	if (Settings->TagsPromotion.bPromoteIsUnattended)
 	{
-		SubsystemNativeImpl->SetTag(TEXT("Is unattended"), LexToString(FApp::IsUnattended()));
+		PromotedTags.Add(TEXT("Is unattended"), LexToString(FApp::IsUnattended()));
+	}
+
+	if (PromotedTags.Num() > 0)
+	{
+		SubsystemNativeImpl->SetTags(PromotedTags);
 	}
 }
 

--- a/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/SentrySubsystem.cpp
@@ -653,6 +653,18 @@ void USentrySubsystem::SetTag(const FString& Key, const FString& Value)
 	SubsystemNativeImpl->SetTag(Key, Value);
 }
 
+void USentrySubsystem::SetTags(const TMap<FString, FString>& Tags)
+{
+	check(SubsystemNativeImpl);
+
+	if (!SubsystemNativeImpl || !SubsystemNativeImpl->IsEnabled())
+	{
+		return;
+	}
+
+	SubsystemNativeImpl->SetTags(Tags);
+}
+
 void USentrySubsystem::RemoveTag(const FString& Key)
 {
 	check(SubsystemNativeImpl);

--- a/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Public/SentrySubsystem.h
@@ -398,6 +398,14 @@ public:
 	void SetTag(const FString& Key, const FString& Value);
 
 	/**
+	 * Sets multiple global tags at once. Tags that aren't listed remain unchanged.
+	 *
+	 * @param Tags Tag key/value pairs.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Sentry")
+	void SetTags(const TMap<FString, FString>& Tags);
+
+	/**
 	 * Removes global tag.
 	 *
 	 * @param Key Tag key.


### PR DESCRIPTION
`SentrySubsystem` could only set global tags one key at a time while `SentryScope` and `SentryEvent` both already accept a whole map. This PR adds `SetTags` to close that gap.

Setting tags in bulk was more expensive as each `SetTag` also writes the crash reporter config, and every write re-serializes the entire JSON document (tags, contexts, user and all) so N tags meant N full serializations of a document that grows as tags are added. `SetTags` now collects the keys and serializes once. It also passes the whole map to `sentry_set_tags`, added upstream in [getsentry/sentry-native#1993](https://github.com/getsentry/sentry-native/pull/1993).

Apple and Android have no batch tag setter to call, but both can still set every key inside a single scope callback instead of dispatching one per tag. On Android that also collapses N JNI crossings into one.

`PromoteTags` is converted as the first caller: up to 6 individual calls at startup become one.

Tags that aren't listed remain unchanged, matching `sentry_set_tags` and the existing scope behavior. Consoles inherit the native implementation, so no extension changes are needed.

## Related items

- https://github.com/getsentry/sentry-native/pull/1993
- https://github.com/getsentry/sentry-unreal/pull/1548