### PR TITLE
Add hint support for macOS/iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+### Features
+
+- Add hint support for macOS/iOS ([#1577](https://github.com/getsentry/sentry-unreal/pull/1577))
+
 ### Fixes
 
 - Reduce overhead when reading event and scope data on native platforms ([#1576](https://github.com/getsentry/sentry-unreal/pull/1576))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Features
 
-- Add hint support for macOS/iOS ([#1577](https://github.com/getsentry/sentry-unreal/pull/1577))
+- Add hint support for macOS/iOS ([#1578](https://github.com/getsentry/sentry-unreal/pull/1578))
 
 ### Fixes
 

--- a/integration-test/Integration.Android.Tests.ps1
+++ b/integration-test/Integration.Android.Tests.ps1
@@ -122,6 +122,9 @@ BeforeAll {
 
     $script:PackageName = "io.sentry.unreal.sample"
     $script:ActivityName = "$script:PackageName/com.epicgames.unreal.GameActivity"
+
+    # Project setting overrides shared by every scenario, appended to each scenario's intent extras
+    $script:BaseAppArgs = "\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableAutoLogAttachment=True"
 }
 
 Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTargets {
@@ -142,7 +145,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # The crash is captured but NOT uploaded yet (Android behavior).
 
             Write-Host "Running crash-capture test (will crash) on $Platform..." -ForegroundColor Yellow
-            $crashIntentArgs = "-e cmdline -crash-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableAutoLogAttachment=True"
+            $crashIntentArgs = "-e cmdline -crash-capture$script:BaseAppArgs"
             $global:AndroidCrashResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $crashIntentArgs
 
             Write-Host "Crash test exit code: $($global:AndroidCrashResult.ExitCode)" -ForegroundColor Cyan
@@ -155,7 +158,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # -init-only allows starting the app to flush captured events and quit right after.
 
             Write-Host "Running init-only to flush crash event on $Platform..." -ForegroundColor Yellow
-            $initOnlyIntentArgs = "-e cmdline -init-only\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableAutoLogAttachment=True"
+            $initOnlyIntentArgs = "-e cmdline -init-only$script:BaseAppArgs"
             $global:AndroidInitOnlyResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $initOnlyIntentArgs
 
             Write-Host "Init-only exit code: $($global:AndroidInitOnlyResult.ExitCode)" -ForegroundColor Cyan
@@ -165,7 +168,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # ==========================================
 
             Write-Host "Running message-capture test on $Platform..." -ForegroundColor Yellow
-            $messageIntentArgs = "-e cmdline -message-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeSendHandler=/Script/SentryPlayground.CppBeforeSendHandler\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeBreadcrumbHandler=/Script/SentryPlayground.CppBeforeBreadcrumbHandler"
+            $messageIntentArgs = "-e cmdline -message-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeSendHandler=/Script/SentryPlayground.CppBeforeSendHandler\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeBreadcrumbHandler=/Script/SentryPlayground.CppBeforeBreadcrumbHandler$script:BaseAppArgs"
             $global:AndroidMessageResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $messageIntentArgs
 
             Write-Host "Message test exit code: $($global:AndroidMessageResult.ExitCode)" -ForegroundColor Cyan
@@ -175,7 +178,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # ==========================================
 
             Write-Host "Running feedback-capture test on $Platform..." -ForegroundColor Yellow
-            $feedbackIntentArgs = "-e cmdline -feedback-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeSendFeedbackHandler=/Script/SentryPlayground.CppBeforeSendFeedbackHandler"
+            $feedbackIntentArgs = "-e cmdline -feedback-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeSendFeedbackHandler=/Script/SentryPlayground.CppBeforeSendFeedbackHandler$script:BaseAppArgs"
             $global:AndroidFeedbackResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $feedbackIntentArgs
 
             Write-Host "Feedback test exit code: $($global:AndroidFeedbackResult.ExitCode)" -ForegroundColor Cyan
@@ -185,7 +188,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # ==========================================
 
             Write-Host "Running log-capture test on $Platform..." -ForegroundColor Yellow
-            $logIntentArgs = "-e cmdline -log-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeLogHandler=/Script/SentryPlayground.CppBeforeLogHandler"
+            $logIntentArgs = "-e cmdline -log-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeLogHandler=/Script/SentryPlayground.CppBeforeLogHandler$script:BaseAppArgs"
             $global:AndroidLogResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $logIntentArgs
 
             Write-Host "Log test exit code: $($global:AndroidLogResult.ExitCode)" -ForegroundColor Cyan
@@ -195,7 +198,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # ==========================================
 
             Write-Host "Running metric-capture test on $Platform..." -ForegroundColor Yellow
-            $metricIntentArgs = "-e cmdline -metric-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeMetricHandler=/Script/SentryPlayground.CppBeforeMetricHandler"
+            $metricIntentArgs = "-e cmdline -metric-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:BeforeMetricHandler=/Script/SentryPlayground.CppBeforeMetricHandler$script:BaseAppArgs"
             $global:AndroidMetricResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $metricIntentArgs
 
             Write-Host "Metric test exit code: $($global:AndroidMetricResult.ExitCode)" -ForegroundColor Cyan
@@ -205,7 +208,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # ==========================================
 
             Write-Host "Running tracing-capture test on $Platform..." -ForegroundColor Yellow
-            $tracingIntentArgs = "-e cmdline -tracing-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableTracing=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:SamplingType=TracesSampler\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:TracesSampler=/Script/SentryPlayground.CppTraceSampler"
+            $tracingIntentArgs = "-e cmdline -tracing-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableTracing=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:SamplingType=TracesSampler\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:TracesSampler=/Script/SentryPlayground.CppTraceSampler$script:BaseAppArgs"
             $global:AndroidTracingResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $tracingIntentArgs
 
             Write-Host "Tracing test exit code: $($global:AndroidTracingResult.ExitCode)" -ForegroundColor Cyan
@@ -215,7 +218,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # ==========================================
 
             Write-Host "Running hang-capture test on $Platform..." -ForegroundColor Yellow
-            $hangIntentArgs = "-e cmdline -hang-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableHangTracking=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:UseNativeHangTracking=True"
+            $hangIntentArgs = "-e cmdline -hang-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableHangTracking=True\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:UseNativeHangTracking=True$script:BaseAppArgs"
             $global:AndroidHangResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $hangIntentArgs
 
             Write-Host "Hang test exit code: $($global:AndroidHangResult.ExitCode)" -ForegroundColor Cyan
@@ -236,6 +239,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # But the crash_id comes from the CRASH run (Run 1)
             $script:CrashResult = $global:AndroidCrashResult
             $script:CrashEvent = $null
+            $script:CrashAttachments = @()
     
             # Parse crash event ID from crash run output
             $eventIds = Get-EventIds -AppOutput $script:CrashResult.Output -ExpectedCount 1
@@ -251,6 +255,15 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
                 }
                 catch {
                     Write-Host "Failed to fetch crash event from Sentry: $_" -ForegroundColor Red
+                }
+
+                if ($script:CrashEvent) {
+                    try {
+                        $script:CrashAttachments = Get-SentryTestEventAttachments -EventId $script:CrashEvent.id
+                    }
+                    catch {
+                        Write-Host "Failed to fetch crash event attachments from Sentry: $_" -ForegroundColor Red
+                    }
                 }
             }
             else {
@@ -309,8 +322,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
         }
 
         It "Should have game log attached to the crash event" {
-            $attachments = Get-SentryTestEventAttachments -EventId $script:CrashEvent.id
-            $attachments | Where-Object { $_.name -like '*.log' } | Should -Not -BeNullOrEmpty
+            $script:CrashAttachments | Where-Object { $_.name -like '*.log' } | Should -Not -BeNullOrEmpty
         }
     }
 

--- a/integration-test/Integration.Android.Tests.ps1
+++ b/integration-test/Integration.Android.Tests.ps1
@@ -142,7 +142,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # The crash is captured but NOT uploaded yet (Android behavior).
 
             Write-Host "Running crash-capture test (will crash) on $Platform..." -ForegroundColor Yellow
-            $crashIntentArgs = "-e cmdline -crash-capture"
+            $crashIntentArgs = "-e cmdline -crash-capture\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableAutoLogAttachment=True"
             $global:AndroidCrashResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $crashIntentArgs
 
             Write-Host "Crash test exit code: $($global:AndroidCrashResult.ExitCode)" -ForegroundColor Cyan
@@ -155,7 +155,7 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
             # -init-only allows starting the app to flush captured events and quit right after.
 
             Write-Host "Running init-only to flush crash event on $Platform..." -ForegroundColor Yellow
-            $initOnlyIntentArgs = "-e cmdline -init-only"
+            $initOnlyIntentArgs = "-e cmdline -init-only\ -ini:Engine:\[/Script/Sentry.SentrySettings\]:EnableAutoLogAttachment=True"
             $global:AndroidInitOnlyResult = Invoke-DeviceApp -ExecutablePath $script:ActivityName -Arguments $initOnlyIntentArgs
 
             Write-Host "Init-only exit code: $($global:AndroidInitOnlyResult.ExitCode)" -ForegroundColor Cyan
@@ -306,6 +306,11 @@ Describe 'Sentry Unreal Android Integration Tests (<Platform>)' -ForEach $TestTa
         It "Should have breadcrumbs from before crash" {
             $script:CrashEvent.breadcrumbs | Should -Not -BeNullOrEmpty
             $script:CrashEvent.breadcrumbs.values | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have game log attached to the crash event" {
+            $attachments = Get-SentryTestEventAttachments -EventId $script:CrashEvent.id
+            $attachments | Where-Object { $_.name -like '*.log' } | Should -Not -BeNullOrEmpty
         }
     }
 

--- a/integration-test/Integration.Desktop.Tests.ps1
+++ b/integration-test/Integration.Desktop.Tests.ps1
@@ -293,6 +293,12 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
             $modified | Should -Not -BeNullOrEmpty
             $modified.data.handler_key | Should -Be 'handler_value'
         }
+
+        # Memory exhaustion makes attachment delivery unreliable, so OOM is left out
+        It "Should have game log attached to the crash event" -Skip:($Name -eq 'OutOfMemory') {
+            $attachments = Get-SentryTestEventAttachments -EventId $script:CrashEvent.id
+            $attachments | Where-Object { $_.name -like '*.log' } | Should -Not -BeNullOrEmpty
+        }
     }
 
     Context "Ensure Capture Tests" {

--- a/integration-test/Integration.Desktop.Tests.ps1
+++ b/integration-test/Integration.Desktop.Tests.ps1
@@ -179,6 +179,7 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
 
             $script:CrashResult = $null
             $script:CrashEvent = $null
+            $script:CrashAttachments = @()
 
             Write-Host "Running $crashTypeName crash test..." -ForegroundColor Yellow
 
@@ -218,6 +219,15 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
                 }
                 catch {
                     Write-Host "Failed to fetch event from Sentry: $_" -ForegroundColor Red
+                }
+
+                if ($script:CrashEvent) {
+                    try {
+                        $script:CrashAttachments = Get-SentryTestEventAttachments -EventId $script:CrashEvent.id
+                    }
+                    catch {
+                        Write-Host "Failed to fetch crash event attachments from Sentry: $_" -ForegroundColor Red
+                    }
                 }
             }
             else {
@@ -294,10 +304,8 @@ Describe "Sentry Unreal Desktop Integration Tests (<Platform>)" -ForEach $TestTa
             $modified.data.handler_key | Should -Be 'handler_value'
         }
 
-        # Memory exhaustion makes attachment delivery unreliable, so OOM is left out
-        It "Should have game log attached to the crash event" -Skip:($Name -eq 'OutOfMemory') {
-            $attachments = Get-SentryTestEventAttachments -EventId $script:CrashEvent.id
-            $attachments | Where-Object { $_.name -like '*.log' } | Should -Not -BeNullOrEmpty
+        It "Should have game log attached to the crash event" {
+            $script:CrashAttachments | Where-Object { $_.name -like '*.log' } | Should -Not -BeNullOrEmpty
         }
     }
 

--- a/integration-test/Integration.iOS.Tests.ps1
+++ b/integration-test/Integration.iOS.Tests.ps1
@@ -93,6 +93,11 @@ BeforeAll {
 
     $script:SentrySettings = '-ini:Engine:[/Script/Sentry.SentrySettings]'
 
+    # Project setting overrides shared by every scenario
+    $script:BaseAppArgs = @(
+        "$script:SentrySettings`:EnableAutoLogAttachment=True"  # Enables log attachment
+    )
+
     # Launch the app on the connected device and return its captured output
     function Invoke-iOSTestAction {
         param (
@@ -126,10 +131,7 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
             # The crash is captured but NOT uploaded yet (Cocoa behavior).
 
             Write-Host "Running crash-capture test (will crash) on $Platform..." -ForegroundColor Yellow
-            $global:iOSCrashResult = Invoke-iOSTestAction -Arguments @(
-                '-crash-capture',
-                "$script:SentrySettings`:EnableAutoLogAttachment=True"
-            )
+            $global:iOSCrashResult = Invoke-iOSTestAction -Arguments (@('-crash-capture') + $script:BaseAppArgs)
 
             Write-Host "Crash test exit code: $($global:iOSCrashResult.ExitCode)" -ForegroundColor Cyan
 
@@ -139,10 +141,7 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
             # Cocoa sends crash reports on the next app launch, so run the app again to upload it.
 
             Write-Host "Running init-only to flush crash event on $Platform..." -ForegroundColor Yellow
-            $global:iOSInitOnlyResult = Invoke-iOSTestAction -Arguments @(
-                '-init-only',
-                "$script:SentrySettings`:EnableAutoLogAttachment=True"
-            )
+            $global:iOSInitOnlyResult = Invoke-iOSTestAction -Arguments (@('-init-only') + $script:BaseAppArgs)
 
             Write-Host "Init-only exit code: $($global:iOSInitOnlyResult.ExitCode)" -ForegroundColor Cyan
 
@@ -151,11 +150,11 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
             # ==========================================
 
             Write-Host "Running message-capture test on $Platform..." -ForegroundColor Yellow
-            $global:iOSMessageResult = Invoke-iOSTestAction -Arguments @(
+            $global:iOSMessageResult = Invoke-iOSTestAction -Arguments (@(
                 '-message-capture',
                 "$script:SentrySettings`:BeforeSendHandler=/Script/SentryPlayground.CppBeforeSendHandler",
                 "$script:SentrySettings`:BeforeBreadcrumbHandler=/Script/SentryPlayground.CppBeforeBreadcrumbHandler"
-            )
+            ) + $script:BaseAppArgs)
 
             Write-Host "Message test exit code: $($global:iOSMessageResult.ExitCode)" -ForegroundColor Cyan
 
@@ -164,10 +163,10 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
             # ==========================================
 
             Write-Host "Running feedback-capture test on $Platform..." -ForegroundColor Yellow
-            $global:iOSFeedbackResult = Invoke-iOSTestAction -Arguments @(
+            $global:iOSFeedbackResult = Invoke-iOSTestAction -Arguments (@(
                 '-feedback-capture',
                 "$script:SentrySettings`:BeforeSendFeedbackHandler=/Script/SentryPlayground.CppBeforeSendFeedbackHandler"
-            )
+            ) + $script:BaseAppArgs)
 
             Write-Host "Feedback test exit code: $($global:iOSFeedbackResult.ExitCode)" -ForegroundColor Cyan
 
@@ -176,10 +175,10 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
             # ==========================================
 
             Write-Host "Running log-capture test on $Platform..." -ForegroundColor Yellow
-            $global:iOSLogResult = Invoke-iOSTestAction -Arguments @(
+            $global:iOSLogResult = Invoke-iOSTestAction -Arguments (@(
                 '-log-capture',
                 "$script:SentrySettings`:BeforeLogHandler=/Script/SentryPlayground.CppBeforeLogHandler"
-            )
+            ) + $script:BaseAppArgs)
 
             Write-Host "Log test exit code: $($global:iOSLogResult.ExitCode)" -ForegroundColor Cyan
 
@@ -188,10 +187,10 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
             # ==========================================
 
             Write-Host "Running metric-capture test on $Platform..." -ForegroundColor Yellow
-            $global:iOSMetricResult = Invoke-iOSTestAction -Arguments @(
+            $global:iOSMetricResult = Invoke-iOSTestAction -Arguments (@(
                 '-metric-capture',
                 "$script:SentrySettings`:BeforeMetricHandler=/Script/SentryPlayground.CppBeforeMetricHandler"
-            )
+            ) + $script:BaseAppArgs)
 
             Write-Host "Metric test exit code: $($global:iOSMetricResult.ExitCode)" -ForegroundColor Cyan
 
@@ -200,12 +199,12 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
             # ==========================================
 
             Write-Host "Running tracing-capture test on $Platform..." -ForegroundColor Yellow
-            $global:iOSTracingResult = Invoke-iOSTestAction -Arguments @(
+            $global:iOSTracingResult = Invoke-iOSTestAction -Arguments (@(
                 '-tracing-capture',
                 "$script:SentrySettings`:EnableTracing=True",
                 "$script:SentrySettings`:SamplingType=TracesSampler",
                 "$script:SentrySettings`:TracesSampler=/Script/SentryPlayground.CppTraceSampler"
-            )
+            ) + $script:BaseAppArgs)
 
             Write-Host "Tracing test exit code: $($global:iOSTracingResult.ExitCode)" -ForegroundColor Cyan
         }
@@ -225,6 +224,7 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
             # But the crash_id comes from the CRASH run (Run 1)
             $script:CrashResult = $global:iOSCrashResult
             $script:CrashEvent = $null
+            $script:CrashAttachments = @()
 
             # Parse crash event ID from crash run output
             $eventIds = Get-EventIds -AppOutput $script:CrashResult.Output -ExpectedCount 1
@@ -240,6 +240,15 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
                 }
                 catch {
                     Write-Host "Failed to fetch crash event from Sentry: $_" -ForegroundColor Red
+                }
+
+                if ($script:CrashEvent) {
+                    try {
+                        $script:CrashAttachments = Get-SentryTestEventAttachments -EventId $script:CrashEvent.id
+                    }
+                    catch {
+                        Write-Host "Failed to fetch crash event attachments from Sentry: $_" -ForegroundColor Red
+                    }
                 }
             }
             else {
@@ -298,8 +307,7 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
         }
 
         It "Should have game log attached to the crash event" {
-            $attachments = Get-SentryTestEventAttachments -EventId $script:CrashEvent.id
-            $attachments | Where-Object { $_.name -like '*.log' } | Should -Not -BeNullOrEmpty
+            $script:CrashAttachments | Where-Object { $_.name -like '*.log' } | Should -Not -BeNullOrEmpty
         }
     }
 

--- a/integration-test/Integration.iOS.Tests.ps1
+++ b/integration-test/Integration.iOS.Tests.ps1
@@ -126,7 +126,10 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
             # The crash is captured but NOT uploaded yet (Cocoa behavior).
 
             Write-Host "Running crash-capture test (will crash) on $Platform..." -ForegroundColor Yellow
-            $global:iOSCrashResult = Invoke-iOSTestAction -Arguments @('-crash-capture')
+            $global:iOSCrashResult = Invoke-iOSTestAction -Arguments @(
+                '-crash-capture',
+                "$script:SentrySettings`:EnableAutoLogAttachment=True"
+            )
 
             Write-Host "Crash test exit code: $($global:iOSCrashResult.ExitCode)" -ForegroundColor Cyan
 
@@ -136,7 +139,10 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
             # Cocoa sends crash reports on the next app launch, so run the app again to upload it.
 
             Write-Host "Running init-only to flush crash event on $Platform..." -ForegroundColor Yellow
-            $global:iOSInitOnlyResult = Invoke-iOSTestAction -Arguments @('-init-only')
+            $global:iOSInitOnlyResult = Invoke-iOSTestAction -Arguments @(
+                '-init-only',
+                "$script:SentrySettings`:EnableAutoLogAttachment=True"
+            )
 
             Write-Host "Init-only exit code: $($global:iOSInitOnlyResult.ExitCode)" -ForegroundColor Cyan
 
@@ -289,6 +295,11 @@ Describe 'Sentry Unreal iOS Integration Tests (<Platform>)' -ForEach $TestTarget
         It "Should have breadcrumbs from before crash" {
             $script:CrashEvent.breadcrumbs | Should -Not -BeNullOrEmpty
             $script:CrashEvent.breadcrumbs.values | Should -Not -BeNullOrEmpty
+        }
+
+        It "Should have game log attached to the crash event" {
+            $attachments = Get-SentryTestEventAttachments -EventId $script:CrashEvent.id
+            $attachments | Where-Object { $_.name -like '*.log' } | Should -Not -BeNullOrEmpty
         }
     }
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
@@ -195,8 +195,6 @@ TMap<FString, FSentryVariant> FAppleSentryEvent::GetExtras() const
 
 bool FAppleSentryEvent::IsCrash() const
 {
-	// Cocoa's `isFatalEvent` isn't public, so an unhandled mechanism is used to identify a fatal event
-	// restored from the previous app run. Events captured while running carry no mechanism at all.
 	if (EventApple.exceptions == nil)
 	{
 		return false;

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
@@ -195,7 +195,25 @@ TMap<FString, FSentryVariant> FAppleSentryEvent::GetExtras() const
 
 bool FAppleSentryEvent::IsCrash() const
 {
-	return EventApple.error != nullptr;
+	// Cocoa marks crash events internally via `isFatalEvent` which isn't part of its public API, so the
+	// event is classified by its exception mechanism instead. An unhandled mechanism identifies a fatal
+	// event restored from the previous app run - a crash, a watchdog termination or a fatal app hang.
+	// Events captured while the app is running (errors, exceptions, ensures) carry no mechanism at all.
+	// This matches how `SentryEvent.isCrashed()` is defined in the Java SDK.
+	if (EventApple.exceptions == nil)
+	{
+		return false;
+	}
+
+	for (SentryObjCException* exception in EventApple.exceptions)
+	{
+		if (exception.mechanism != nil && exception.mechanism.handled != nil && ![exception.mechanism.handled boolValue])
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 TSharedPtr<ISentryFeedback> FAppleSentryEvent::GetFeedback() const

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryEvent.cpp
@@ -195,11 +195,8 @@ TMap<FString, FSentryVariant> FAppleSentryEvent::GetExtras() const
 
 bool FAppleSentryEvent::IsCrash() const
 {
-	// Cocoa marks crash events internally via `isFatalEvent` which isn't part of its public API, so the
-	// event is classified by its exception mechanism instead. An unhandled mechanism identifies a fatal
-	// event restored from the previous app run - a crash, a watchdog termination or a fatal app hang.
-	// Events captured while the app is running (errors, exceptions, ensures) carry no mechanism at all.
-	// This matches how `SentryEvent.isCrashed()` is defined in the Java SDK.
+	// Cocoa's `isFatalEvent` isn't public, so an unhandled mechanism is used to identify a fatal event
+	// restored from the previous app run. Events captured while running carry no mechanism at all.
 	if (EventApple.exceptions == nil)
 	{
 		return false;

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryHint.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryHint.cpp
@@ -43,8 +43,6 @@ void FAppleSentryHint::AddAttachment(TSharedPtr<ISentryAttachment> attachment)
 		return;
 	}
 
-	// Cocoa exposes the hint's attachments as a copied array property rather than an `addAttachment`
-	// method, so a new array has to be assigned in order to append to it.
 	HintApple.attachments = [HintApple.attachments arrayByAddingObject:nativeAttachment];
 }
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryHint.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryHint.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2026 Sentry. All Rights Reserved.
+
+#include "AppleSentryHint.h"
+
+#if !USE_SENTRY_NATIVE
+
+#include "AppleSentryAttachment.h"
+
+#include "Convenience/AppleSentryInclude.h"
+#include "Convenience/AppleSentryMacro.h"
+
+FAppleSentryHint::FAppleSentryHint()
+{
+	HintApple = [[SENTRY_APPLE_CLASS(SentryObjCHint) alloc] init];
+}
+
+FAppleSentryHint::FAppleSentryHint(SentryObjCHint* hint)
+{
+	HintApple = hint;
+}
+
+FAppleSentryHint::~FAppleSentryHint()
+{
+	// Put custom destructor logic here if needed
+}
+
+SentryObjCHint* FAppleSentryHint::GetNativeObject()
+{
+	return HintApple;
+}
+
+void FAppleSentryHint::AddAttachment(TSharedPtr<ISentryAttachment> attachment)
+{
+	TSharedPtr<FAppleSentryAttachment> attachmentApple = StaticCastSharedPtr<FAppleSentryAttachment>(attachment);
+	if (!attachmentApple)
+	{
+		return;
+	}
+
+	SentryObjCAttachment* nativeAttachment = attachmentApple->GetNativeObject();
+	if (nativeAttachment == nil)
+	{
+		return;
+	}
+
+	// Cocoa exposes the hint's attachments as a copied array property rather than an `addAttachment`
+	// method, so a new array has to be assigned in order to append to it.
+	HintApple.attachments = [HintApple.attachments arrayByAddingObject:nativeAttachment];
+}
+
+#endif // !USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentryHint.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentryHint.h
@@ -1,0 +1,28 @@
+// Copyright (c) 2026 Sentry. All Rights Reserved.
+
+#pragma once
+
+#if !USE_SENTRY_NATIVE
+
+#include "Interface/SentryHintInterface.h"
+
+@class SentryObjCHint;
+
+class FAppleSentryHint : public ISentryHint
+{
+public:
+	FAppleSentryHint();
+	FAppleSentryHint(SentryObjCHint* hint);
+	virtual ~FAppleSentryHint() override;
+
+	SentryObjCHint* GetNativeObject();
+
+	virtual void AddAttachment(TSharedPtr<ISentryAttachment> attachment) override;
+
+private:
+	SentryObjCHint* HintApple;
+};
+
+typedef FAppleSentryHint FPlatformSentryHint;
+
+#endif // !USE_SENTRY_NATIVE

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -8,6 +8,7 @@
 #include "AppleSentryBreadcrumb.h"
 #include "AppleSentryEvent.h"
 #include "AppleSentryFeedback.h"
+#include "AppleSentryHint.h"
 #include "AppleSentryId.h"
 #include "AppleSentryLog.h"
 #include "AppleSentryMetric.h"
@@ -25,6 +26,7 @@
 #include "SentryBreadcrumb.h"
 #include "SentryDefines.h"
 #include "SentryEvent.h"
+#include "SentryHint.h"
 #include "SentryLog.h"
 #include "SentryMetric.h"
 #include "SentrySamplingContext.h"
@@ -186,7 +188,11 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 			}
 			if (beforeBreadcrumbHandler != nullptr)
 			{
-				options.beforeBreadcrumb = ^SentryObjCBreadcrumb*(SentryObjCBreadcrumb* breadcrumb) {
+				// `beforeBreadcrumbWithHint` is deprecated on arrival in cocoa - the next major version adds the hint
+				// parameter to `beforeBreadcrumb` directly and removes this callback. Migrate once that lands.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+				options.beforeBreadcrumbWithHint = ^SentryObjCBreadcrumb*(SentryObjCBreadcrumb* breadcrumb, SentryObjCHint* hint) {
 					if (!SentryCallbackUtils::IsCallbackSafeToRun())
 					{
 						// Breadcrumb will be added without calling a `beforeBreadcrumb` handler
@@ -200,11 +206,13 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 					}
 
 					USentryBreadcrumb* BreadcrumbToProcess = USentryBreadcrumb::Create(MakeShareable(new FAppleSentryBreadcrumb(breadcrumb)));
+					USentryHint* HintToProcess = USentryHint::Create(MakeShareable(new FAppleSentryHint(hint)));
 
-					USentryBreadcrumb* ProcessedBreadcrumb = beforeBreadcrumbHandler->HandleBeforeBreadcrumb(BreadcrumbToProcess, nullptr);
+					USentryBreadcrumb* ProcessedBreadcrumb = beforeBreadcrumbHandler->HandleBeforeBreadcrumb(BreadcrumbToProcess, HintToProcess);
 
 					return ProcessedBreadcrumb ? breadcrumb : nullptr;
 				};
+#pragma clang diagnostic pop
 			}
 			if (beforeLogHandler != nullptr)
 			{
@@ -252,7 +260,11 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 			}
 			if (beforeSendHandler != nullptr)
 			{
-				options.beforeSend = ^SentryObjCEvent*(SentryObjCEvent* event) {
+				// `beforeSendWithHint` is deprecated on arrival in cocoa - the next major version adds the hint
+				// parameter to `beforeSend` directly and removes this callback. Migrate once that lands.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+				options.beforeSendWithHint = ^SentryObjCEvent*(SentryObjCEvent* event, SentryObjCHint* hint) {
 					if (!SentryCallbackUtils::IsCallbackSafeToRun())
 					{
 						// Event will be sent without calling a `onBeforeSend` handler
@@ -266,11 +278,13 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 					}
 
 					USentryEvent* EventToProcess = USentryEvent::Create(MakeShareable(new FAppleSentryEvent(event)));
+					USentryHint* HintToProcess = USentryHint::Create(MakeShareable(new FAppleSentryHint(hint)));
 
-					USentryEvent* ProcessedEvent = beforeSendHandler->HandleBeforeSend(EventToProcess, nullptr);
+					USentryEvent* ProcessedEvent = beforeSendHandler->HandleBeforeSend(EventToProcess, HintToProcess);
 
 					return ProcessedEvent ? event : nullptr;
 				};
+#pragma clang diagnostic pop
 			}
 		}];
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -244,12 +244,10 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 					return ProcessedMetric ? metric : nullptr;
 				};
 			}
