### PR TITLE
Use native setter for event level on desktop and consoles

### DIFF
--- a/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/GenericPlatform/GenericPlatformSentryEvent.cpp
@@ -54,9 +54,7 @@ FString FGenericPlatformSentryEvent::GetMessage() const
 
 void FGenericPlatformSentryEvent::SetLevel(ESentryLevel level)
 {
-	FString levelStr = FGenericPlatformSentryConverters::SentryLevelToString(level).ToLower();
-	if (!levelStr.IsEmpty())
-		sentry_value_set_by_key(Event, "level", sentry_value_new_string(TCHAR_TO_UTF8(*levelStr)));
+	sentry_event_set_level(Event, FGenericPlatformSentryConverters::SentryLevelToNative(level));
 }
 
 ESentryLevel FGenericPlatformSentryEvent::GetLevel() const


### PR DESCRIPTION
This PR replaces the manual `"level"` protocol field write in `FGenericPlatformSentryEvent::SetLevel` with the dedicated `sentry_event_set_level` API added in sentry-native 0.16.6 via getsentry/sentry-native#2038.

Previously the level was assigned by converting `ESentryLevel` to its lowercased enum name and setting the `"level"` key on the event value directly. The new API does exactly that internally, so behavior is unchanged and the protocol detail now lives in sentry-native instead of the plugin. The conversion still goes through the existing `SentryLevelToNative` converter.

Apple and Android are unaffected; they already set the level through per-event native APIs.

#skip-changelog
