### PR TITLE
Fix eventless attachments being uploaded on Mac/iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - Add thread stackwalk mode setting for the native backend ([#1546](https://github.com/getsentry/sentry-unreal/pull/1546))
 
+### Fixes
+
+- Fix eventless attachments being uploaded on Mac/iOS ([#1558](https://github.com/getsentry/sentry-unreal/pull/1558))
+
 ### Dependencies
 
 - Bump Android Gradle Plugin from v6.19.0 to v6.20.0 ([#1553](https://github.com/getsentry/sentry-unreal/pull/1553))

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryId.cpp
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryId.cpp
@@ -31,3 +31,8 @@ FString FAndroidSentryId::ToString() const
 {
 	return CallMethod<FString>(ToStringMethod);
 }
+
+bool FAndroidSentryId::IsValid() const
+{
+	return !CallStaticMethod<bool>(SentryJavaClasses::SentryBridgeJava, "isEmptyId", "(Lio/sentry/protocol/SentryId;)Z", GetJObject());
+}

--- a/plugin-dev/Source/Sentry/Private/Android/AndroidSentryId.h
+++ b/plugin-dev/Source/Sentry/Private/Android/AndroidSentryId.h
@@ -16,6 +16,7 @@ public:
 	void SetupClassMethods();
 
 	virtual FString ToString() const override;
+	virtual bool IsValid() const override;
 
 private:
 	FSentryJavaMethod ToStringMethod;

--- a/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
+++ b/plugin-dev/Source/Sentry/Private/Android/Java/SentryBridgeJava.java
@@ -312,6 +312,10 @@ public class SentryBridgeJava {
 		}
 	}
 
+	public static boolean isEmptyId(final SentryId id) {
+		return id == null || SentryId.EMPTY_ID.equals(id);
+	}
+
 	public static void setContext(final SentryEvent event, final String key, final Object values) {
 		event.getContexts().put(key, values);
 	}

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryId.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryId.cpp
@@ -37,4 +37,16 @@ FString FAppleSentryId::ToString() const
 	return FString(IdApple.sentryIdString);
 }
 
+bool FAppleSentryId::IsValid() const
+{
+	if (IdApple == nil)
+	{
+		return false;
+	}
+
+	SentryObjCId* EmptyId = [SENTRY_APPLE_CLASS(SentryObjCId) empty];
+
+	return ![IdApple.sentryIdString isEqualToString:EmptyId.sentryIdString];
+}
+
 #endif // !USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryId.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryId.h
@@ -19,6 +19,7 @@ public:
 	SentryObjCId* GetNativeObject();
 
 	virtual FString ToString() const override;
+	virtual bool IsValid() const override;
 
 private:
 	SentryObjCId* IdApple;

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -770,6 +770,18 @@ void FAppleSentrySubsystem::UploadAttachmentForEvent(TSharedPtr<ISentryId> event
 		return;
 	}
 
+	if (!eventId || !eventId->IsValid())
+	{
+		UE_LOG(LogSentrySdk, Log, TEXT("Skipping attachment upload for an event that wasn't sent: %s"), *filePath);
+
+		if (deleteAfterUpload && !fileManager.Delete(*filePath))
+		{
+			UE_LOG(LogSentrySdk, Error, TEXT("Failed to delete file attachment: %s"), *filePath);
+		}
+
+		return;
+	}
+
 	const FString& filePathExt = fileManager.ConvertToAbsolutePathForExternalAppForRead(*filePath);
 
 	SentryObjCAttachment* attachment = [[SENTRY_APPLE_CLASS(SentryObjCAttachment) alloc] initWithPath:filePathExt.GetNSString() filename:name.GetNSString()];

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryId.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryId.cpp
@@ -40,4 +40,9 @@ FString FGenericPlatformSentryId::ToString() const
 	return SanitizedIdString;
 }
 
+bool FGenericPlatformSentryId::IsValid() const
+{
+	return sentry_uuid_is_nil(&Id) == 0;
+}
+
 #endif

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryId.h
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryId.h
@@ -19,6 +19,7 @@ public:
 	sentry_uuid_t GetNativeObject();
 
 	virtual FString ToString() const override;
+	virtual bool IsValid() const override;
 
 private:
 	sentry_uuid_t Id;

--- a/plugin-dev/Source/Sentry/Private/Interface/SentryIdInterface.h
+++ b/plugin-dev/Source/Sentry/Private/Interface/SentryIdInterface.h
@@ -10,4 +10,5 @@ public:
 	virtual ~ISentryId() = default;
 
 	virtual FString ToString() const = 0;
+	virtual bool IsValid() const = 0;
 };

--- a/plugin-dev/Source/Sentry/Private/Null/NullSentryId.h
+++ b/plugin-dev/Source/Sentry/Private/Null/NullSentryId.h
@@ -12,6 +12,7 @@ public:
 	virtual ~FNullSentryId() override = default;
 
 	virtual FString ToString() const override { return TEXT(""); }
+	virtual bool IsValid() const override { return false; }
 };
 
 typedef FNullSentryId FPlatformSentryId;


### PR DESCRIPTION
This PR fixes attachments being uploaded on Mac/iOS for events that were never sent, producing attachments not linked to any event.

On Mac/iOS attachments are delivered in a separate envelope once `captureMessage`, `captureEvent` or `captureEnsure` returns. `sentry-cocoa` reports an empty ID for events discarded by the sample rate, a `beforeSend` handler or an event processor, but the upload was performed regardless and capturing an envelope directly bypasses filtering altogether.

Key changes:

- `ISentryId::IsValid` added and implemented for every backend using the empty ID representation of the corresponding SDK: `sentry_uuid_is_nil` (native), `SentryObjCId.empty` (cocoa) and `SentryId.EMPTY_ID` via a new `SentryBridgeJava.isEmptyId` helper (Java)
- `FAppleSentrySubsystem::UploadAttachmentForEvent` skips the upload for events that weren't sent, still removing the file if it was meant to be deleted afterwards

Windows/Linux/Android are unaffected: there attachments belong to the event envelope (or its hint) and are discarded together with the event.