-			// Set up unconditionally - the SDK uses this callback itself to attach the previous run's files
 			// Deprecated in cocoa: the next major version moves the hint parameter into `beforeSend`
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 			options.beforeSendWithHint = ^SentryObjCEvent*(SentryObjCEvent* event, SentryObjCHint* hint) {
-				// Added before the guards below so that a skipped user handler doesn't cost the attachments
 				FAppleSentryEvent eventApple(event);
 				if (eventApple.IsCrash())
 				{

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -118,9 +118,6 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 					}
 					return;
 				}
-				// The game log and screenshot captured during the previous app run are attached to the crash
-				// event from `beforeSendWithHint`, which runs before this callback and is the only place where
-				// they can still be added to the event's own envelope.
 				if (settings->AttachSessionReplay)
 				{
 					// Deliver the previous run's replay as a structured envelope so it shows
@@ -178,8 +175,7 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 			}
 			if (beforeBreadcrumbHandler != nullptr)
 			{
-				// `beforeBreadcrumbWithHint` is deprecated on arrival in cocoa - the next major version adds the hint
-				// parameter to `beforeBreadcrumb` directly and removes this callback. Migrate once that lands.
+				// Deprecated in cocoa: the next major version moves the hint parameter into `beforeBreadcrumb`
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 				options.beforeBreadcrumbWithHint = ^SentryObjCBreadcrumb*(SentryObjCBreadcrumb* breadcrumb, SentryObjCHint* hint) {
@@ -248,15 +244,12 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 					return ProcessedMetric ? metric : nullptr;
 				};
 			}
