### PR TITLE
chore: Clean up CI workflows and integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,168 +100,17 @@ jobs:
       backend: native
       runsOn: windows-11-arm
 
-  package-preparation:
+  package:
     needs: [android-sdk, ios-sdk, macos-cocoa-sdk, macos-native-sdk, linux-sdk-crashpad, linux-sdk-native, linux-arm64-sdk-crashpad, linux-arm64-sdk-native, windows-sdk-crashpad, windows-sdk-native, windows-arm64-sdk-crashpad, windows-arm64-sdk-native]
     name: Package
-    runs-on: ubuntu-latest
-
-    env:
-      DO_CODESIGN: ${{ startsWith(github.ref, 'refs/heads/release/') && '1' || '0' }}
-      APPLE_CERT_PATH: /tmp/certs.p12
-      APPLE_API_KEY_PATH: /tmp/apple_key.json
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          submodules: recursive
-
-      - name: Download CLI
-        shell: pwsh
-        run: ./scripts/download-cli.ps1
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: Android-sdk
-          path: plugin-dev/Source/ThirdParty/Android
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: IOS-sdk
-          path: plugin-dev/Source/ThirdParty/IOS
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: Mac-cocoa-sdk
-          path: plugin-dev/Source/ThirdParty/Mac
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: Mac-native-sdk
-          path: plugin-dev/Source/ThirdParty/Mac/Native
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: Linux-crashpad-sdk
-          path: plugin-dev/Source/ThirdParty/Linux/Crashpad
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: Linux-native-sdk
-          path: plugin-dev/Source/ThirdParty/Linux/Native
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: LinuxArm64-crashpad-sdk
-          path: plugin-dev/Source/ThirdParty/LinuxArm64/Crashpad
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: LinuxArm64-native-sdk
-          path: plugin-dev/Source/ThirdParty/LinuxArm64/Native
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: Win64-crashpad-sdk
-          path: plugin-dev/Source/ThirdParty/Win64/Crashpad
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: Win64-native-sdk
-          path: plugin-dev/Source/ThirdParty/Win64/Native
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: WinArm64-crashpad-sdk
-          path: plugin-dev/Source/ThirdParty/WinArm64/Crashpad
-
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
-        with:
-          name: WinArm64-native-sdk
-          path: plugin-dev/Source/ThirdParty/WinArm64/Native
-
-      - name: Download Crash Reporter
-        shell: bash
-        run: ./scripts/download-crash-reporter.sh
-
-      # Workaround for https://github.com/actions/download-artifact/issues/14
-      # Adding execute permission for crashpad before preparing final packages
-      # allows to avoid issues with plugin initialization on Unix-based systems.
-      - name: Set permissions for executables
-        shell: pwsh
-        run: |
-          chmod +x plugin-dev/Source/ThirdParty/Linux/Crashpad/bin/crashpad_handler
-          chmod +x plugin-dev/Source/ThirdParty/Linux/Native/bin/sentry-crash
-          chmod +x plugin-dev/Source/ThirdParty/LinuxArm64/Crashpad/bin/crashpad_handler
-          chmod +x plugin-dev/Source/ThirdParty/LinuxArm64/Native/bin/sentry-crash
-          chmod +x plugin-dev/Source/ThirdParty/Mac/Native/bin/sentry-crash
-
-      - name: Install rcodesign
-        if: env.DO_CODESIGN == '1'
-        env:
-          RCODESIGN_VERSION: 0.29.0
-          RCODESIGN_CHECKSUM: dbe85cedd8ee4217b64e9a0e4c2aef92ab8bcaaa41f20bde99781ff02e600002
-        run: |
-          curl -fsSL "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign/${RCODESIGN_VERSION}/apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-            -o rcodesign.tar.gz
-          echo "${RCODESIGN_CHECKSUM}  rcodesign.tar.gz" | sha256sum -c -
-          tar -xz --strip-components=1 -C /tmp -f rcodesign.tar.gz
-          sudo mv /tmp/rcodesign /usr/local/bin/rcodesign
-          rm rcodesign.tar.gz
-
-      - name: Sign macOS binaries
-        if: env.DO_CODESIGN == '1'
-        env:
-          APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}
-          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
-        run: |
-          if [ -z "$APPLE_CERT_DATA" ]; then
-            echo "::error title=Codesign failed::Missing Apple signing certificate (APPLE_CERT_DATA)."
-            exit 1
-          fi
-          echo "$APPLE_CERT_DATA" | base64 --decode > "$APPLE_CERT_PATH"
-
-          rcodesign sign --for-notarization \
-            --p12-file "$APPLE_CERT_PATH" --p12-password "$APPLE_CERT_PASSWORD" \
-            plugin-dev/Source/ThirdParty/Mac/Cocoa/bin/SentryObjC.dylib
-          rcodesign sign --for-notarization \
-            --p12-file "$APPLE_CERT_PATH" --p12-password "$APPLE_CERT_PASSWORD" \
-            plugin-dev/Source/ThirdParty/Mac/Native/bin/sentry-crash
-
-      - name: Notarize macOS binaries
-        if: env.DO_CODESIGN == '1'
-        env:
-          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
-        run: |
-          if [ -z "$APPLE_API_KEY" ]; then
-            echo "::error title=Notarization failed::Missing Apple API key (APPLE_API_KEY)."
-            exit 1
-          fi
-          echo "$APPLE_API_KEY" | base64 --decode > "$APPLE_API_KEY_PATH"
-
-          zip -j macos-binaries.zip \
-            plugin-dev/Source/ThirdParty/Mac/Cocoa/bin/SentryObjC.dylib \
-            plugin-dev/Source/ThirdParty/Mac/Native/bin/sentry-crash
-          rcodesign notary-submit --wait \
-            --api-key-file "$APPLE_API_KEY_PATH" \
-            macos-binaries.zip
-          rm macos-binaries.zip
-
-      - name: Prepare Sentry packages for release
-        shell: pwsh
-        run: ./scripts/packaging/pack.ps1
-
-      - name: Upload release artifacts
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
-        with:
-          # Artifact name is the commit sha. Which is what craft uses to find the relevant artifact.
-          name: ${{ github.sha }}
-          if-no-files-found: error
-          path: |
-            sentry-unreal-*.zip
+    secrets:
+      APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}
+      APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+      APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+    uses: ./.github/workflows/package.yml
 
   package-validation:
