### PR TITLE
Reduce overhead when reading event and scope data on native platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Fixes
+
+- Reduce overhead when reading event and scope data on native platforms ([#1576](https://github.com/getsentry/sentry-unreal/pull/1576))
+
 ### Dependencies
 
 - Bump Java SDK from v8.55.0 to v8.56.0 ([#1575](https://github.com/getsentry/sentry-unreal/pull/1575))

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
@@ -5,7 +5,6 @@
 #include "SentryDefines.h"
 
 #include "Dom/JsonObject.h"
-#include "Serialization/JsonReader.h"
 #include "Serialization/JsonSerializer.h"
 #include "Serialization/JsonWriter.h"
 #include "UObject/Class.h"
@@ -354,35 +353,15 @@ TMap<FString, FSentryVariant> FGenericPlatformSentryConverters::VariantMapToUnre
 {
 	TMap<FString, FSentryVariant> unrealMap;
 
-	char* jsonString = sentry_value_to_json(map);
-	if (!jsonString)
+	const sentry_value_foreach_key_value_function_t addPair = [](const char* key, sentry_value_t value, void* userdata) -> int
 	{
-		return unrealMap;
-	}
+		auto* outMap = static_cast<TMap<FString, FSentryVariant>*>(userdata);
+		outMap->Add(UTF8_TO_TCHAR(key), VariantToUnreal(value));
+		return 0;
+	};
 
-	FString mapJsonString = FString(UTF8_TO_TCHAR(jsonString));
-	if (mapJsonString.IsEmpty() || mapJsonString.Equals(TEXT("null")))
-	{
-		sentry_string_free(jsonString);
-		return unrealMap;
-	}
+	sentry_value_foreach_key_value(map, addPair, &unrealMap);
 
-	TSharedPtr<FJsonObject> jsonObject;
-	TSharedRef<TJsonReader<>> jsonReader = TJsonReaderFactory<>::Create(mapJsonString);
-	bool bDeserializeSuccess = FJsonSerializer::Deserialize(jsonReader, jsonObject);
-	if (!bDeserializeSuccess)
-	{
-		UE_LOG(LogSentrySdk, Error, TEXT("VariantToUnreal failed to deserialize map Json."));
-		sentry_string_free(jsonString);
-		return unrealMap;
-	}
-
-	for (const auto& pair : jsonObject->Values)
-	{
-		unrealMap.Add(FString(*pair.Key), VariantToUnreal(sentry_value_get_by_key(map, TCHAR_TO_UTF8(*pair.Key))));
-	}
-
-	sentry_string_free(jsonString);
 	return unrealMap;
 }
 
@@ -403,36 +382,15 @@ TMap<FString, FString> FGenericPlatformSentryConverters::StringMapToUnreal(sentr
 {
 	TMap<FString, FString> unrealMap;
 
-	char* jsonString = sentry_value_to_json(map);
-	if (!jsonString)
+	const sentry_value_foreach_key_value_function_t addPair = [](const char* key, sentry_value_t value, void* userdata) -> int
 	{
-		return unrealMap;
-	}
+		auto* outMap = static_cast<TMap<FString, FString>*>(userdata);
+		outMap->Add(UTF8_TO_TCHAR(key), UTF8_TO_TCHAR(sentry_value_as_string(value)));
+		return 0;
+	};
 
-	FString mapJsonString = FString(UTF8_TO_TCHAR(jsonString));
-	if (mapJsonString.IsEmpty() || mapJsonString.Equals(TEXT("null")))
-	{
-		sentry_string_free(jsonString);
-		return unrealMap;
-	}
+	sentry_value_foreach_key_value(map, addPair, &unrealMap);
 
-	TSharedPtr<FJsonObject> jsonObject;
-	TSharedRef<TJsonReader<>> jsonReader = TJsonReaderFactory<>::Create(mapJsonString);
-	bool bDeserializeSuccess = FJsonSerializer::Deserialize(jsonReader, jsonObject);
-	if (!bDeserializeSuccess)
-	{
-		UE_LOG(LogSentrySdk, Error, TEXT("StringMapToUnreal failed to deserialize map Json."));
-		sentry_string_free(jsonString);
-		return unrealMap;
-	}
-
-	for (const auto& pair : jsonObject->Values)
-	{
-		FString key(*pair.Key);
-		unrealMap.Add(key, jsonObject->GetStringField(key));
-	}
-
-	sentry_string_free(jsonString);
 	return unrealMap;
 }
 

--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/Infrastructure/GenericPlatformSentryConverters.cpp
@@ -353,14 +353,12 @@ TMap<FString, FSentryVariant> FGenericPlatformSentryConverters::VariantMapToUnre
 {
 	TMap<FString, FSentryVariant> unrealMap;
 
-	const sentry_value_foreach_key_value_function_t addPair = [](const char* key, sentry_value_t value, void* userdata) -> int
+	sentry_value_foreach_key_value(map, [](const char* key, sentry_value_t value, void* userdata)
 	{
 		auto* outMap = static_cast<TMap<FString, FSentryVariant>*>(userdata);
 		outMap->Add(UTF8_TO_TCHAR(key), VariantToUnreal(value));
 		return 0;
-	};
-
-	sentry_value_foreach_key_value(map, addPair, &unrealMap);
+	}, &unrealMap);
 
 	return unrealMap;
 }
@@ -382,14 +380,12 @@ TMap<FString, FString> FGenericPlatformSentryConverters::StringMapToUnreal(sentr
 {
 	TMap<FString, FString> unrealMap;
 
-	const sentry_value_foreach_key_value_function_t addPair = [](const char* key, sentry_value_t value, void* userdata) -> int
+	sentry_value_foreach_key_value(map, [](const char* key, sentry_value_t value, void* userdata)
 	{
 		auto* outMap = static_cast<TMap<FString, FString>*>(userdata);
 		outMap->Add(UTF8_TO_TCHAR(key), UTF8_TO_TCHAR(sentry_value_as_string(value)));
 		return 0;
-	};
-
-	sentry_value_foreach_key_value(map, addPair, &unrealMap);
+	}, &unrealMap);
 
 	return unrealMap;
 }


### PR DESCRIPTION
This PR reduces the cost of reading event and scope data on `sentry-native` platforms by adopting the `sentry_value_foreach_key_value` API.

`VariantMapToUnreal` and `StringMapToUnreal` serialized the whole native value to JSON and parsed it with `FJsonSerializer` purely to obtain the key list, then looked each key back up in the native value. Iterating the object directly makes that unnecessary.

### Key changes

* Replace the JSON round-trip in `VariantMapToUnreal` and `StringMapToUnreal` with `sentry_value_foreach_key_value`.
* Remove the quadratic cost on nested maps, where each nesting level re-serialized its entire subtree.
* Drop the now-unused `Serialization/JsonReader.h` include.

This affects the getters behind `GetTags`, `GetContext`, `GetExtras`, breadcrumb `GetData` and `GetCustomSamplingContext` (i.e. the `beforeSend` and `beforeBreadcrumb` paths), which run on the erroring thread.

### Additional Notes

`StringMapToUnreal` now yields an empty string for non-string entries, where UE's JSON reader used to coerce numbers and booleans via `FString::SanitizeFloat`. That coercion was incidental rather than intentional, and the case is unreachable in practice: `SetTag`/`SetTags`/`SetData` are all `FString`-typed, and sentry-native only ever stores string tags. Noted here
rather than worked around.

`VariantMapToUnreal` is unaffected as it always read values natively, so all types are preserved exactly as before.

### Related Items

- getsentry/sentry-native#2032