-			// This callback is set up unconditionally since the SDK relies on it itself to attach files captured
-			// during the previous app run to the crash event.
-			// `beforeSendWithHint` is deprecated on arrival in cocoa - the next major version adds the hint
-			// parameter to `beforeSend` directly and removes this callback. Migrate once that lands.
+			// Set up unconditionally - the SDK uses this callback itself to attach the previous run's files
+			// Deprecated in cocoa: the next major version moves the hint parameter into `beforeSend`
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 			options.beforeSendWithHint = ^SentryObjCEvent*(SentryObjCEvent* event, SentryObjCHint* hint) {
-				// Attachments are added before the guards below on purpose - a user handler that can't be
-				// invoked shouldn't cost the crash event its attachments.
+				// Added before the guards below so that a skipped user handler doesn't cost the attachments
 				FAppleSentryEvent eventApple(event);
 				if (eventApple.IsCrash())
 				{
@@ -772,8 +765,7 @@ void FAppleSentrySubsystem::AddCrashAttachmentsToHint(SentryObjCHint* hint) cons
 
 	IFileManager& fileManager = IFileManager::Get();
 
-	// For fatal events cocoa pre-populates the hint with the crash report's own attachments, so any file
-	// it already provided takes precedence over the ones captured by the plugin.
+	// Cocoa pre-populates the hint with the crash report's own attachments, which take precedence
 	TSet<FString> existingAttachments;
 	for (SentryObjCAttachment* attachment in hint.attachments)
 	{
@@ -784,8 +776,8 @@ void FAppleSentrySubsystem::AddCrashAttachmentsToHint(SentryObjCHint* hint) cons
 #if !NO_LOGGING
 	if (isGameLogAttachmentEnabled)
 	{
-		// Unreal creates game log backups automatically on every app run, so the most recent one holds the
-		// output of the run that crashed. The file belongs to the engine and is left in place after sending.
+		// Unreal creates game log backups on every app run, so the most recent one holds the crashed run's
+		// output. The file belongs to the engine and is left in place.
 		const FString& logFilePath = GetLatestGameLog();
 		const FString& logFileName = SentryFileUtils::GetGameLogName();
 
@@ -811,9 +803,8 @@ void FAppleSentrySubsystem::AddCrashAttachmentsToHint(SentryObjCHint* hint) cons
 		TArray<uint8> screenshotData;
 		const bool bScreenshotLoaded = FFileHelper::LoadFileToArray(screenshotData, *screenshotPath);
 
-		// Unlike the game log this file is created by the plugin, so it's removed once its contents have been
-		// read. The screenshot is attached as raw data rather than by path for the same reason: cocoa reads
-		// path-based attachments while building the envelope item, which happens after this callback returns.
+		// Attached as raw data rather than by path because the file is deleted here: cocoa reads path-based
+		// attachments while building the envelope item, which happens after this callback returns.
 		if (!fileManager.Delete(*screenshotPath))
 		{
 			UE_LOG(LogSentrySdk, Error, TEXT("Failed to delete screenshot attachment: %s"), *screenshotPath);

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -789,6 +789,8 @@ void FAppleSentrySubsystem::AddCrashAttachmentsToHint(SentryObjCHint* hint) cons
 			return;
 		}
 
+		// Attached as data, not by path - the file is deleted below and cocoa reads paths only later,
+		// when building the envelope item
 		TArray<uint8> screenshotData;
 		const bool bScreenshotLoaded = FFileHelper::LoadFileToArray(screenshotData, *screenshotPath);
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -763,23 +763,14 @@ void FAppleSentrySubsystem::AddCrashAttachmentsToHint(SentryObjCHint* hint) cons
 
 	IFileManager& fileManager = IFileManager::Get();
 
-	// Cocoa pre-populates the hint with the crash report's own attachments, which take precedence
-	TSet<FString> existingAttachments;
-	for (SentryObjCAttachment* attachment in hint.attachments)
-	{
-		existingAttachments.Add(FString(attachment.filename));
-	}
-
 	// If writing logs to a file is disabled (i.e. default behavior for Shipping builds) skip the attachment
 #if !NO_LOGGING
 	if (isGameLogAttachmentEnabled)
 	{
-		// Unreal creates game log backups on every app run, so the most recent one holds the crashed run's
-		// output. The file belongs to the engine and is left in place.
 		const FString& logFilePath = GetLatestGameLog();
 		const FString& logFileName = SentryFileUtils::GetGameLogName();
 
-		if (!logFilePath.IsEmpty() && fileManager.FileExists(*logFilePath) && !existingAttachments.Contains(logFileName))
+		if (!logFilePath.IsEmpty() && fileManager.FileExists(*logFilePath))
 		{
 			FAppleSentryAttachment logAttachment(fileManager.ConvertToAbsolutePathForExternalAppForRead(*logFilePath),
 				logFileName, TEXT("text/plain"));
@@ -801,8 +792,6 @@ void FAppleSentrySubsystem::AddCrashAttachmentsToHint(SentryObjCHint* hint) cons
 		TArray<uint8> screenshotData;
 		const bool bScreenshotLoaded = FFileHelper::LoadFileToArray(screenshotData, *screenshotPath);
 
-		// Attached as raw data rather than by path because the file is deleted here: cocoa reads path-based
-		// attachments while building the envelope item, which happens after this callback returns.
 		if (!fileManager.Delete(*screenshotPath))
 		{
 			UE_LOG(LogSentrySdk, Error, TEXT("Failed to delete screenshot attachment: %s"), *screenshotPath);
@@ -814,12 +803,9 @@ void FAppleSentrySubsystem::AddCrashAttachmentsToHint(SentryObjCHint* hint) cons
 			return;
 		}
 
-		if (!existingAttachments.Contains(TEXT("screenshot.png")))
-		{
-			FAppleSentryAttachment screenshotAttachment(screenshotData, TEXT("screenshot.png"), TEXT("image/png"));
+		FAppleSentryAttachment screenshotAttachment(screenshotData, TEXT("screenshot.png"), TEXT("image/png"));
 
-			hint.attachments = [hint.attachments arrayByAddingObject:screenshotAttachment.GetNativeObject()];
-		}
+		hint.attachments = [hint.attachments arrayByAddingObject:screenshotAttachment.GetNativeObject()];
 	}
 }
 

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.cpp
@@ -66,7 +66,6 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 	isScreenshotAttachmentEnabled = settings->AttachScreenshot;
 	isGameLogAttachmentEnabled = settings->EnableAutoLogAttachment;
 	isSessionReplayAttachmentEnabled = settings->AttachSessionReplay;
-	maxAttachmentSize = settings->MaxAttachmentSize;
 
 	FString prevSessionReplayPath;
 	FString prevSessionReplaySidecarPath;
@@ -119,18 +118,9 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 					}
 					return;
 				}
-				if (settings->AttachScreenshot)
-				{
-					// If a screenshot was captured during assertion/crash in the previous app run
-					// find the most recent one and upload it to Sentry.
-					UploadScreenshotForEvent(MakeShareable(new FAppleSentryId(event.eventId)), GetLatestScreenshot());
-				}
-				if (settings->EnableAutoLogAttachment)
-				{
-					// Unreal creates game log backups automatically on every app run. If logging is enabled for current configuration, SDK can
-					// find the most recent one and upload it to Sentry.
-					UploadGameLogForEvent(MakeShareable(new FAppleSentryId(event.eventId)), GetLatestGameLog());
-				}
+				// The game log and screenshot captured during the previous app run are attached to the crash
+				// event from `beforeSendWithHint`, which runs before this callback and is the only place where
+				// they can still be added to the event's own envelope.
 				if (settings->AttachSessionReplay)
 				{
 					// Deliver the previous run's replay as a structured envelope so it shows
@@ -258,34 +248,46 @@ void FAppleSentrySubsystem::InitWithSettings(const USentrySettings* settings, co
 					return ProcessedMetric ? metric : nullptr;
 				};
 			}
-			if (beforeSendHandler != nullptr)
-			{
-				// `beforeSendWithHint` is deprecated on arrival in cocoa - the next major version adds the hint
-				// parameter to `beforeSend` directly and removes this callback. Migrate once that lands.
+			// This callback is set up unconditionally since the SDK relies on it itself to attach files captured
+			// during the previous app run to the crash event.
+			// `beforeSendWithHint` is deprecated on arrival in cocoa - the next major version adds the hint
+			// parameter to `beforeSend` directly and removes this callback. Migrate once that lands.
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
-				options.beforeSendWithHint = ^SentryObjCEvent*(SentryObjCEvent* event, SentryObjCHint* hint) {
-					if (!SentryCallbackUtils::IsCallbackSafeToRun())
-					{
-						// Event will be sent without calling a `onBeforeSend` handler
-						return event;
-					}
+			options.beforeSendWithHint = ^SentryObjCEvent*(SentryObjCEvent* event, SentryObjCHint* hint) {
+				// Attachments are added before the guards below on purpose - a user handler that can't be
+				// invoked shouldn't cost the crash event its attachments.
+				FAppleSentryEvent eventApple(event);
+				if (eventApple.IsCrash())
+				{
+					AddCrashAttachmentsToHint(hint);
+				}
 
-					TSentryCallbackGuard<USentryBeforeSendHandler> ReentrancyGuard;
-					if (ReentrancyGuard.IsReentrant())
-					{
-						return event;
-					}
+				if (beforeSendHandler == nullptr)
+				{
+					return event;
+				}
 
-					USentryEvent* EventToProcess = USentryEvent::Create(MakeShareable(new FAppleSentryEvent(event)));
-					USentryHint* HintToProcess = USentryHint::Create(MakeShareable(new FAppleSentryHint(hint)));
+				if (!SentryCallbackUtils::IsCallbackSafeToRun())
+				{
+					// Event will be sent without calling a `onBeforeSend` handler
+					return event;
+				}
 
-					USentryEvent* ProcessedEvent = beforeSendHandler->HandleBeforeSend(EventToProcess, HintToProcess);
+				TSentryCallbackGuard<USentryBeforeSendHandler> ReentrancyGuard;
+				if (ReentrancyGuard.IsReentrant())
+				{
+					return event;
+				}
 
-					return ProcessedEvent ? event : nullptr;
-				};
+				USentryEvent* EventToProcess = USentryEvent::Create(MakeShareable(new FAppleSentryEvent(event)));
+				USentryHint* HintToProcess = USentryHint::Create(MakeShareable(new FAppleSentryHint(hint)));
+
+				USentryEvent* ProcessedEvent = beforeSendHandler->HandleBeforeSend(EventToProcess, HintToProcess);
+
+				return ProcessedEvent ? event : nullptr;
+			};
 #pragma clang diagnostic pop
-			}
 		}];
 
 		dispatch_group_leave(sentryDispatchGroup);