-    needs: [package-preparation]
+    needs: [package]
     name: Check snapshot
     runs-on: ubuntu-latest
     steps:
@@ -307,7 +156,7 @@ jobs:
           fi
 
   test-linux:
-    needs: [package-preparation, generate-test-matrix]
+    needs: [package, generate-test-matrix]
     name: Linux UE ${{ matrix.unreal }}
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -322,7 +171,7 @@ jobs:
       unreal-version: ${{ matrix.unreal }}
 
   test-windows:
-    needs: [package-preparation, generate-test-matrix]
+    needs: [package, generate-test-matrix]
     name: Windows UE ${{ matrix.unreal }}
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -337,7 +186,7 @@ jobs:
       unreal-version: ${{ matrix.unreal }}
 
   test-macos:
-    needs: [package-preparation]
+    needs: [package]
     name: macOS UE ${{ matrix.unreal }}
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -354,7 +203,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
 
   test-ios:
-    needs: [package-preparation]
+    needs: [package]
     name: iOS UE ${{ matrix.unreal }}
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -374,7 +223,7 @@ jobs:
     if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
 
   test-android:
-    needs: [package-preparation, generate-test-matrix]
+    needs: [package, generate-test-matrix]
     name: Android UE ${{ matrix.unreal }}
     secrets:
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -389,7 +238,7 @@ jobs:
       unreal-version: ${{ matrix.unreal }}
 
   test-consoles:
-    needs: [package-preparation]
+    needs: [package]
     name: ${{ matrix.name }}
     if: github.event_name == 'push'
     secrets:

--- a/.github/workflows/integration-test-android.yml
+++ b/.github/workflows/integration-test-android.yml
@@ -19,16 +19,6 @@ jobs:
     name: Integration Test
     runs-on: ubuntu-latest
 
-    env:
-      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-      SAUCE_REGION: us-west-1
-      SAUCE_DEVICE_NAME: Samsung_Galaxy_S23_15_real_sjc1
-      SAUCE_SESSION_NAME: UE ${{ inputs.unreal-version }} Android Integration Test
-      # Capture only relevant logcat tags - system spam (thousands of lines/sec on real devices)
-      # evicts UE's EVENT_CAPTURED/TEST_RESULT markers from the log window otherwise
-      SAUCE_LOGCAT_FILTER: "UE:V UE4:V Sentry:V sentry-native:V DEBUG:V ActivityManager:I *:S"
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -45,6 +35,14 @@ jobs:
         shell: pwsh
         working-directory: integration-test
         env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          SAUCE_REGION: us-west-1
