### PR TITLE
Add Windows Error Reporting support for the native backend

### DIFF
--- a/BUNDLED-EXECUTABLES.md
+++ b/BUNDLED-EXECUTABLES.md
@@ -34,6 +34,14 @@ To keep this notice accurate without manual upkeep on every dependency bump, exa
 - **Modified:** No — unmodified upstream release build
 - **Purpose / when it runs:** The sentry-native out-of-process crash handler. Serves the same role as `crashpad_handler`, but is used when the **native** backend is selected instead of Crashpad. Runtime, on the player's machine.
 
+### `sentry-wer.dll`
+
+- **Location:** `Source/ThirdParty/{Win64,WinArm64}/Native/bin/`
+- **Source:** [getsentry/sentry-native](https://github.com/getsentry/sentry-native)
+- **Version:** see the "Native SDK" entry under `### Dependencies` in `CHANGELOG.md`
+- **Modified:** No — unmodified upstream release build
+- **Purpose / when it runs:** Windows Error Reporting helper module loaded when the **native** backend is used — the native-backend counterpart to `crashpad_wer.dll` — to capture certain Windows crash types. Runtime, on the player's machine.
+
 ### `sentry-cli-Windows-x86_64.exe`, `sentry-cli-Linux-x86_64`, `sentry-cli-Darwin-universal`
 
 - **Location:** `Source/ThirdParty/CLI/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Features
 
 - Add support for iOS Simulator builds on UE 5.5 and newer ([#1561](https://github.com/getsentry/sentry-unreal/pull/1561))
+- Add Windows Error Reporting support for the native backend ([#1568](https://github.com/getsentry/sentry-unreal/pull/1568))
 
 ### Dependencies
 

--- a/plugin-dev/Source/Sentry/Sentry.Build.cs
+++ b/plugin-dev/Source/Sentry/Sentry.Build.cs
@@ -158,6 +158,7 @@ public class Sentry : ModuleRules
 			if (bUseNativeBackend)
 			{
 				RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "sentry-crash.exe"), Path.Combine(PlatformThirdPartyPath, Backend, "bin", "sentry-crash.exe"));
+				RuntimeDependencies.Add(Path.Combine(PlatformBinariesPath, "sentry-wer.dll"), Path.Combine(PlatformThirdPartyPath, Backend, "bin", "sentry-wer.dll"));
 
 				PublicAdditionalLibraries.Add(Path.Combine(PlatformThirdPartyPath, Backend, "lib", "sentry-wer.lib"));
 			}

--- a/scripts/build-deps.ps1
+++ b/scripts/build-deps.ps1
@@ -337,6 +337,7 @@ function buildSentryNative()
 
     Get-ChildItem -Path "$NativePath/install_native/lib" -Filter "*.lib" -Recurse | Copy-Item -Destination "$nativeDir/lib"
     Copy-Item "$NativePath/install_native/bin/sentry-crash.exe" -Destination "$nativeDir/bin"
+    Copy-Item "$NativePath/install_native/bin/sentry-wer.dll" -Destination "$nativeDir/bin"
     Copy-Item "$NativePath/install_native/include/sentry.h" -Destination "$nativeDir/include"
 }
 

--- a/scripts/build-win64-native.sh
+++ b/scripts/build-win64-native.sh
@@ -18,4 +18,5 @@ mkdir "${sentryArtifactsDestination}/lib"
 
 cp ${sentryNativeRoot}/install_native/lib/*.lib ${sentryArtifactsDestination}/lib
 cp ${sentryNativeRoot}/install_native/bin/sentry-crash.exe ${sentryArtifactsDestination}/bin/sentry-crash.exe
+cp ${sentryNativeRoot}/install_native/bin/sentry-wer.dll ${sentryArtifactsDestination}/bin/sentry-wer.dll
 cp ${sentryNativeRoot}/install_native/include/sentry.h ${sentryArtifactsDestination}/include/sentry.h

--- a/scripts/build-winarm64-native.sh
+++ b/scripts/build-winarm64-native.sh
@@ -17,4 +17,5 @@ mkdir "${sentryArtifactsDestination}/lib"
 
 cp ${sentryNativeRoot}/install_native/lib/*.lib ${sentryArtifactsDestination}/lib
 cp ${sentryNativeRoot}/install_native/bin/sentry-crash.exe ${sentryArtifactsDestination}/bin/sentry-crash.exe
+cp ${sentryNativeRoot}/install_native/bin/sentry-wer.dll ${sentryArtifactsDestination}/bin/sentry-wer.dll
 cp ${sentryNativeRoot}/install_native/include/sentry.h ${sentryArtifactsDestination}/include/sentry.h

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -723,6 +723,7 @@ Source/ThirdParty/Win64/Crashpad/lib/crashpad_zlib.lib
 Source/ThirdParty/Win64/Crashpad/lib/mini_chromium.lib
 Source/ThirdParty/Win64/Crashpad/lib/sentry.lib
 Source/ThirdParty/Win64/Native/bin/sentry-crash.exe
+Source/ThirdParty/Win64/Native/bin/sentry-wer.dll
 Source/ThirdParty/Win64/Native/include/sentry.h
 Source/ThirdParty/Win64/Native/lib/sentry-wer.lib
 Source/ThirdParty/Win64/Native/lib/sentry.lib
@@ -743,6 +744,7 @@ Source/ThirdParty/WinArm64/Crashpad/lib/crashpad_zlib.lib
 Source/ThirdParty/WinArm64/Crashpad/lib/mini_chromium.lib
 Source/ThirdParty/WinArm64/Crashpad/lib/sentry.lib
 Source/ThirdParty/WinArm64/Native/bin/sentry-crash.exe
+Source/ThirdParty/WinArm64/Native/bin/sentry-wer.dll
 Source/ThirdParty/WinArm64/Native/include/sentry.h
 Source/ThirdParty/WinArm64/Native/lib/sentry-wer.lib
 Source/ThirdParty/WinArm64/Native/lib/sentry.lib


### PR DESCRIPTION
This PR ships `sentry-wer.dll` with the `native` backend on Windows, so Windows Error Reporting can hand fast-fail exceptions (heap corruption, `__fastfail`, stack buffer overrun) to Sentry - the role `crashpad_wer.dll` already plays for the `crashpad` backend. The module is built by `sentry-native` but was never packaged, leaving that path dead on every native-backend Windows build.

Key changes:

- `build-win64-native.sh`, `build-winarm64-native.sh` and `build-deps.ps1` copy `sentry-wer.dll` into `ThirdParty/{Win64,WinArm64}/Native/bin`. They previously took only `sentry-crash.exe` out of the install tree, while their crashpad counterparts do copy `crashpad_wer.dll`
- `Sentry.Build.cs` stages it as a runtime dependency next to `sentry-crash.exe`. The existing `sentry-wer.lib` entry in `PublicAdditionalLibraries` never did that - it's an import library whose only exports are the three `OutOfProcessException*Callback` entry points WerFault calls, which nothing in the game references
- `package.snapshot`: two `Native/bin/sentry-wer.dll` entries in

Depends on https://github.com/getsentry/sentry-native/pull/2073 since currently `sentry-native` resolves the module against the running executable's directory, while the crashpad backend resolves `crashpad_wer.dll` against `handler_path`. Unreal stages plugin runtime dependencies under the plugin's own `Binaries` directory, never next to the game exe, so the lookup misses.

## Related items

- https://github.com/getsentry/sentry-native/pull/2073