@@ -761,72 +763,75 @@ TSharedPtr<ISentryTransactionContext> FAppleSentrySubsystem::ContinueTrace(const
 	return MakeShareable(new FAppleSentryTransactionContext(transactionContext));
 }
 
-void FAppleSentrySubsystem::UploadAttachmentForEvent(TSharedPtr<ISentryId> eventId, const FString& filePath, const FString& name, bool deleteAfterUpload) const
+void FAppleSentrySubsystem::AddCrashAttachmentsToHint(SentryObjCHint* hint) const
 {
+	if (hint == nil)
+	{
+		return;
+	}
+
 	IFileManager& fileManager = IFileManager::Get();
-	if (!fileManager.FileExists(*filePath))
+
+	// For fatal events cocoa pre-populates the hint with the crash report's own attachments, so any file
+	// it already provided takes precedence over the ones captured by the plugin.
+	TSet<FString> existingAttachments;
+	for (SentryObjCAttachment* attachment in hint.attachments)
 	{
-		UE_LOG(LogSentrySdk, Error, TEXT("Failed to upload attachment - file path provided did not exist: %s"), *filePath);
-		return;
+		existingAttachments.Add(FString(attachment.filename));
 	}
 
-	if (!eventId || !eventId->IsValid())
-	{
-		UE_LOG(LogSentrySdk, Log, TEXT("Skipping attachment upload for an event that wasn't sent: %s"), *filePath);
-
-		if (deleteAfterUpload && !fileManager.Delete(*filePath))
-		{
-			UE_LOG(LogSentrySdk, Error, TEXT("Failed to delete file attachment: %s"), *filePath);
-		}
-
-		return;
-	}
-
-	const FString& filePathExt = fileManager.ConvertToAbsolutePathForExternalAppForRead(*filePath);
-
-	SentryObjCAttachment* attachment = [[SENTRY_APPLE_CLASS(SentryObjCAttachment) alloc] initWithPath:filePathExt.GetNSString() filename:name.GetNSString()];
-
-	SentryObjCEnvelopeItem* envelopeItem = [[SENTRY_APPLE_CLASS(SentryObjCEnvelopeItem) alloc] initWithAttachment:attachment maxAttachmentSize:maxAttachmentSize];
-	if (envelopeItem == nil)
-	{
-		UE_LOG(LogSentrySdk, Error, TEXT("Failed to upload attachment - file exceeds max attachment size or could not be read: %s"), *filePath);
-		return;
-	}
-
-	SentryObjCId* id = StaticCastSharedPtr<FAppleSentryId>(eventId)->GetNativeObject();
-
-	SentryObjCEnvelopeHeader* envelopeHeader = [[SENTRY_APPLE_CLASS(SentryObjCEnvelopeHeader) alloc] initWithId:id traceContext:nil];
-
-	SentryObjCEnvelope* envelope = [[SENTRY_APPLE_CLASS(SentryObjCEnvelope) alloc] initWithHeader:envelopeHeader singleItem:envelopeItem];
-
-	[[[SENTRY_APPLE_CLASS(SentryObjCSDK) internal] envelope] capture:envelope];
-
-	if (deleteAfterUpload)
-	{
-		if (!fileManager.Delete(*filePath))
-		{
-			UE_LOG(LogSentrySdk, Error, TEXT("Failed to delete file attachment after upload: %s"), *filePath);
-		}
-	}
-}
-
-void FAppleSentrySubsystem::UploadScreenshotForEvent(TSharedPtr<ISentryId> eventId, const FString& screenshotPath) const
-{
-	if (screenshotPath.IsEmpty())
-	{
-		// Screenshot capturing is a best-effort solution so if one wasn't captured (path is empty) skip the upload
-		return;
-	}
-
-	UploadAttachmentForEvent(eventId, screenshotPath, TEXT("screenshot.png"), true);
-}
-
-void FAppleSentrySubsystem::UploadGameLogForEvent(TSharedPtr<ISentryId> eventId, const FString& logFilePath) const
-{
-	// If writing logs to a file is disabled (i.e. default behavior for Shipping builds) skip the upload
+	// If writing logs to a file is disabled (i.e. default behavior for Shipping builds) skip the attachment
 #if !NO_LOGGING
-	UploadAttachmentForEvent(eventId, logFilePath, SentryFileUtils::GetGameLogName());
+	if (isGameLogAttachmentEnabled)
+	{
+		// Unreal creates game log backups automatically on every app run, so the most recent one holds the
+		// output of the run that crashed. The file belongs to the engine and is left in place after sending.
+		const FString& logFilePath = GetLatestGameLog();
+		const FString& logFileName = SentryFileUtils::GetGameLogName();
+
+		if (!logFilePath.IsEmpty() && fileManager.FileExists(*logFilePath) && !existingAttachments.Contains(logFileName))
+		{
+			FAppleSentryAttachment logAttachment(fileManager.ConvertToAbsolutePathForExternalAppForRead(*logFilePath),
+				logFileName, TEXT("text/plain"));
+
+			hint.attachments = [hint.attachments arrayByAddingObject:logAttachment.GetNativeObject()];
+		}
+	}
 #endif
+
+	if (isScreenshotAttachmentEnabled)
+	{
+		// Screenshot capturing is a best-effort solution so if one wasn't captured skip the attachment
+		const FString& screenshotPath = GetLatestScreenshot();
+		if (screenshotPath.IsEmpty() || !fileManager.FileExists(*screenshotPath))
+		{
+			return;
+		}
+
+		TArray<uint8> screenshotData;
+		const bool bScreenshotLoaded = FFileHelper::LoadFileToArray(screenshotData, *screenshotPath);
+
+		// Unlike the game log this file is created by the plugin, so it's removed once its contents have been
+		// read. The screenshot is attached as raw data rather than by path for the same reason: cocoa reads
+		// path-based attachments while building the envelope item, which happens after this callback returns.
+		if (!fileManager.Delete(*screenshotPath))
+		{
+			UE_LOG(LogSentrySdk, Error, TEXT("Failed to delete screenshot attachment: %s"), *screenshotPath);
+		}
+
+		if (!bScreenshotLoaded)
+		{
+			UE_LOG(LogSentrySdk, Error, TEXT("Failed to read screenshot attachment: %s"), *screenshotPath);
+			return;
+		}
+
+		if (!existingAttachments.Contains(TEXT("screenshot.png")))
+		{
+			FAppleSentryAttachment screenshotAttachment(screenshotData, TEXT("screenshot.png"), TEXT("image/png"));
+
+			hint.attachments = [hint.attachments arrayByAddingObject:screenshotAttachment.GetNativeObject()];
+		}
+	}
 }
 
 void FAppleSentrySubsystem::AddGameLogAttachmentToScope(SentryObjCScope* scope) const