+          SAUCE_DEVICE_NAME: Samsung_Galaxy_S23_15_real_sjc1
+          SAUCE_SESSION_NAME: UE ${{ inputs.unreal-version }} Android Integration Test
+          # Capture only relevant logcat tags - system spam (thousands of lines/sec on real devices)
+          # evicts UE's EVENT_CAPTURED/TEST_RESULT markers from the log window otherwise
+          SAUCE_LOGCAT_FILTER: "UE:V UE4:V Sentry:V sentry-native:V DEBUG:V ActivityManager:I *:S"
           SENTRY_UNREAL_TEST_DSN: ${{ secrets.SENTRY_UNREAL_TEST_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_API_TOKEN }}
           SENTRY_UNREAL_TEST_APP_PATH: ${{ github.workspace }}/sample-build/SentryPlayground-arm64.apk

--- a/.github/workflows/integration-test-android.yml
+++ b/.github/workflows/integration-test-android.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      GITHUB_TOKEN: ${{ github.token }}
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       SAUCE_REGION: us-west-1

--- a/.github/workflows/integration-test-ios.yml
+++ b/.github/workflows/integration-test-ios.yml
@@ -20,7 +20,6 @@ jobs:
     runs-on: ubuntu-latest
 
     env:
-      GITHUB_TOKEN: ${{ github.token }}
       SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
       SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
       SAUCE_REGION: us-west-1

--- a/.github/workflows/integration-test-ios.yml
+++ b/.github/workflows/integration-test-ios.yml
@@ -19,13 +19,6 @@ jobs:
     name: Integration Test
     runs-on: ubuntu-latest
 
-    env:
-      SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
-      SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
-      SAUCE_REGION: us-west-1
-      SAUCE_DEVICE_NAME: iPhone_17_*_real_sjc1
-      SAUCE_SESSION_NAME: UE ${{ inputs.unreal-version }} iOS Integration Test
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
@@ -42,6 +35,11 @@ jobs:
         shell: pwsh
         working-directory: integration-test
         env:
