### PR TITLE
Route Apple attachments for non-fatal events through the event scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,7 @@
 
 ### Fixes
 
-- Fix eventless attachments being uploaded on Mac/iOS ([#1558](https://github.com/getsentry/sentry-unreal/pull/1558))
-- Attach game log and screenshots to the corresponding event envelope on Mac/iOS ([#1559](https://github.com/getsentry/sentry-unreal/pull/1559))
+- Fix eventless attachments being uploaded on Mac/iOS ([#1558](https://github.com/getsentry/sentry-unreal/pull/1558), [#1559](https://github.com/getsentry/sentry-unreal/pull/1559))
 
 ### Dependencies
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Fix eventless attachments being uploaded on Mac/iOS ([#1558](https://github.com/getsentry/sentry-unreal/pull/1558))
+- Attach game log and screenshots to the corresponding event envelope on Mac/iOS ([#1559](https://github.com/getsentry/sentry-unreal/pull/1559))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -817,7 +817,6 @@ void FAppleSentrySubsystem::UploadGameLogForEvent(TSharedPtr<ISentryId> eventId,
 
 void FAppleSentrySubsystem::AddGameLogAttachmentToScope(SentryObjCScope* scope) const
 {
-	// If writing logs to a file is disabled (i.e. default behavior for Shipping builds) skip the attachment
 #if !NO_LOGGING
 	if (!isGameLogAttachmentEnabled)
 	{
@@ -842,7 +841,6 @@ void FAppleSentrySubsystem::AddGameLogAttachmentToScope(SentryObjCScope* scope) 
 
 void FAppleSentrySubsystem::AddScreenshotAttachmentToScope(SentryObjCScope* scope) const
 {
-	// On UIKit platforms screenshots are attached to non-fatal events by the Cocoa SDK itself (see `attachScreenshot`)
 #if !SENTRY_OBJC_UIKIT_AVAILABLE
 	if (!isScreenshotAttachmentEnabled || IsRunningCommandlet())
 	{

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -462,16 +462,11 @@ TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureMessageWithScope(const FStri
 	SentryObjCId* nativeId = [SENTRY_APPLE_CLASS(SentryObjCSDK) captureMessage:message.GetNSString() withScopeBlock:^(SentryObjCScope* scope) {
 		[scope setLevel:FAppleSentryConverters::SentryLevelToNative(level)];
 		onConfigureScope.ExecuteIfBound(MakeShareable(new FAppleSentryScope(scope)));
+
+		AddGameLogAttachmentToScope(scope);
 	}];
 
-	TSharedPtr<ISentryId> id = MakeShareable(new FAppleSentryId(nativeId));
-
-	if (isGameLogAttachmentEnabled)
-	{
-		UploadGameLogForEvent(id, GetGameLogPath());
-	}
-
-	return id;
+	return MakeShareable(new FAppleSentryId(nativeId));
 }
 
 TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureEvent(TSharedPtr<ISentryEvent> event)
@@ -486,16 +481,11 @@ TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureEventWithScope(TSharedPtr<IS
 
 	SentryObjCId* nativeId = [SENTRY_APPLE_CLASS(SentryObjCSDK) captureEvent:eventApple->GetNativeObject() withScopeBlock:^(SentryObjCScope* scope) {
 		onConfigureScope.ExecuteIfBound(MakeShareable(new FAppleSentryScope(scope)));
+
+		AddGameLogAttachmentToScope(scope);
 	}];
 
-	TSharedPtr<ISentryId> id = MakeShareable(new FAppleSentryId(nativeId));
-
-	if (isGameLogAttachmentEnabled)
-	{
-		UploadGameLogForEvent(id, GetGameLogPath());
-	}
-
-	return id;
+	return MakeShareable(new FAppleSentryId(nativeId));
 }
 
 TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureEnsure(const FString& type, const FString& message)
@@ -507,16 +497,12 @@ TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureEnsure(const FString& type, 
 	SentryObjCEvent* exceptionEvent = [[SENTRY_APPLE_CLASS(SentryObjCEvent) alloc] init];
 	exceptionEvent.exceptions = nativeExceptionArray;
 
-	SentryObjCId* nativeId = [SENTRY_APPLE_CLASS(SentryObjCSDK) captureEvent:exceptionEvent];
+	SentryObjCId* nativeId = [SENTRY_APPLE_CLASS(SentryObjCSDK) captureEvent:exceptionEvent withScopeBlock:^(SentryObjCScope* scope) {
+		AddGameLogAttachmentToScope(scope);
+		AddScreenshotAttachmentToScope(scope);
+	}];
 
-	TSharedPtr<ISentryId> id = MakeShareable(new FAppleSentryId(nativeId));
-
-	if (isGameLogAttachmentEnabled)
-	{
-		UploadGameLogForEvent(id, GetGameLogPath());
-	}
-
-	return id;
+	return MakeShareable(new FAppleSentryId(nativeId));
 }
 
 TSharedPtr<ISentryId> FAppleSentrySubsystem::CaptureHang(uint32 HungThreadId)
@@ -826,6 +812,67 @@ void FAppleSentrySubsystem::UploadGameLogForEvent(TSharedPtr<ISentryId> eventId,
 	// If writing logs to a file is disabled (i.e. default behavior for Shipping builds) skip the upload
 #if !NO_LOGGING
 	UploadAttachmentForEvent(eventId, logFilePath, SentryFileUtils::GetGameLogName());
+#endif
+}
+
+void FAppleSentrySubsystem::AddGameLogAttachmentToScope(SentryObjCScope* scope) const
+{
+	// If writing logs to a file is disabled (i.e. default behavior for Shipping builds) skip the attachment
+#if !NO_LOGGING
+	if (!isGameLogAttachmentEnabled)
+	{
+		return;
+	}
+
+	IFileManager& fileManager = IFileManager::Get();
+
+	const FString& logFilePath = GetGameLogPath();
+	if (!fileManager.FileExists(*logFilePath))
+	{
+		UE_LOG(LogSentrySdk, Error, TEXT("Failed to attach game log - file path provided did not exist: %s"), *logFilePath);
+		return;
+	}
+
+	FAppleSentryAttachment logAttachment(fileManager.ConvertToAbsolutePathForExternalAppForRead(*logFilePath),
+		SentryFileUtils::GetGameLogName(), TEXT("text/plain"));
+
+	[scope addAttachment:logAttachment.GetNativeObject()];
+#endif
+}
+
+void FAppleSentrySubsystem::AddScreenshotAttachmentToScope(SentryObjCScope* scope) const
+{
+	// On UIKit platforms screenshots are attached to non-fatal events by the Cocoa SDK itself (see `attachScreenshot`)
+#if !SENTRY_OBJC_UIKIT_AVAILABLE
+	if (!isScreenshotAttachmentEnabled || IsRunningCommandlet())
+	{
+		return;
+	}
+
+	// Screenshot capturing is a best-effort solution so if one wasn't captured skip the attachment
+	const FString& screenshotPath = TryCaptureScreenshot();
+	if (screenshotPath.IsEmpty())
+	{
+		return;
+	}
+
+	TArray<uint8> screenshotData;
+	const bool bScreenshotLoaded = FFileHelper::LoadFileToArray(screenshotData, *screenshotPath);
+
+	if (!IFileManager::Get().Delete(*screenshotPath))
+	{
+		UE_LOG(LogSentrySdk, Error, TEXT("Failed to delete screenshot attachment: %s"), *screenshotPath);
+	}
+
+	if (!bScreenshotLoaded)
+	{
+		UE_LOG(LogSentrySdk, Error, TEXT("Failed to read screenshot attachment: %s"), *screenshotPath);
+		return;
+	}
+
+	FAppleSentryAttachment screenshotAttachment(screenshotData, TEXT("screenshot.png"), TEXT("image/png"));
+
+	[scope addAttachment:screenshotAttachment.GetNativeObject()];
 #endif
 }
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -10,6 +10,8 @@
 #include "SessionReplay/SentrySessionReplayRecorder.h"
 #endif
 
+@class SentryObjCScope;
+
 class FAppleSentrySubsystem : public ISentrySubsystem
 {
 public:
@@ -70,6 +72,9 @@ protected:
 
 	void UploadScreenshotForEvent(TSharedPtr<ISentryId> eventId, const FString& screenshotPath) const;
 	void UploadGameLogForEvent(TSharedPtr<ISentryId> eventId, const FString& logFilePath) const;
+
+	void AddGameLogAttachmentToScope(SentryObjCScope* scope) const;
+	void AddScreenshotAttachmentToScope(SentryObjCScope* scope) const;
 
 	virtual FString GetScreenshotPath() const;
 	virtual FString GetLatestScreenshot() const;

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.cpp
@@ -130,19 +130,6 @@ void FMacSentrySubsystem::Close()
 	FAppleSentrySubsystem::Close();
 }
 
-TSharedPtr<ISentryId> FMacSentrySubsystem::CaptureEnsure(const FString& type, const FString& message)
-{
-	TSharedPtr<ISentryId> id = FAppleSentrySubsystem::CaptureEnsure(type, message);
-
-	if (isScreenshotAttachmentEnabled && !IsRunningCommandlet())
-	{
-		const FString& screenshotPath = TryCaptureScreenshot();
-		UploadScreenshotForEvent(id, screenshotPath);
-	}
-
-	return id;
-}
-
 FString FMacSentrySubsystem::TryCaptureScreenshot() const
 {
 	NSWindow* MainWindow = [NSApp mainWindow];

--- a/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Mac/MacSentrySubsystem.h
@@ -37,8 +37,6 @@ public:
 	virtual void InitWithSettings(const USentrySettings* settings, const FSentryCallbackHandlers& callbackHandlers) override;
 	virtual void Close() override;
 
-	virtual TSharedPtr<ISentryId> CaptureEnsure(const FString& type, const FString& message) override;
-
 	virtual FString TryCaptureScreenshot() const override;
 
 	virtual FString GetDeviceType() const override { return TEXT("Desktop"); }


### PR DESCRIPTION
This is a follow-up PR for #1558 that changes how attachments for non-fatal events are sent to Sentry on Mac/iOS.

The game log and the ensure screenshot were uploaded as standalone attachment envelopes once the capture call returned. Standalone attachments have no filtering stage on ingest, so inbound filters and the error category quota could drop the event while its attachments are accepted and billed.

Key changes:

- `AddGameLogAttachmentToScope` and `AddScreenshotAttachmentToScope` added to `FAppleSentrySubsystem`, both reusing `FAppleSentryAttachment` and attaching to the scope provided by the capture APIs
- `CaptureMessageWithScope`, `CaptureEventWithScope` and `CaptureEnsure` attach through the scope instead of uploading a separate envelope afterwards, so attachments are now dropped along with events discarded by the sample rate, a `beforeSend` handler, an inbound filter or a rate limit
- `FMacSentrySubsystem::CaptureEnsure` removed in favor of a single base implementation; screenshots are skipped on UIKit platforms (iOS) where the Cocoa SDK attaches them itself
- Attachment size limit is now enforced by the Cocoa SDK via `maxAttachmentSize`, and content types (`text/plain`, `image/png`) are set to match the other platforms

Attachments are added after the user-provided scope callback so that they can't be removed by `ClearAttachments`, keeping the behavior in line with Android and native. The crash path still uploads a separate envelope since the event it belongs to originates from a previous app run.

## Related Items

- #1558

#skip-changelog