--- a/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
+++ b/plugin-dev/Source/Sentry/Private/Apple/AppleSentrySubsystem.h
@@ -10,6 +10,7 @@
 #include "SessionReplay/SentrySessionReplayRecorder.h"
 #endif
 
+@class SentryObjCHint;
 @class SentryObjCScope;
 
 class FAppleSentrySubsystem : public ISentrySubsystem
@@ -68,10 +69,7 @@ public:
 	virtual FString TryCaptureScreenshot() const { return FString(); };
 
 protected:
-	void UploadAttachmentForEvent(TSharedPtr<ISentryId> eventId, const FString& filePath, const FString& name, bool deleteAfterUpload = false) const;
-
-	void UploadScreenshotForEvent(TSharedPtr<ISentryId> eventId, const FString& screenshotPath) const;
-	void UploadGameLogForEvent(TSharedPtr<ISentryId> eventId, const FString& logFilePath) const;
+	void AddCrashAttachmentsToHint(SentryObjCHint* hint) const;
 
 	void AddGameLogAttachmentToScope(SentryObjCScope* scope) const;
 	void AddScreenshotAttachmentToScope(SentryObjCScope* scope) const;
@@ -86,8 +84,6 @@ protected:
 	bool isScreenshotAttachmentEnabled = false;
 	bool isGameLogAttachmentEnabled = false;
 	bool isSessionReplayAttachmentEnabled = false;