+          SAUCE_USERNAME: ${{ secrets.SAUCE_USERNAME }}
+          SAUCE_ACCESS_KEY: ${{ secrets.SAUCE_ACCESS_KEY }}
+          SAUCE_REGION: us-west-1
+          SAUCE_DEVICE_NAME: iPhone_17_*_real_sjc1
+          SAUCE_SESSION_NAME: UE ${{ inputs.unreal-version }} iOS Integration Test
           SENTRY_UNREAL_TEST_DSN: ${{ secrets.SENTRY_UNREAL_TEST_DSN }}
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_API_TOKEN }}
           SENTRY_UNREAL_TEST_APP_PATH: ${{ github.workspace }}/sample-build/SentryPlayground.ipa

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -1,0 +1,172 @@
+on:
+  workflow_call:
+    secrets:
+      APPLE_CERT_DATA:
+        description: Base64-encoded .p12 signing certificate
+        required: false
+      APPLE_CERT_PASSWORD:
+        description: Password for the .p12 signing certificate
+        required: false
+      APPLE_API_KEY:
+        description: Base64-encoded App Store Connect API key used for notarization
+        required: false
+
+jobs:
+  package-preparation:
+    name: Prepare
+    runs-on: ubuntu-latest
+
+    env:
+      DO_CODESIGN: ${{ startsWith(github.ref, 'refs/heads/release/') && '1' || '0' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          submodules: recursive
+
+      - name: Download CLI
+        shell: pwsh
+        run: ./scripts/download-cli.ps1
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: Android-sdk
+          path: plugin-dev/Source/ThirdParty/Android
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: IOS-sdk
+          path: plugin-dev/Source/ThirdParty/IOS
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: Mac-cocoa-sdk
+          path: plugin-dev/Source/ThirdParty/Mac
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: Mac-native-sdk
+          path: plugin-dev/Source/ThirdParty/Mac/Native
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: Linux-crashpad-sdk
+          path: plugin-dev/Source/ThirdParty/Linux/Crashpad
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: Linux-native-sdk
+          path: plugin-dev/Source/ThirdParty/Linux/Native
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: LinuxArm64-crashpad-sdk
+          path: plugin-dev/Source/ThirdParty/LinuxArm64/Crashpad
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: LinuxArm64-native-sdk
+          path: plugin-dev/Source/ThirdParty/LinuxArm64/Native
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: Win64-crashpad-sdk
+          path: plugin-dev/Source/ThirdParty/Win64/Crashpad
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: Win64-native-sdk
+          path: plugin-dev/Source/ThirdParty/Win64/Native
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: WinArm64-crashpad-sdk
+          path: plugin-dev/Source/ThirdParty/WinArm64/Crashpad
+
+      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: WinArm64-native-sdk
+          path: plugin-dev/Source/ThirdParty/WinArm64/Native
+
+      - name: Download Crash Reporter
+        shell: bash
+        run: ./scripts/download-crash-reporter.sh
+
+      # Workaround for https://github.com/actions/download-artifact/issues/14
+      # Adding execute permission for crashpad before preparing final packages
+      # allows to avoid issues with plugin initialization on Unix-based systems.
+      - name: Set permissions for executables
+        shell: pwsh
+        run: |
+          chmod +x plugin-dev/Source/ThirdParty/Linux/Crashpad/bin/crashpad_handler
+          chmod +x plugin-dev/Source/ThirdParty/Linux/Native/bin/sentry-crash
+          chmod +x plugin-dev/Source/ThirdParty/LinuxArm64/Crashpad/bin/crashpad_handler
+          chmod +x plugin-dev/Source/ThirdParty/LinuxArm64/Native/bin/sentry-crash
+          chmod +x plugin-dev/Source/ThirdParty/Mac/Native/bin/sentry-crash
+
+      - name: Install rcodesign
+        if: env.DO_CODESIGN == '1'
+        env:
+          RCODESIGN_VERSION: 0.29.0
+          RCODESIGN_CHECKSUM: dbe85cedd8ee4217b64e9a0e4c2aef92ab8bcaaa41f20bde99781ff02e600002
+        run: |
+          curl -fsSL "https://github.com/indygreg/apple-platform-rs/releases/download/apple-codesign/${RCODESIGN_VERSION}/apple-codesign-${RCODESIGN_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+            -o rcodesign.tar.gz
+          echo "${RCODESIGN_CHECKSUM}  rcodesign.tar.gz" | sha256sum -c -
+          tar -xz --strip-components=1 -C /tmp -f rcodesign.tar.gz
+          sudo mv /tmp/rcodesign /usr/local/bin/rcodesign
+          rm rcodesign.tar.gz
+
+      - name: Sign macOS binaries
+        if: env.DO_CODESIGN == '1'
+        env:
+          APPLE_CERT_DATA: ${{ secrets.APPLE_CERT_DATA }}
+          APPLE_CERT_PASSWORD: ${{ secrets.APPLE_CERT_PASSWORD }}
+          APPLE_CERT_PATH: /tmp/certs.p12
+        run: |
+          if [ -z "$APPLE_CERT_DATA" ]; then
+            echo "::error title=Codesign failed::Missing Apple signing certificate (APPLE_CERT_DATA)."
+            exit 1
+          fi
+          echo "$APPLE_CERT_DATA" | base64 --decode > "$APPLE_CERT_PATH"
+
+          rcodesign sign --for-notarization \
+            --p12-file "$APPLE_CERT_PATH" --p12-password "$APPLE_CERT_PASSWORD" \
+            plugin-dev/Source/ThirdParty/Mac/Cocoa/bin/SentryObjC.dylib
+          rcodesign sign --for-notarization \
+            --p12-file "$APPLE_CERT_PATH" --p12-password "$APPLE_CERT_PASSWORD" \
+            plugin-dev/Source/ThirdParty/Mac/Native/bin/sentry-crash
+
+      - name: Notarize macOS binaries
+        if: env.DO_CODESIGN == '1'
+        env:
+          APPLE_API_KEY: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_PATH: /tmp/apple_key.json
+        run: |
+          if [ -z "$APPLE_API_KEY" ]; then
+            echo "::error title=Notarization failed::Missing Apple API key (APPLE_API_KEY)."
+            exit 1
+          fi
+          echo "$APPLE_API_KEY" | base64 --decode > "$APPLE_API_KEY_PATH"
+
+          zip -j macos-binaries.zip \
+            plugin-dev/Source/ThirdParty/Mac/Cocoa/bin/SentryObjC.dylib \
+            plugin-dev/Source/ThirdParty/Mac/Native/bin/sentry-crash
+          rcodesign notary-submit --wait \
+            --api-key-file "$APPLE_API_KEY_PATH" \
+            macos-binaries.zip
+          rm macos-binaries.zip
+
+      - name: Prepare Sentry packages for release
+        shell: pwsh
+        run: ./scripts/packaging/pack.ps1
+
+      - name: Upload release artifacts
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7
+        with:
+          # Artifact name is the commit sha. Which is what craft uses to find the relevant artifact.
+          name: ${{ github.sha }}
+          if-no-files-found: error
+          path: |
+            sentry-unreal-*.zip

--- a/integration-test/Integration.Android.Tests.ps1
+++ b/integration-test/Integration.Android.Tests.ps1
@@ -127,104 +127,106 @@ BeforeAll {
 Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTargets {
 
     BeforeAll {
-        # Connect to Android device (provider validates its own env vars)
-        Write-Host "Connecting to Android via $Platform..." -ForegroundColor Yellow
-        Connect-Device -Platform $ProviderName
+        try {
+            # Connect to Android device (provider validates its own env vars)
+            Write-Host "Connecting to Android via $Platform..." -ForegroundColor Yellow
+            Connect-Device -Platform $ProviderName
 
-        # Install APK
-        Write-Host "Installing APK via $Platform..." -ForegroundColor Yellow
-        Install-DeviceApp -Path $script:ApkPath
+            # Install APK
+            Write-Host "Installing APK via $Platform..." -ForegroundColor Yellow
+            Install-DeviceApp -Path $script:ApkPath
 
-        # ==========================================
-        # RUN 1: Crash test - creates minidump
-        # ==========================================
-        # The crash is captured but NOT uploaded yet (Android behavior).
+            # ==========================================
+            # RUN 1: Crash test - creates minidump
+            # ==========================================
+            # The crash is captured but NOT uploaded yet (Android behavior).
 
-        Write-Host "Running crash-capture test (will crash) on $Platform..." -ForegroundColor Yellow
-        $crashIntentArgs = "-e cmdline -crash-capture"
-        $global:AndroidCrashResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $crashIntentArgs
+            Write-Host "Running crash-capture test (will crash) on $Platform..." -ForegroundColor Yellow
+            $crashIntentArgs = "-e cmdline -crash-capture"
+            $global:AndroidCrashResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $crashIntentArgs
 
-        Write-Host "Crash test exit code: $($global:AndroidCrashResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Crash test exit code: $($global:AndroidCrashResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 2: Init-only - flushes crash event from Run 1
-        # ==========================================
-        # The crash is captured but NOT uploaded immediately on Android,
-        # so we need to run the app again to send it to Sentry.
-        # -init-only allows starting the app to flush captured events and quit right after.
+            # ==========================================
+            # RUN 2: Init-only - flushes crash event from Run 1
+            # ==========================================
+            # The crash is captured but NOT uploaded immediately on Android,
+            # so we need to run the app again to send it to Sentry.
+            # -init-only allows starting the app to flush captured events and quit right after.
 
-        Write-Host "Running init-only to flush crash event on $Platform..." -ForegroundColor Yellow
-        $initOnlyIntentArgs = "-e cmdline -init-only"
-        $global:AndroidInitOnlyResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $initOnlyIntentArgs
+            Write-Host "Running init-only to flush crash event on $Platform..." -ForegroundColor Yellow
+            $initOnlyIntentArgs = "-e cmdline -init-only"
+            $global:AndroidInitOnlyResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $initOnlyIntentArgs
 
-        Write-Host "Init-only exit code: $($global:AndroidInitOnlyResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Init-only exit code: $($global:AndroidInitOnlyResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 3: Message test - captures message
-        # ==========================================
+            # ==========================================
+            # RUN 3: Message test - captures message
+            # ==========================================
 
-        Write-Host "Running message-capture test on $Platform..." -ForegroundColor Yellow
-        $messageIntentArgs = "-e cmdline -message-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeSendHandler=/Script/SentryPlayground.CppBeforeSendHandler\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeBreadcrumbHandler=/Script/SentryPlayground.CppBeforeBreadcrumbHandler"
-        $global:AndroidMessageResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $messageIntentArgs
+            Write-Host "Running message-capture test on $Platform..." -ForegroundColor Yellow
+            $messageIntentArgs = "-e cmdline -message-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeSendHandler=/Script/SentryPlayground.CppBeforeSendHandler\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeBreadcrumbHandler=/Script/SentryPlayground.CppBeforeBreadcrumbHandler"
+            $global:AndroidMessageResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $messageIntentArgs
 
-        Write-Host "Message test exit code: $($global:AndroidMessageResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Message test exit code: $($global:AndroidMessageResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN: Feedback test - captures user feedback
-        # ==========================================
+            # ==========================================
+            # RUN: Feedback test - captures user feedback
+            # ==========================================
 
-        Write-Host "Running feedback-capture test on $Platform..." -ForegroundColor Yellow
-        $feedbackIntentArgs = "-e cmdline -feedback-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeSendFeedbackHandler=/Script/SentryPlayground.CppBeforeSendFeedbackHandler"
-        $global:AndroidFeedbackResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $feedbackIntentArgs
+            Write-Host "Running feedback-capture test on $Platform..." -ForegroundColor Yellow
+            $feedbackIntentArgs = "-e cmdline -feedback-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeSendFeedbackHandler=/Script/SentryPlayground.CppBeforeSendFeedbackHandler"
+            $global:AndroidFeedbackResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $feedbackIntentArgs
 
-        Write-Host "Feedback test exit code: $($global:AndroidFeedbackResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Feedback test exit code: $($global:AndroidFeedbackResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 4: Log test - captures structured log
-        # ==========================================
+            # ==========================================
+            # RUN 4: Log test - captures structured log
+            # ==========================================
 
-        Write-Host "Running log-capture test on $Platform..." -ForegroundColor Yellow
-        $logIntentArgs = "-e cmdline -log-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeLogHandler=/Script/SentryPlayground.CppBeforeLogHandler"
-        $global:AndroidLogResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $logIntentArgs
+            Write-Host "Running log-capture test on $Platform..." -ForegroundColor Yellow
+            $logIntentArgs = "-e cmdline -log-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeLogHandler=/Script/SentryPlayground.CppBeforeLogHandler"
+            $global:AndroidLogResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $logIntentArgs
 
-        Write-Host "Log test exit code: $($global:AndroidLogResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Log test exit code: $($global:AndroidLogResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 4: Metric test - captures custom metric
-        # ==========================================
+            # ==========================================
+            # RUN 4: Metric test - captures custom metric
+            # ==========================================
 
-        Write-Host "Running metric-capture test on $Platform..." -ForegroundColor Yellow
-        $metricIntentArgs = "-e cmdline -metric-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeMetricHandler=/Script/SentryPlayground.CppBeforeMetricHandler"
-        $global:AndroidMetricResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $metricIntentArgs
+            Write-Host "Running metric-capture test on $Platform..." -ForegroundColor Yellow
+            $metricIntentArgs = "-e cmdline -metric-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeMetricHandler=/Script/SentryPlayground.CppBeforeMetricHandler"
+            $global:AndroidMetricResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $metricIntentArgs
 
-        Write-Host "Metric test exit code: $($global:AndroidMetricResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Metric test exit code: $($global:AndroidMetricResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 5: Tracing test - captures transaction
-        # ==========================================
+            # ==========================================
+            # RUN 5: Tracing test - captures transaction
+            # ==========================================
 
-        Write-Host "Running tracing-capture test on $Platform..." -ForegroundColor Yellow
-        $tracingIntentArgs = "-e cmdline -tracing-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableTracing=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:SamplingType=TracesSampler\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:TracesSampler=/Script/SentryPlayground.CppTraceSampler"
-        $global:AndroidTracingResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $tracingIntentArgs
+            Write-Host "Running tracing-capture test on $Platform..." -ForegroundColor Yellow
+            $tracingIntentArgs = "-e cmdline -tracing-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableTracing=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:SamplingType=TracesSampler\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:TracesSampler=/Script/SentryPlayground.CppTraceSampler"
+            $global:AndroidTracingResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $tracingIntentArgs
 
-        Write-Host "Tracing test exit code: $($global:AndroidTracingResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Tracing test exit code: $($global:AndroidTracingResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 7: Hang test - captures app-hang event
-        # ==========================================
+            # ==========================================
+            # RUN 7: Hang test - captures app-hang event
+            # ==========================================
 
-        Write-Host "Running hang-capture test on $Platform..." -ForegroundColor Yellow
-        $hangIntentArgs = "-e cmdline -hang-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableHangTracking=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:UseNativeHangTracking=True"
-        $global:AndroidHangResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $hangIntentArgs
+            Write-Host "Running hang-capture test on $Platform..." -ForegroundColor Yellow
+            $hangIntentArgs = "-e cmdline -hang-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableHangTracking=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:UseNativeHangTracking=True"
+            $global:AndroidHangResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $hangIntentArgs
 
-        Write-Host "Hang test exit code: $($global:AndroidHangResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Hang test exit code: $($global:AndroidHangResult.ExitCode)" -ForegroundColor Cyan
+        }
+        finally {
+            Write-Host "Disconnecting from $Platform..." -ForegroundColor Yellow
+            Disconnect-Device
+        }
     }
 
     AfterAll {
-        # Disconnect from Android device
-        Write-Host "Disconnecting from $Platform..." -ForegroundColor Yellow
-        Disconnect-Device
-
         Write-Host "Integration tests complete on $Platform" -ForegroundColor Green
     }
 

--- a/integration-test/Integration.iOS.Tests.ps1
+++ b/integration-test/Integration.iOS.Tests.ps1
@@ -108,106 +108,108 @@ BeforeAll {
 Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTargets {
 
     BeforeAll {
-        # Connect to iOS device (provider validates its own env vars)
-        Write-Host "Connecting to iOS device via $Platform..." -ForegroundColor Yellow
-        Connect-Device -Platform $ProviderName
+        try {
+            # Connect to iOS device (provider validates its own env vars)
+            Write-Host "Connecting to iOS device via $Platform..." -ForegroundColor Yellow
+            Connect-Device -Platform $ProviderName
 
-        # Install IPA
-        Write-Host "Installing IPA via $Platform..." -ForegroundColor Yellow
-        Install-DeviceApp -Path $script:IpaPath
+            # Install IPA
+            Write-Host "Installing IPA via $Platform..." -ForegroundColor Yellow
+            Install-DeviceApp -Path $script:IpaPath
 
-        # All actions run upfront to minimize device idle time - SauceLabs sessions time out
-        # while the harness polls the Sentry API between launches.
+            # All actions run upfront to minimize device idle time - SauceLabs sessions time out
+            # while the harness polls the Sentry API between launches.
 
-        # ==========================================
-        # RUN 1: Crash test - captures crash report
-        # ==========================================
-        # The crash is captured but NOT uploaded yet (Cocoa behavior).
+            # ==========================================
+            # RUN 1: Crash test - captures crash report
+            # ==========================================
+            # The crash is captured but NOT uploaded yet (Cocoa behavior).
 
-        Write-Host "Running crash-capture test (will crash) on $Platform..." -ForegroundColor Yellow
-        $global:iOSCrashResult = Invoke-iOSTestAction -Arguments @('-crash-capture')
+            Write-Host "Running crash-capture test (will crash) on $Platform..." -ForegroundColor Yellow
+            $global:iOSCrashResult = Invoke-iOSTestAction -Arguments @('-crash-capture')
 
-        Write-Host "Crash test exit code: $($global:iOSCrashResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Crash test exit code: $($global:iOSCrashResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 2: Init-only - flushes crash event from Run 1
-        # ==========================================
-        # Cocoa sends crash reports on the next app launch, so run the app again to upload it.
+            # ==========================================
+            # RUN 2: Init-only - flushes crash event from Run 1
+            # ==========================================
+            # Cocoa sends crash reports on the next app launch, so run the app again to upload it.
 
-        Write-Host "Running init-only to flush crash event on $Platform..." -ForegroundColor Yellow
-        $global:iOSInitOnlyResult = Invoke-iOSTestAction -Arguments @('-init-only')
+            Write-Host "Running init-only to flush crash event on $Platform..." -ForegroundColor Yellow
+            $global:iOSInitOnlyResult = Invoke-iOSTestAction -Arguments @('-init-only')
 
-        Write-Host "Init-only exit code: $($global:iOSInitOnlyResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Init-only exit code: $($global:iOSInitOnlyResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 3: Message test - captures message
-        # ==========================================
+            # ==========================================
+            # RUN 3: Message test - captures message
+            # ==========================================
 
-        Write-Host "Running message-capture test on $Platform..." -ForegroundColor Yellow
-        $global:iOSMessageResult = Invoke-iOSTestAction -Arguments @(
-            '-message-capture',
-            "$script:SentrySettings`:BeforeSendHandler=/Script/SentryPlayground.CppBeforeSendHandler",
-            "$script:SentrySettings`:BeforeBreadcrumbHandler=/Script/SentryPlayground.CppBeforeBreadcrumbHandler"
-        )
+            Write-Host "Running message-capture test on $Platform..." -ForegroundColor Yellow
+            $global:iOSMessageResult = Invoke-iOSTestAction -Arguments @(
+                '-message-capture',
+                "$script:SentrySettings`:BeforeSendHandler=/Script/SentryPlayground.CppBeforeSendHandler",
+                "$script:SentrySettings`:BeforeBreadcrumbHandler=/Script/SentryPlayground.CppBeforeBreadcrumbHandler"
+            )
 
-        Write-Host "Message test exit code: $($global:iOSMessageResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Message test exit code: $($global:iOSMessageResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 4: Feedback test - captures user feedback
-        # ==========================================
+            # ==========================================
+            # RUN 4: Feedback test - captures user feedback
+            # ==========================================
 
-        Write-Host "Running feedback-capture test on $Platform..." -ForegroundColor Yellow
-        $global:iOSFeedbackResult = Invoke-iOSTestAction -Arguments @(
-            '-feedback-capture',
-            "$script:SentrySettings`:BeforeSendFeedbackHandler=/Script/SentryPlayground.CppBeforeSendFeedbackHandler"
-        )
+            Write-Host "Running feedback-capture test on $Platform..." -ForegroundColor Yellow
+            $global:iOSFeedbackResult = Invoke-iOSTestAction -Arguments @(
+                '-feedback-capture',
+                "$script:SentrySettings`:BeforeSendFeedbackHandler=/Script/SentryPlayground.CppBeforeSendFeedbackHandler"
+            )
 
-        Write-Host "Feedback test exit code: $($global:iOSFeedbackResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Feedback test exit code: $($global:iOSFeedbackResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 5: Log test - captures structured log
-        # ==========================================
+            # ==========================================
+            # RUN 5: Log test - captures structured log
+            # ==========================================
 
-        Write-Host "Running log-capture test on $Platform..." -ForegroundColor Yellow
-        $global:iOSLogResult = Invoke-iOSTestAction -Arguments @(
-            '-log-capture',
-            "$script:SentrySettings`:BeforeLogHandler=/Script/SentryPlayground.CppBeforeLogHandler"
-        )
+            Write-Host "Running log-capture test on $Platform..." -ForegroundColor Yellow
+            $global:iOSLogResult = Invoke-iOSTestAction -Arguments @(
+                '-log-capture',
+                "$script:SentrySettings`:BeforeLogHandler=/Script/SentryPlayground.CppBeforeLogHandler"
+            )
 
-        Write-Host "Log test exit code: $($global:iOSLogResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Log test exit code: $($global:iOSLogResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 6: Metric test - captures custom metric
-        # ==========================================
+            # ==========================================
+            # RUN 6: Metric test - captures custom metric
+            # ==========================================
 
-        Write-Host "Running metric-capture test on $Platform..." -ForegroundColor Yellow
-        $global:iOSMetricResult = Invoke-iOSTestAction -Arguments @(
-            '-metric-capture',
-            "$script:SentrySettings`:BeforeMetricHandler=/Script/SentryPlayground.CppBeforeMetricHandler"
-        )
+            Write-Host "Running metric-capture test on $Platform..." -ForegroundColor Yellow
+            $global:iOSMetricResult = Invoke-iOSTestAction -Arguments @(
+                '-metric-capture',
+                "$script:SentrySettings`:BeforeMetricHandler=/Script/SentryPlayground.CppBeforeMetricHandler"
+            )
 
-        Write-Host "Metric test exit code: $($global:iOSMetricResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Metric test exit code: $($global:iOSMetricResult.ExitCode)" -ForegroundColor Cyan
 
-        # ==========================================
-        # RUN 7: Tracing test - captures transaction
-        # ==========================================
+            # ==========================================
+            # RUN 7: Tracing test - captures transaction
+            # ==========================================
 
-        Write-Host "Running tracing-capture test on $Platform..." -ForegroundColor Yellow
-        $global:iOSTracingResult = Invoke-iOSTestAction -Arguments @(
-            '-tracing-capture',
-            "$script:SentrySettings`:EnableTracing=True",
-            "$script:SentrySettings`:SamplingType=TracesSampler",
-            "$script:SentrySettings`:TracesSampler=/Script/SentryPlayground.CppTraceSampler"
-        )
+            Write-Host "Running tracing-capture test on $Platform..." -ForegroundColor Yellow
+            $global:iOSTracingResult = Invoke-iOSTestAction -Arguments @(
+                '-tracing-capture',
+                "$script:SentrySettings`:EnableTracing=True",
+                "$script:SentrySettings`:SamplingType=TracesSampler",
+                "$script:SentrySettings`:TracesSampler=/Script/SentryPlayground.CppTraceSampler"
+            )
 
-        Write-Host "Tracing test exit code: $($global:iOSTracingResult.ExitCode)" -ForegroundColor Cyan
+            Write-Host "Tracing test exit code: $($global:iOSTracingResult.ExitCode)" -ForegroundColor Cyan
+        }
+        finally {
+            Write-Host "Disconnecting from $Platform..." -ForegroundColor Yellow
+            Disconnect-Device
+        }
     }
 
     AfterAll {
-        # Disconnect from iOS device
-        Write-Host "Disconnecting from $Platform..." -ForegroundColor Yellow
-        Disconnect-Device
-
         Write-Host "Integration tests complete on $Platform" -ForegroundColor Green
     }
 


### PR DESCRIPTION
This PR groups a few CI maintenance changes: extracting the packaging job into its own callable workflow, plus the three review comments from #1565.

### Key changes

- **Packaging workflow** - `package-preparation` moved from `ci.yml` into `package.yml` since it had grown to ~160 lines after macOS binaries notarization landed (#1566).
- **Unused `GITHUB_TOKEN`** - dropped from the Android and iOS integration test jobs as nothing reads it
- **SauceLabs env scope** - moved from job level into the one step that uses it
- **Test device lifecycle** - `Disconnect-Device` ran in `AfterAll` holding the SauceLabs session through the whole Sentry polling phase. Now released in a `finally` right after the last run

#skip-changelog
