### PR TITLE
chore: Update app-runner module

### DIFF
--- a/integration-test/CMakeLists.txt
+++ b/integration-test/CMakeLists.txt
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
     app-runner
     GIT_REPOSITORY https://github.com/getsentry/app-runner.git
-    GIT_TAG 9810e633f91fa168fb42fd245b81387aaffc4cc2
+    GIT_TAG 0ff6656314b1efd008e9ac6d43f914670c59ff10
 )
 
 FetchContent_MakeAvailable(app-runner)


### PR DESCRIPTION
This PR updates the app-runner module to bring in fixes that should improve the stability of integration tests running on Sauce Labs devices (https://github.com/getsentry/app-runner/pull/59).

#skip-changelog