-
-	int32 maxAttachmentSize = 0;
 
 private:
 #ifdef USE_SENTRY_SESSION_REPLAY

--- a/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryHint.h
+++ b/plugin-dev/Source/Sentry/Private/HAL/PlatformSentryHint.h
@@ -6,6 +6,8 @@
 
 #if PLATFORM_ANDROID
 #include "Android/AndroidSentryHint.h"
+#elif PLATFORM_APPLE && !USE_SENTRY_NATIVE
+#include "Apple/AppleSentryHint.h"
 #else
 #include "Null/NullSentryHint.h"
 #endif

--- a/scripts/packaging/package.snapshot
+++ b/scripts/packaging/package.snapshot
@@ -64,6 +64,8 @@ Source/Sentry/Private/Apple/AppleSentryEvent.cpp
 Source/Sentry/Private/Apple/AppleSentryEvent.h
 Source/Sentry/Private/Apple/AppleSentryFeedback.cpp
 Source/Sentry/Private/Apple/AppleSentryFeedback.h
+Source/Sentry/Private/Apple/AppleSentryHint.cpp
+Source/Sentry/Private/Apple/AppleSentryHint.h
 Source/Sentry/Private/Apple/AppleSentryId.cpp
 Source/Sentry/Private/Apple/AppleSentryId.h
 Source/Sentry/Private/Apple/AppleSentryLog.cpp


### PR DESCRIPTION
This PR adds hint support for macOS and iOS, and uses it to deliver crash attachments in the crash event's own envelope.

The game log and screenshot captured during a crashed run were uploaded as standalone envelopes carrying only the crash event's id. Relay treats those as independent submissions, so whenever the event itself was dropped the attachments were left orphaned. Non-fatal events were already fixed by routing their attachments through a local scope so this does the same for the crash path.

### Key Changes

- `FAppleSentryHint` wraps cocoa's `SentryObjCHint`, routed through the HAL on Apple platforms using the cocoa backend.
- `HandleBeforeSend` and `HandleBeforeBreadcrumb` now receive a real hint instead of `nullptr`, matching Android. Both use cocoa's `*WithHint` callbacks, which are deprecated on arrival (the next major version moves the hint parameter into `beforeSend`/`beforeBreadcrumb` directly).
- Crash attachments are added to `hint.attachments` from `beforeSendWithHint`, so they ship in the event's envelope. The standalone upload path is removed. The screenshot is attached as raw data because the plugin deletes that file; cocoa reads path-based attachments after the callback returns.
- `FAppleSentryEvent::IsCrash()` now classifies events by exception mechanism. It previously read the `NSError` convenience property, which is nil for signal and mach crashes so it returned false for exactly the events it names.
- Integration tests assert the game log is attached to crash events on iOS, Android and desktop. This is the suite's first attachment coverage on any platform.

### Related Items

- getsentry/sentry-cocoa#8942
- #1559
- #1558
